### PR TITLE
feat: update SQLSpec base to 0.52

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -240,8 +240,8 @@ advertises, then fall back to the portable path when a capability is absent.
      - Positional Arrow ingest is contract-tested so column order matches the
        table definition.
    * - ``asyncpg`` / ``psycopg``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec event hints advertise it;
-       compare-and-swap fallback otherwise.
+     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
+       dialect support; compare-and-swap fallback otherwise.
      - ``JSONB`` with native decoded JSON columns where the driver returns
        Python values.
      - Arrow ``load_from_records`` path.
@@ -250,24 +250,27 @@ advertises, then fall back to the portable path when a capability is absent.
      - Stale-recovery statement batches use SQLSpec ``StatementStack``; psycopg
        can collapse the batch through the driver pipeline.
    * - ``psqlpy``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec event hints advertise it.
+     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
+       dialect support.
      - ``JSONB`` payload/metadata columns with native decode; ``result_json``
        stays text-backed for driver compatibility.
      - Arrow ``load_from_records`` path.
      - SQLSpec durable table queue.
      - PostgreSQL storage parameters tune queue-table churn where supported.
    * - ``asyncmy`` / ``aiomysql`` / ``mysqlconnector``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec event hints advertise it.
+     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
+       dialect support.
      - MySQL ``JSON`` columns with native decoded JSON values.
      - Arrow ``load_from_records`` path.
      - Polling.
      - Index prefixes keep InnoDB key length within portable bounds.
    * - ``oracledb``
-     - Optimistic compare-and-swap until SQLSpec exposes an Oracle locking
-       capability hint.
+     - ``FOR UPDATE SKIP LOCKED`` through SQLSpec's Oracle data-dictionary
+       capability.
      - Version-aware ``JSON``, checked ``BLOB``, or plain ``BLOB`` storage.
      - Arrow ``load_from_records`` path.
-     - Polling.
+     - Polling by default; explicit ``aq`` or ``txeventq`` when Oracle queues
+       are provisioned.
      - Oracle object names are kept within the adapter's identifier limits;
        Oracle 23ai can pipeline stale-recovery statement batches.
 
@@ -633,8 +636,44 @@ configured. To wake workers through SQLSpec Events, configure the SQLSpec
    )
 
 PostgreSQL SQLSpec adapters can use SQLSpec's native ``listen_notify`` backend;
-other adapters can use the durable ``table_queue`` backend. Queue notification
-channel names must be valid SQLSpec event identifiers.
+other adapters can use the durable ``table_queue`` backend. Oracle adapters can
+use native ``aq`` or ``txeventq`` transports when the database user has AQ
+privileges and the target queues are provisioned. These Oracle transports stay
+explicit because queue provisioning is DBA-owned:
+
+.. code-block:: python
+
+   from sqlspec.adapters.oracledb import OracleAsyncConfig
+
+   oracle_config = OracleAsyncConfig(
+       connection_config={
+           "host": "db.example.com",
+           "port": 1521,
+           "service_name": "FREEPDB1",
+           "user": "queue_app",
+           "password": "...",
+           "min": 1,
+           "max": 5,
+       },
+       extension_config={
+           "events": {
+               "backend": "txeventq",
+               "aq_queue": "LQ_EVENTS_TXQ",
+           }
+       },
+   )
+
+   config = QueueConfig(
+       queue_backend=SQLSpecBackendConfig(
+           config=oracle_config,
+           notifications=True,
+           notify_transport="txeventq",
+           event_settings={"aq_queue": "LQ_EVENTS_TXQ"},
+       ),
+       execution_backend="local",
+   )
+
+Queue notification channel names must be valid SQLSpec event identifiers.
 
 SQLSpec Observability
 ~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ litestar-queues-cloudrun-worker = "litestar_queues.execution.cloudrun.entrypoint
 advanced-alchemy = ["advanced-alchemy>=1.10.0"]
 cloudrun = ["google-cloud-run>=0.10.0"]
 redis = ["redis>=5.0.0"]
-sqlspec = ["sqlspec>=0.51.0"]
+sqlspec = ["sqlspec>=0.52.0"]
 valkey = ["valkey>=6.0.0"]
 
 ######################
@@ -123,7 +123,7 @@ tests = [
   "numpy",
   "advanced-alchemy>=1.10.0",
   # SQLSpec adapters covered by the default integration matrix
-  "sqlspec[aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,litestar,mysql-connector]>=0.51.0",
+  "sqlspec[aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,litestar,mysql-connector]>=0.52.0",
 ]
 
 #####################

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 __all__ = ("SQLSpecQueueBackend",)
 
 _DUE_STATUSES = ("pending", "scheduled")
-_DURABLE_NOTIFICATION_BACKENDS = frozenset({"advanced_queue", "listen_notify_durable", "table_queue"})
+_DURABLE_NOTIFICATION_BACKENDS = frozenset({"aq", "listen_notify_durable", "table_queue", "txeventq"})
 _EVENT_EXTENSION_NAME = "events"
 _QUEUE_SETTING_EVENT_SETTINGS = ("event_settings", "events")
 
@@ -375,15 +375,22 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 await driver.begin()
                 try:
                     now = _utc_now()
-                    rows = await driver.select(
-                        store.select_claimable(
-                            now=self._serialize_datetime(now), limit=1, queue=queue, execution_backend=execution_backend
-                        )
+                    statement = store.select_claimable(
+                        now=self._serialize_datetime(now), limit=1, queue=queue, execution_backend=execution_backend
                     )
-                    if not rows:
+                    stream_chunk_size = cast("int | None", getattr(store, "claim_select_stream_chunk_size", None))
+                    if stream_chunk_size is None:
+                        rows = await driver.select(statement)
+                        row = cast("dict[str, Any] | None", rows[0] if rows else None)
+                    else:
+                        row = None
+                        async for claimable_row in _select_stream(driver, statement, chunk_size=stream_chunk_size):
+                            row = cast("dict[str, Any]", claimable_row)
+                            break
+                    if row is None:
                         await driver.rollback()
                         return None
-                    record = self._record_from_row(cast("dict[str, Any]", rows[0]))
+                    record = self._record_from_row(row)
                     result = await driver.execute(
                         store.claim_task(
                             task_id=str(record.id),

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -20,12 +20,20 @@ __all__ = ("DEFAULT_NOTIFICATION_CHANNEL", "NOTIFY_TRANSPORTS", "SQLSpecBackendC
 
 DEFAULT_NOTIFICATION_CHANNEL = "litestar_queues_tasks"
 
-NOTIFY_TRANSPORTS: "frozenset[str]" = frozenset({"listen_notify", "listen_notify_durable", "table_queue", "polling"})
+NOTIFY_TRANSPORTS: "frozenset[str]" = frozenset({
+    "aq",
+    "listen_notify",
+    "listen_notify_durable",
+    "polling",
+    "table_queue",
+    "txeventq",
+})
 """Valid worker-wakeup transports for :attr:`SQLSpecBackendConfig.notify_transport`.
 
 ``listen_notify``/``listen_notify_durable`` push wakeups through native
-LISTEN/NOTIFY, ``table_queue`` uses the durable events table, and ``polling``
-disables push wakeups so workers fall back to interval polling.
+LISTEN/NOTIFY, ``table_queue`` uses the durable events table, ``aq`` and
+``txeventq`` use Oracle Advanced Queuing backends, and ``polling`` disables
+push wakeups so workers fall back to interval polling.
 """
 
 

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from sqlspec import sql
 from sqlspec.data_dictionary import get_dialect_config
-from sqlspec.extensions.events import get_runtime_hints
 from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.text import quote_backtick_identifier, quote_identifier, split_qualified_identifier
 
@@ -58,6 +57,7 @@ class SQLSpecQueueStore:
 
     data_dictionary_dialect: "ClassVar[str | None]" = None
     identifier_quote_style: 'ClassVar[Literal["double", "backtick", "none"]]' = "double"
+    claim_select_stream_chunk_size: "ClassVar[int | None]" = None
     # Per-store opt-in: canonical JSON columns whose driver round-trips
     # native Python values rather than JSON-encoded strings. Subclasses
     # whose drivers register a JSON codec (asyncpg JSONB, psycopg JSONB,
@@ -100,16 +100,17 @@ class SQLSpecQueueStore:
     def supports_skip_locked(self) -> "bool":
         """Whether the adapter supports ``SELECT ... FOR UPDATE SKIP LOCKED``.
 
-        Resolved from the adapter config's event runtime hints
-        (``select_for_update`` and ``skip_locked``). SQLSpec 0.51 exposes no
-        locking capability through ``data_dictionary`` feature flags, so the
-        config-level hints are the runtime signal. Adapters that do not
-        advertise the hints (sqlite, duckdb, and oracle today) degrade to
-        the optimistic-CAS claim. This is a deliberate workaround pending a
-        first-class capability flag upstream (litestar-org/sqlspec#544).
+        Resolved from SQLSpec's data dictionary. Some dialects expose
+        ``supports_skip_locked`` as a static flag; version-gated dialects
+        expose the minimum supported version instead, which is treated as an
+        adapter capability until live server-version checks are introduced.
         """
-        hints = get_runtime_hints(_adapter_name(self._config), self._config)
-        return bool(hints.select_for_update and hints.skip_locked)
+        dialect_config = self._dialect_config()
+        if dialect_config is None or dialect_config.get_feature_flag("supports_for_update") is not True:
+            return False
+        return dialect_config.get_feature_flag("supports_skip_locked") is True or (
+            dialect_config.get_feature_version("supports_skip_locked") is not None
+        )
 
     @property
     def supports_native_bulk_ingest(self) -> "bool":

--- a/src/litestar_queues/backends/sqlspec/stores/oracledb/store.py
+++ b/src/litestar_queues/backends/sqlspec/stores/oracledb/store.py
@@ -4,6 +4,7 @@ from enum import Enum
 from inspect import isawaitable
 from typing import Any, ClassVar, Literal, cast
 
+from sqlspec import sql
 from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.sync_tools import async_
 
@@ -102,6 +103,23 @@ class _OracledbQueueStore(SQLSpecQueueStore):
             self._native_json_columns |= frozenset({"args_json", "kwargs_json", "metadata_json", "result_json"})
         return storage_type
 
+    def _select_claimable_unlimited(
+        self, *, now: "Any", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "Any":
+        statement = (
+            self
+            ._select_all()
+            .where_in(self._col("status"), ("pending", "scheduled"))
+            .where(f"{self._col('scheduled_at')} IS NULL OR {self._col('scheduled_at')} <= :now", now=now)
+        )
+        if queue is not None:
+            statement = statement.where_eq(self._col("queue"), queue)
+        if execution_backend is not None:
+            statement = statement.where_eq(self._col("execution_backend"), execution_backend)
+        return statement.order_by(
+            sql.raw(f"{self._col('priority')} DESC"), sql.raw(f"{self._col('created_at')} ASC")
+        ).for_update(skip_locked=True)
+
 
 class OracledbSyncQueueStore(_OracledbQueueStore):
     """oracledb sync SQLSpec queue statement store."""
@@ -118,12 +136,18 @@ class OracledbSyncQueueStore(_OracledbQueueStore):
         if self._json_storage is not None:
             self._apply_json_storage(self._json_storage)
 
+    @property
+    def supports_skip_locked(self) -> "bool":
+        """Bridge-managed sync Oracle claims stay on the CAS path."""
+        return False
+
 
 class OracledbAsyncQueueStore(_OracledbQueueStore):
     """oracledb async SQLSpec queue statement store."""
 
     __slots__ = ("_in_memory",)
 
+    claim_select_stream_chunk_size: "ClassVar[int | None]" = 1
     _in_memory: "bool"
 
     def __init__(self, config: "Any", *, table_name: "str | None" = None, **kwargs: "Any") -> "None":
@@ -133,6 +157,12 @@ class OracledbAsyncQueueStore(_OracledbQueueStore):
         self._json_storage = _json_storage_from_settings(queue_settings)
         if self._json_storage is not None:
             self._apply_json_storage(self._json_storage)
+
+    def select_claimable(
+        self, *, now: "Any", limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "Any":
+        """Return an ordered Oracle row-locking query consumed through a one-row stream."""
+        return self._select_claimable_unlimited(now=now, queue=queue, execution_backend=execution_backend)
 
 
 class _OracleJSONStorageType(str, Enum):

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -415,63 +415,58 @@ async def test_sqlspec_backend_store_factory_covers_sqlspec_adapter_modules(
     assert expected_sql_fragment in "\n".join(store.create_statements())
 
 
-def _event_hinted_config(
-    adapter_name: "str", *, select_for_update: "bool", skip_locked: "bool", dialect: "str | None" = None
-) -> "FakeSQLSpecConfig":
-    """Fake adapter config advertising SQLSpec event runtime hints.
-
-    Returns:
-        Adapter config with event runtime hints attached.
-    """
-    from sqlspec.extensions.events import EventRuntimeHints
-
-    config = _fake_adapter_config(adapter_name, dialect=dialect)
-    setattr(
-        config,
-        "get_event_runtime_hints",
-        lambda: EventRuntimeHints(select_for_update=select_for_update, skip_locked=skip_locked),
-    )
-    return config
-
-
 @pytest.mark.parametrize(
-    ("adapter_name", "select_for_update", "skip_locked", "expected"),
+    ("adapter_name", "dialect", "expected"),
     (
-        ("asyncpg", True, True, True),
-        ("asyncmy", True, True, True),
-        ("psqlpy", True, True, True),
-        ("aiosqlite", False, False, False),
-        ("duckdb", False, False, False),
-        # Oracle supports FOR UPDATE SKIP LOCKED, but its config advertises False today
-        # (sqlspec FR litestar-org/sqlspec#544); the gate must honour the config, not guess.
-        ("oracledb", False, False, False),
+        ("asyncpg", "postgres", True),
+        ("asyncmy", "mysql", True),
+        ("psqlpy", "postgres", True),
+        ("aiosqlite", "sqlite", False),
+        ("duckdb", "duckdb", False),
     ),
 )
-def test_sqlspec_store_supports_skip_locked_follows_config_event_hints(
-    adapter_name: "str", select_for_update: "bool", skip_locked: "bool", expected: "bool"
+def test_sqlspec_store_supports_skip_locked_follows_data_dictionary_flags(
+    adapter_name: "str", dialect: "str", expected: "bool"
 ) -> "None":
-    """``supports_skip_locked`` gates off the adapter config's event runtime hints."""
-    store = create_queue_store(
-        _event_hinted_config(adapter_name, select_for_update=select_for_update, skip_locked=skip_locked),
-        table_name="queue_tasks",
-    )
+    """``supports_skip_locked`` gates off SQLSpec data-dictionary feature flags."""
+    store = create_queue_store(_fake_adapter_config(adapter_name, dialect=dialect), table_name="queue_tasks")
 
     assert store.supports_skip_locked is expected
 
 
-def test_sqlspec_store_supports_skip_locked_defaults_false_without_hints() -> "None":
-    """A config that does not advertise event hints degrades to optimistic CAS."""
-    store = create_queue_store(_fake_adapter_config("aiosqlite", dialect="sqlite"), table_name="queue_tasks")
+def test_sqlspec_oracledb_async_store_supports_skip_locked_from_data_dictionary() -> "None":
+    """Async Oracle uses SQLSpec 0.52's Oracle SKIP LOCKED capability."""
+    store = create_queue_store(
+        _fake_adapter_config("oracledb", dialect="oracle", config_type_name="FakeOracleAsyncConfig"),
+        table_name="queue_tasks",
+    )
+
+    assert isinstance(store, OracledbAsyncQueueStore)
+    assert store.supports_skip_locked is True
+    assert store.claim_select_stream_chunk_size == 1
+
+
+def test_sqlspec_oracledb_sync_store_uses_cas_until_safe_streaming_claims() -> "None":
+    """Sync Oracle stays on CAS because the sync bridge cannot bound locked rows."""
+    store = create_queue_store(
+        _fake_adapter_config("oracledb", dialect="oracle", config_type_name="FakeOracleSyncConfig"),
+        table_name="queue_tasks",
+    )
+
+    assert isinstance(store, OracledbSyncQueueStore)
+    assert store.supports_skip_locked is False
+
+
+def test_sqlspec_store_supports_skip_locked_defaults_false_without_dialect() -> "None":
+    """A config without dialect metadata degrades to optimistic CAS."""
+    store = create_queue_store(_fake_adapter_config("aiosqlite", dialect=None), table_name="queue_tasks")
 
     assert store.supports_skip_locked is False
 
 
 def test_sqlspec_store_select_claimable_uses_skip_locked_on_supporting_dialect() -> "None":
     """``select_claimable`` builds a due-task SELECT that locks rows with SKIP LOCKED."""
-    store = create_queue_store(
-        _event_hinted_config("asyncpg", select_for_update=True, skip_locked=True, dialect="postgres"),
-        table_name="queue_tasks",
-    )
+    store = create_queue_store(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
 
     built = store.select_claimable(now="2026-01-01T00:00:00+00:00", limit=1, queue="default").build(dialect="postgres")
 

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -9,9 +9,10 @@ Postgres NOTIFY path against a live container.
 """
 
 import asyncio
+import contextlib
 import time
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -21,6 +22,7 @@ pytest.importorskip("sqlspec")
 from litestar import Litestar
 from sqlspec import SQLSpec
 from sqlspec.adapters.aiosqlite import AiosqliteConfig
+from sqlspec.exceptions import SQLSpecError
 from sqlspec.extensions.litestar import SQLSpecPlugin
 
 from litestar_queues import QueueConfig, QueuePlugin
@@ -31,14 +33,207 @@ from litestar_queues.exceptions import QueueConfigurationError
 from tests.integration.backends.sqlspec.conftest import StubAsyncEventChannel
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
+    from pytest import FixtureRequest
+    from pytest_databases.docker.oracle import OracleService
     from sqlspec.extensions.events import AsyncEventChannel
 
     from tests.integration._backends import PostgresService
     from tests.integration.backends.sqlspec.conftest import SqliteConfigFactory
 
 pytestmark = pytest.mark.anyio
+
+_ORACLE_AQ_QUEUE_TABLE = "LQ_EVENTS_AQ_TABLE"
+_ORACLE_AQ_QUEUE = "LQ_EVENTS_AQ_QUEUE"
+_ORACLE_TXEVENTQ_QUEUE = "LQ_EVENTS_TXQ"
+
+
+def _oracle_sync_config(
+    oracle_service: "OracleService", *, user: "str | None" = None, password: "str | None" = None
+) -> "Any":
+    from sqlspec.adapters.oracledb import OracleSyncConfig
+
+    return OracleSyncConfig(
+        connection_config={
+            "host": oracle_service.host,
+            "port": oracle_service.port,
+            "service_name": oracle_service.service_name,
+            "user": user or oracle_service.user,
+            "password": password or oracle_service.password,
+        }
+    )
+
+
+def _oracle_async_config(oracle_service: "OracleService", *, backend_name: "str", aq_queue: "str") -> "Any":
+    from sqlspec.adapters.oracledb import OracleAsyncConfig
+
+    return OracleAsyncConfig(
+        connection_config={
+            "host": oracle_service.host,
+            "port": oracle_service.port,
+            "service_name": oracle_service.service_name,
+            "user": oracle_service.user,
+            "password": oracle_service.password,
+            "min": 1,
+            "max": 5,
+        },
+        extension_config={"events": {"backend": backend_name, "aq_queue": aq_queue, "aq_wait_seconds": 1}},
+    )
+
+
+@contextlib.contextmanager
+def _classic_aq_queue(oracle_service: "OracleService") -> "Iterator[None]":
+    """Provision a classic Advanced Queuing queue for the Oracle notification smoke.
+
+    Yields:
+        Control while the AQ queue exists.
+    """
+
+    config = _oracle_sync_config(oracle_service)
+    try:
+        with config.provide_session() as session:
+            session.execute_script(
+                f"""
+                DECLARE
+                    table_count INTEGER;
+                BEGIN
+                    SELECT COUNT(*) INTO table_count
+                    FROM user_queue_tables
+                    WHERE queue_table = '{_ORACLE_AQ_QUEUE_TABLE}';
+                    IF table_count = 0 THEN
+                        dbms_aqadm.create_queue_table(
+                            queue_table => '{_ORACLE_AQ_QUEUE_TABLE}',
+                            queue_payload_type => 'JSON'
+                        );
+                    END IF;
+                    BEGIN
+                        dbms_aqadm.create_queue(
+                            queue_name => '{_ORACLE_AQ_QUEUE}',
+                            queue_table => '{_ORACLE_AQ_QUEUE_TABLE}'
+                        );
+                    EXCEPTION
+                        WHEN OTHERS THEN
+                            IF SQLCODE != -24005 THEN
+                                RAISE;
+                            END IF;
+                    END;
+                    dbms_aqadm.start_queue(queue_name => '{_ORACLE_AQ_QUEUE}');
+                END;
+                """
+            )
+            session.commit()
+    except SQLSpecError as exc:
+        with suppress(Exception):
+            config.close_pool()
+        pytest.skip(f"Oracle AQ queue provisioning unavailable: {exc}")
+    try:
+        yield
+    finally:
+        with suppress(Exception), config.provide_session() as session:
+            session.execute_script(
+                f"""
+                    BEGIN
+                        BEGIN
+                            dbms_aqadm.stop_queue(queue_name => '{_ORACLE_AQ_QUEUE}');
+                        EXCEPTION WHEN OTHERS THEN NULL; END;
+                        BEGIN
+                            dbms_aqadm.drop_queue(queue_name => '{_ORACLE_AQ_QUEUE}');
+                        EXCEPTION WHEN OTHERS THEN NULL; END;
+                        BEGIN
+                            dbms_aqadm.drop_queue_table(queue_table => '{_ORACLE_AQ_QUEUE_TABLE}');
+                        EXCEPTION WHEN OTHERS THEN NULL; END;
+                    END;
+                    """
+            )
+        with suppress(Exception):
+            config.close_pool()
+
+
+@contextlib.contextmanager
+def _txeventq_queue(oracle_service: "OracleService") -> "Iterator[None]":
+    """Provision a Transactional Event Queue for the Oracle notification smoke.
+
+    Yields:
+        Control while the TxEventQ queue exists.
+    """
+
+    config = _oracle_sync_config(oracle_service)
+    try:
+        with config.provide_session() as session:
+            session.execute_script(
+                f"""
+                DECLARE
+                    queue_count INTEGER;
+                BEGIN
+                    SELECT COUNT(*) INTO queue_count
+                    FROM user_queues
+                    WHERE name = '{_ORACLE_TXEVENTQ_QUEUE}';
+                    IF queue_count = 0 THEN
+                        dbms_aqadm.create_transactional_event_queue(
+                            queue_name => '{_ORACLE_TXEVENTQ_QUEUE}',
+                            queue_payload_type => 'JSON',
+                            multiple_consumers => FALSE
+                        );
+                    END IF;
+                    dbms_aqadm.start_queue(queue_name => '{_ORACLE_TXEVENTQ_QUEUE}');
+                END;
+                """
+            )
+            session.commit()
+    except SQLSpecError as exc:
+        with suppress(Exception):
+            config.close_pool()
+        pytest.skip(f"Oracle TxEventQ provisioning unavailable: {exc}")
+    try:
+        yield
+    finally:
+        with suppress(Exception), config.provide_session() as session:
+            session.execute_script(
+                f"""
+                    BEGIN
+                        BEGIN
+                            dbms_aqadm.stop_queue(queue_name => '{_ORACLE_TXEVENTQ_QUEUE}');
+                        EXCEPTION WHEN OTHERS THEN NULL; END;
+                        BEGIN
+                            dbms_aqadm.drop_transactional_event_queue(queue_name => '{_ORACLE_TXEVENTQ_QUEUE}');
+                        EXCEPTION WHEN OTHERS THEN NULL; END;
+                    END;
+                    """
+            )
+        with suppress(Exception):
+            config.close_pool()
+
+
+@pytest.fixture(scope="session")
+def oracle_aq_privileges(request: "FixtureRequest") -> "None":
+    """Grant the app user Oracle AQ privileges when the 23ai fixture is available."""
+
+    pytest.importorskip("oracledb")
+    try:
+        oracle_service = cast("OracleService", request.getfixturevalue("oracle_23ai_service"))
+    except pytest.FixtureLookupError:
+        pytest.skip("Oracle 23ai fixture is not available")
+    system_password = getattr(oracle_service, "system_password", None)
+    if system_password is None:
+        pytest.skip("Oracle service fixture does not expose a system password for AQ grants")
+
+    config = _oracle_sync_config(oracle_service, user="system", password=cast("str", system_password))
+    app_user = oracle_service.user
+    try:
+        with config.provide_session() as session:
+            for grant in (
+                f"GRANT aq_administrator_role, aq_user_role TO {app_user}",
+                f"GRANT EXECUTE ON dbms_aq TO {app_user}",
+            ):
+                session.execute_script(grant)
+            session.commit()
+    except SQLSpecError as exc:
+        pytest.skip(f"Oracle AQ privileges unavailable: {exc}")
+    finally:
+        with suppress(Exception):
+            config.close_pool()
 
 
 async def test_sqlspec_backend_event_channel_notifications_wake_waiters(
@@ -193,6 +388,83 @@ def test_adapter_notify_transport_capability_gate(adapter_name: "str | None", ex
 def test_notify_transport_config_rejects_unknown_value() -> "None":
     with pytest.raises(QueueConfigurationError):
         SQLSpecBackendConfig(notify_transport="not-a-transport")
+
+
+@pytest.mark.parametrize("transport", ("aq", "txeventq"))
+def test_notify_transport_config_accepts_oracle_event_backends(transport: "str") -> "None":
+    """Oracle AQ and TxEventQ backend names are valid SQLSpec event transports."""
+    config = SQLSpecBackendConfig(notify_transport=transport)
+
+    assert config.notify_transport == transport
+
+
+@pytest.mark.parametrize("backend_name", ("aq", "txeventq"))
+async def test_oracle_event_backend_names_are_reported_durable(
+    backend_name: "str", tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    """Injected Oracle event channels report durable queue wakeups."""
+    event_channel = StubAsyncEventChannel(backend_name=backend_name)
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlite_config_factory(tmp_path / f"{backend_name}-durable.db"),
+            event_channel=cast("AsyncEventChannel", event_channel),
+        )
+    )
+
+    await backend.open()
+    try:
+        assert backend.capabilities.supports_notifications is True
+        assert backend.capabilities.notification_backend == backend_name
+        assert backend.capabilities.notifications_durable is True
+    finally:
+        await backend.close()
+
+
+@pytest.mark.xdist_group("oracle")
+@pytest.mark.parametrize(
+    ("event_backend", "aq_queue"), [("aq", _ORACLE_AQ_QUEUE), ("txeventq", _ORACLE_TXEVENTQ_QUEUE)]
+)
+async def test_sqlspec_backend_oracle_event_transports_wake_waiters(
+    request: "FixtureRequest", event_backend: "str", aq_queue: "str"
+) -> "None":
+    """Oracle AQ and TxEventQ wake ``wait_for_notifications`` through SQLSpec events."""
+
+    pytest.importorskip("oracledb")
+    oracle_service = cast("OracleService", request.getfixturevalue("oracle_23ai_service"))
+    request.getfixturevalue("oracle_aq_privileges")
+
+    queue_manager = _classic_aq_queue(oracle_service) if event_backend == "aq" else _txeventq_queue(oracle_service)
+    table_name = f"LQ_NOTIFY_{event_backend.upper()}"
+    sqlspec_config = _oracle_async_config(oracle_service, backend_name=event_backend, aq_queue=aq_queue)
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlspec_config,
+            table_name=table_name,
+            notifications=True,
+            notify_transport=event_backend,
+            event_settings={"aq_queue": aq_queue, "aq_wait_seconds": 1},
+            event_poll_interval=0.1,
+        )
+    )
+
+    with queue_manager:
+        await backend.open()
+        try:
+            assert backend.capabilities.supports_notifications is True
+            assert backend.capabilities.notification_backend == event_backend
+            assert backend.capabilities.notifications_durable is True
+
+            waiter = asyncio.create_task(backend.wait_for_notifications(timeout=10))
+            await asyncio.sleep(0.5)
+            await backend.enqueue(f"tasks.oracle_{event_backend}_wake")
+            assert await waiter is True
+        finally:
+            from litestar_queues.backends.sqlspec.backend import _bridge_session
+
+            with suppress(Exception):
+                async with _bridge_session(backend._sqlspec, backend._sqlspec_config) as driver:
+                    await driver.execute_script(f'DROP TABLE IF EXISTS "{table_name}"')
+            await backend.close()
 
 
 async def test_sqlspec_backend_non_notify_adapter_polls(

--- a/uv.lock
+++ b/uv.lock
@@ -776,7 +776,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1435,7 +1435,7 @@ requires-dist = [
     { name = "google-cloud-run", marker = "extra == 'cloudrun'", specifier = ">=0.10.0" },
     { name = "litestar", specifier = ">=2.24.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
-    { name = "sqlspec", marker = "extra == 'sqlspec'", specifier = ">=0.51.0" },
+    { name = "sqlspec", marker = "extra == 'sqlspec'", specifier = ">=0.52.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "valkey", marker = "extra == 'valkey'", specifier = ">=6.0.0" },
 ]
@@ -1471,7 +1471,7 @@ dev = [
     { name = "sphinx-paramlinks", specifier = ">=0.6.0" },
     { name = "sphinx-togglebutton", specifier = ">=0.3.2" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
-    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "litestar", "mysql-connector"], specifier = ">=0.51.0" },
+    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]
 docs = [
@@ -1499,7 +1499,7 @@ tests = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "redis", specifier = ">=5.0.0" },
-    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "litestar", "mysql-connector"], specifier = ">=0.51.0" },
+    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]
 
@@ -3432,7 +3432,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.51.0"
+version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
@@ -3441,29 +3441,29 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/4f/e541c38d24a1b00516f1a022026fd958f396a26fc67cff6ef4507a8cf512/sqlspec-0.51.0.tar.gz", hash = "sha256:0dcab63a49acaa547ee8405557a353990d2e9ef358f47eb44561fa519550792b", size = 3506926, upload-time = "2026-06-26T01:39:35.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/73/e38cb690aa91d6d5a4ea2641d5a58812df387ef36f7aa19330c17a688690/sqlspec-0.52.0.tar.gz", hash = "sha256:0fe1e0adf678ace58f479186cd045649caaafc05eb5d3bc01fd21f0279bf5744", size = 3594355, upload-time = "2026-07-02T18:21:21.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/92/14a4bed577ec7e3035720aa40159d0faee763a2f551b14d39cfdb4e6f229/sqlspec-0.51.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f034aab81a726fee094c89589bcc0cb8af7d3782fe3852e17eb350b5021cdb7a", size = 6261591, upload-time = "2026-06-26T01:38:56.659Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/0e/3c37fef26f5996507d7e222664d11401ac55b928272fdccd9d9af5fc2c54/sqlspec-0.51.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:608607214760abcba899442d9b15c460de93827a96e975269045e8960ae3b8a2", size = 7296003, upload-time = "2026-06-26T01:38:59.031Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/b0/08ffa88eb64697823c7e11a1b69e830c2841b4edad9e8dc122a2dd02b7a0/sqlspec-0.51.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d04af5eff81034ad1af804cfcd819347097bd9717033943793de54c91bbf3643", size = 6814844, upload-time = "2026-06-26T01:39:00.956Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/82/be12f891ec23f01f66bd2709ff1196632096d214b297a80447f86c54135c/sqlspec-0.51.0-cp310-cp310-win_amd64.whl", hash = "sha256:577dd499ac5acb4d8db6ba3873a517795ec5c4e11af28c31e2a1836342fbbf7c", size = 5494243, upload-time = "2026-06-26T01:39:02.972Z" },
-    { url = "https://files.pythonhosted.org/packages/05/15/1490a651aa9835902a9f8a77e0477884cf888c99147781e675281d1703a8/sqlspec-0.51.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f41724bea9b68981176d734df063a5b75529fd9fdf0d7a8e7b3c7ffb231524f", size = 6219167, upload-time = "2026-06-26T01:39:04.69Z" },
-    { url = "https://files.pythonhosted.org/packages/52/bb/d7f7056ccc30143cd5537c9a9e6493009fe1754e50aa7562c1efea6d05c8/sqlspec-0.51.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4a3cc5f58c2d1d0d665ec7e8d5cfd0fb5692f026c5067d312bc22f8de0ed789a", size = 7243140, upload-time = "2026-06-26T01:39:06.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/86/878346ba61bc7824480ef859b7869e56107297aa5587f5d1aeb7cc53fb4e/sqlspec-0.51.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47532dd93217819db6fc0d50eb5f53f37afdffffc78b0a980a8938b9f9fbb04d", size = 6760227, upload-time = "2026-06-26T01:39:08.488Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1b/3acafc0edcc8475b81a6599065f7689030e4c7ed8141c69d2a24cd504574/sqlspec-0.51.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0942bc6a18953731d53761eca65dea6139f859d039c3cb81cdb1bb22b2861c9", size = 5481860, upload-time = "2026-06-26T01:39:10.397Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/30/dda9cfe617f5164c41f227750fcee1bea2befbfbca036219c7e36532bd5d/sqlspec-0.51.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:add924da522d948a956d86b332194f87f76bd1539bcfac88605a520f96429eeb", size = 6274902, upload-time = "2026-06-26T01:39:12.23Z" },
-    { url = "https://files.pythonhosted.org/packages/11/ec/c2ae83cbb15d4fe72c8df56ba754a7cdc389054b4827bdee771a9befe33d/sqlspec-0.51.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cc91bd400197e6dd533b41f5fd2c875984d65b5be45089720b6111bdeb3eb433", size = 7389346, upload-time = "2026-06-26T01:39:14.847Z" },
-    { url = "https://files.pythonhosted.org/packages/07/db/7b94b9136caac055b621a7cb47e07f5271d99ddde71c05e70f5e8aaeedfa/sqlspec-0.51.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe6a1e02b2bb7545493058298d8ac503203a7e8f9d390605cdad1410b7386fce", size = 6838964, upload-time = "2026-06-26T01:39:16.727Z" },
-    { url = "https://files.pythonhosted.org/packages/13/40/fb1e6f1b151855c0e365cad8a6eff5360dcc6a8a07342f5a8e7c855f324d/sqlspec-0.51.0-cp312-cp312-win_amd64.whl", hash = "sha256:3901e99d0d205332a57410d8bd3af61c60c62df76d4ea6f1c40f2e3fcfd6bbd1", size = 5527412, upload-time = "2026-06-26T01:39:18.464Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/7c/b6477586948f4697893d226497fdeacabf849599e762fc453eb8d4629cd1/sqlspec-0.51.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e66a60ded88489d187f22970c0338b664af42680a4f0dc7a9bff47fb198b704e", size = 6267198, upload-time = "2026-06-26T01:39:20.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/5e/8e9de66928963e5a4807238ca84939993ff9579e554445a43a767fb01db3/sqlspec-0.51.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d9b231c9095591177d26291710cc08c651ee8637bdab2c7d20476121fcc16044", size = 7419963, upload-time = "2026-06-26T01:39:21.843Z" },
-    { url = "https://files.pythonhosted.org/packages/03/fd/274ed9d303c2f1887e50ec9054113318d2f0478b9cd8101ab436604a9d97/sqlspec-0.51.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f1cceb1c8bfc90d8a629994a5720e88e773173795ff24962400492c82070d50", size = 6882901, upload-time = "2026-06-26T01:39:23.639Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/f9/a4f11037ec1e9b99b3dad7b87a8f8c899af4f00b7b3bac3cff0391b537ad/sqlspec-0.51.0-cp313-cp313-win_amd64.whl", hash = "sha256:8014aeae64b98cca66bf1d947971b795fa65a30504c2762773295cd61a4a4edd", size = 5535939, upload-time = "2026-06-26T01:39:25.907Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ff/9a2f997aa3017d7ff06175aaf1e2600062b710ff5a80780c101f6605cec2/sqlspec-0.51.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dbc79bbd578f2bafc897672371282706ef8a3bf481f70eb24e24d6c9de346eab", size = 6354349, upload-time = "2026-06-26T01:39:27.428Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ea/af5f84ee20ce874171cb945b4a72ee87ae156438f37d0ed3b0e04c8277e6/sqlspec-0.51.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4a74280c961793b7bc03fd1714da299334e8f21f9e84b1bf292a3e044cfb7b44", size = 7392040, upload-time = "2026-06-26T01:39:29.195Z" },
-    { url = "https://files.pythonhosted.org/packages/96/fe/307fe127df80d0db8973428cd86045f57d7d07ba8520691c3fe9b1205c02/sqlspec-0.51.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d1d4794c29662a4958253f2709004b4eca39261179a9fe6221029bb5e8094a6", size = 6893490, upload-time = "2026-06-26T01:39:30.973Z" },
-    { url = "https://files.pythonhosted.org/packages/77/6e/36df11480db2450c42726911b329f8afd72f3013c8c90c4329d0e51781fb/sqlspec-0.51.0-cp314-cp314-win_amd64.whl", hash = "sha256:798f56f48626d18735f0f0528a4f5920405655de82c93fa8703f5f7d688177a8", size = 5619399, upload-time = "2026-06-26T01:39:32.593Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/3c/1a0234da096e340a5962755c5f4d957adca4b2e6c813faebcfd95de7b9ab/sqlspec-0.51.0-py3-none-any.whl", hash = "sha256:500d9a4830c53370fe9acd6f6889f5ccf102d1a8cc61101a0761caea962a7e74", size = 1215140, upload-time = "2026-06-26T01:39:34.398Z" },
+    { url = "https://files.pythonhosted.org/packages/69/09/fe259f58ea16c3b4b3a4e959304dd080f37966235d37560ca0785fb16592/sqlspec-0.52.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6027c93a0dd211e62f3602aef8822048208f6c0d395ec0991c83688b7fda5aeb", size = 6435038, upload-time = "2026-07-02T18:20:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e8/36085c103dd385bfdcd4d2053cc14c1ce9e824031f32d04345a65f6710fb/sqlspec-0.52.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a642a411b5c4fb82bd3421cc4f946c96057cdf7f95f325014cf317aace8bd96", size = 7384474, upload-time = "2026-07-02T18:20:39.629Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b2/c3fe83c2bf8490676594a80886e2251331106d2fc0c421e13f56adafba64/sqlspec-0.52.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be87bd00bf4aafc771e4635187a7686e6b23e9c499cab91edb14e0b9ea5b1f09", size = 6910762, upload-time = "2026-07-02T18:20:41.592Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/01/3d8b977a25cb0c0c0fb7e77718b3a04f42c3be214e76a644fc79b498ab99/sqlspec-0.52.0-cp310-cp310-win_amd64.whl", hash = "sha256:26dbcd77d39b66a00100b3125dd84206692f9258ad1f4d19f98e4d3ac19ca0a2", size = 5593473, upload-time = "2026-07-02T18:20:43.824Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/6d67129ff7c70b17a43d06ff6e8bb7e04befa3462e9641f6510b713e7ce8/sqlspec-0.52.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11914bc212a3207aa834a7af5a344d154f02b873ca19d25a74b3c92ef950c45e", size = 6392343, upload-time = "2026-07-02T18:20:45.702Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/90/8e0daaed5ee0e1ebf502675f0d4ff009b856f8144649bb85fef1db96a693/sqlspec-0.52.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f08cd5ca7c27ef06d0828bca6cc589ac074dbcfb0115472077aebd1ca54d8252", size = 7332461, upload-time = "2026-07-02T18:20:48.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/49/28b84f638366db4bc1e3f0c53f6ff6f26f6c85c1b99324438ee4f246ad3c/sqlspec-0.52.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49429131d5616207b38de941ee1ab94bf272b675a37066c7a36c8ddc63468303", size = 6855268, upload-time = "2026-07-02T18:20:50.615Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/098781e59d1f2e9abde1101d77616fcc3594c0ff03b700bb0cab564cff52/sqlspec-0.52.0-cp311-cp311-win_amd64.whl", hash = "sha256:799c710f27eb6af4306309a77df5e63a43003be4c760455344c4143fe622d924", size = 5577890, upload-time = "2026-07-02T18:20:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a1/c770b145dfdc65c52145d4d4fb80d92ab519c6e13c762b54af64fcc10072/sqlspec-0.52.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebf760b596012173b9f8b7a06ccee3082c45b848128f337b447bf207783431a7", size = 6454397, upload-time = "2026-07-02T18:20:54.773Z" },
+    { url = "https://files.pythonhosted.org/packages/70/27/ffce81616dca159f0058e58d2a42dfc76e82a22f67834b200b7c121e461e/sqlspec-0.52.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:48729fe84014eca247e9bc642008d7465382bb883c0ef8398f7fa0d6f06708bc", size = 7478907, upload-time = "2026-07-02T18:20:56.776Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/66/587f5b12ecaacfb91bf1129e6f687dae19782c934ff442f7a6473752c7aa/sqlspec-0.52.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb4699b0981d763935c0fff47f7733a95e7858c960b0886d3a39ae90835d7ea1", size = 6937877, upload-time = "2026-07-02T18:20:58.932Z" },
+    { url = "https://files.pythonhosted.org/packages/71/99/ff88fcf9f08b476c0881e0c72ae2c3aa0a62784bf7464afb1c9b5dc204d1/sqlspec-0.52.0-cp312-cp312-win_amd64.whl", hash = "sha256:337a30bcfb6cc2c3638ad1560d89783e7040ec28d8f6e2b5dcda523268270052", size = 5626868, upload-time = "2026-07-02T18:21:01.603Z" },
+    { url = "https://files.pythonhosted.org/packages/41/58/e86b8e8332a819d9a0d79e2d3cf8bf789d75e39396c400e4b597c6b9dae6/sqlspec-0.52.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:549f898f1327b91f15c0fd5986dbcd4c7a05c6e037eb3724854f8e5fcf6a4e6a", size = 6445524, upload-time = "2026-07-02T18:21:03.685Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d6/4248df4a7c9b95e49f64ef20d26a6c9b467b2b47ef570b82c083d00a656c/sqlspec-0.52.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:29c6ba76a57f6064586baeca14f02141952eb69b3e6087a882426a50bc3bc2f5", size = 7515267, upload-time = "2026-07-02T18:21:05.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/fb/0cf4d4e1008e8a5debeb6ca69d55bb94922dd136584527f0e825a12b9a16/sqlspec-0.52.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b03ea51eb9686ca5d79407c18cb3df9b77859d3fea71badd12d2250ad9e8257", size = 6982554, upload-time = "2026-07-02T18:21:08.086Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a7/5f38e1f43bbb46adeebe53aa9746dbf6b42436900dfb0d48ecfae8603770/sqlspec-0.52.0-cp313-cp313-win_amd64.whl", hash = "sha256:af76a0135fcba3e7435dc11f690d0bfe33f6f1ba2d5945d45b86cfa6baba0da6", size = 5637261, upload-time = "2026-07-02T18:21:09.847Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/6d/4b20e73ec90d62d11d57447023043440d61ac0a8d6955ac8592b5aecab14/sqlspec-0.52.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:295f13bf95c47abe814593c588e8e7e7bbd84b8c476e2c269b32c7256216b7cc", size = 6439507, upload-time = "2026-07-02T18:21:11.725Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b7/178347474c3df807aff7cb9fc7f7d082729c5f930acf88f9a089467add22/sqlspec-0.52.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:dadac8c218a473bbeb2a162d661e35893815ab31101adc86e181b692bab3bfaa", size = 7491022, upload-time = "2026-07-02T18:21:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/3129c9d5513cfe44553ab9412f15742f39d853da6ee048064e4b65dc621f/sqlspec-0.52.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:706668ff9fa99a77c54b98b6c5a10a53f18d8601759ff445a634a49a2e66e605", size = 6994198, upload-time = "2026-07-02T18:21:15.6Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f4/a72c04b8e808d04800fa849483b4a5596583466412649d1e519a9c49c9c5/sqlspec-0.52.0-cp314-cp314-win_amd64.whl", hash = "sha256:33b0d958216d966258012e4710d76fc424a83dba84fc53e2de2eda82ca0fc4f4", size = 5719903, upload-time = "2026-07-02T18:21:17.563Z" },
+    { url = "https://files.pythonhosted.org/packages/70/42/472ad71d074c78a96be0af6f1dd09460468ede371cba092c03b71fbb4a8f/sqlspec-0.52.0-py3-none-any.whl", hash = "sha256:40e50294d2d12cfb0326c5076129a8259de4d3db8acbf7d5b5c9f23ce4010b28", size = 1280874, upload-time = "2026-07-02T18:21:19.384Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- update the SQLSpec backend baseline to `sqlspec>=0.52.0`
- use SQLSpec data-dictionary feature checks for skip-locked support
- enable async Oracle skip-locked claiming and Oracle `aq`/`txeventq` queue notifications
