### PR TITLE
feat: restore SQLSpec PyMySQL queue store

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -196,6 +196,9 @@ claim/update statements where the database supports them.
    * - ``mysqlconnector``
      - ``MysqlConnectorAsyncQueueStore`` or ``MysqlConnectorSyncQueueStore``
      - Async and sync variants are selected from the SQLSpec config type.
+   * - ``pymysql``
+     - ``PymysqlQueueStore``
+     - Sync MySQL behavior.
    * - ``oracledb``
      - ``OracledbAsyncQueueStore`` or ``OracledbSyncQueueStore``
      - Uses Oracle-specific DDL and JSON column choices.
@@ -279,6 +282,13 @@ advertises, then fall back to the portable path when a capability is absent.
      - Arrow ``load_from_records`` path.
      - Polling.
      - Index prefixes keep InnoDB key length within portable bounds.
+   * - ``pymysql``
+     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
+       dialect support.
+     - MySQL ``JSON`` columns with native decoded JSON values.
+     - Arrow ``load_from_records`` path.
+     - Polling.
+     - Sync MySQL behavior uses the same InnoDB prefix guard.
    * - ``oracledb``
      - ``FOR UPDATE SKIP LOCKED`` through SQLSpec's Oracle data-dictionary
        capability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ tests = [
   "numpy",
   "advanced-alchemy>=1.10.0",
   # SQLSpec adapters covered by the default integration matrix
-  "sqlspec[aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,cockroachdb,litestar,mysql-connector]>=0.52.0",
+  "sqlspec[aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,cockroachdb,pymysql,litestar,mysql-connector]>=0.52.0",
 ]
 
 #####################

--- a/src/litestar_queues/backends/sqlspec/stores/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/stores/__init__.py
@@ -19,6 +19,7 @@ from litestar_queues.backends.sqlspec.stores.mysqlconnector import (
 from litestar_queues.backends.sqlspec.stores.oracledb import OracledbAsyncQueueStore, OracledbSyncQueueStore
 from litestar_queues.backends.sqlspec.stores.psqlpy import PsqlpyQueueStore
 from litestar_queues.backends.sqlspec.stores.psycopg import PsycopgAsyncQueueStore, PsycopgSyncQueueStore
+from litestar_queues.backends.sqlspec.stores.pymysql import PymysqlQueueStore
 from litestar_queues.backends.sqlspec.stores.sqlite import SqliteQueueStore
 
 __all__ = (
@@ -37,6 +38,7 @@ __all__ = (
     "PsqlpyQueueStore",
     "PsycopgAsyncQueueStore",
     "PsycopgSyncQueueStore",
+    "PymysqlQueueStore",
     "SQLSpecQueueStore",
     "SqliteQueueStore",
     "create_queue_store",

--- a/src/litestar_queues/backends/sqlspec/stores/factory.py
+++ b/src/litestar_queues/backends/sqlspec/stores/factory.py
@@ -20,6 +20,7 @@ from litestar_queues.backends.sqlspec.stores.mysqlconnector import (
 from litestar_queues.backends.sqlspec.stores.oracledb import OracledbAsyncQueueStore, OracledbSyncQueueStore
 from litestar_queues.backends.sqlspec.stores.psqlpy import PsqlpyQueueStore
 from litestar_queues.backends.sqlspec.stores.psycopg import PsycopgAsyncQueueStore, PsycopgSyncQueueStore
+from litestar_queues.backends.sqlspec.stores.pymysql import PymysqlQueueStore
 from litestar_queues.backends.sqlspec.stores.sqlite import SqliteQueueStore
 from litestar_queues.exceptions import QueueConfigurationError
 
@@ -35,6 +36,7 @@ _ADAPTER_STORE_TYPES: "dict[str, type[SQLSpecQueueStore]]" = {
     "asyncpg": AsyncpgQueueStore,
     "cockroach_asyncpg": CockroachAsyncpgQueueStore,
     "duckdb": DuckDBQueueStore,
+    "pymysql": PymysqlQueueStore,
     "psqlpy": PsqlpyQueueStore,
     "sqlite": SqliteQueueStore,
 }

--- a/src/litestar_queues/backends/sqlspec/stores/pymysql/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/stores/pymysql/__init__.py
@@ -1,0 +1,5 @@
+"""pymysql SQLSpec queue store."""
+
+from litestar_queues.backends.sqlspec.stores.pymysql.store import PymysqlQueueStore
+
+__all__ = ("PymysqlQueueStore",)

--- a/src/litestar_queues/backends/sqlspec/stores/pymysql/store.py
+++ b/src/litestar_queues/backends/sqlspec/stores/pymysql/store.py
@@ -1,0 +1,11 @@
+"""pymysql SQLSpec queue store."""
+
+from litestar_queues.backends.sqlspec.stores._families import MySQLQueueStore
+
+__all__ = ("PymysqlQueueStore",)
+
+
+class PymysqlQueueStore(MySQLQueueStore):
+    """pymysql-specific SQLSpec queue statement store."""
+
+    __slots__ = ()

--- a/src/tests/integration/_backends.py
+++ b/src/tests/integration/_backends.py
@@ -272,6 +272,25 @@ async def _build_mysql_mysqlconnector(ctx: "FixtureCtx") -> "BaseQueueBackend":
     )
 
 
+async def _build_mysql_pymysql(ctx: "FixtureCtx") -> "BaseQueueBackend":
+    from sqlspec.adapters.pymysql import PyMysqlConfig
+
+    svc = cast("MySQLService", ctx.service)
+    assert svc is not None
+    return _sqlspec_backend(
+        PyMysqlConfig(
+            connection_config={
+                "host": svc.host,
+                "port": svc.port,
+                "user": svc.user,
+                "password": svc.password,
+                "database": svc.db,
+            }
+        ),
+        table_name=ctx.table_name,
+    )
+
+
 async def _build_oracle_oracledb(ctx: "FixtureCtx") -> "BaseQueueBackend":
     from sqlspec.adapters.oracledb import OracleAsyncConfig
 
@@ -369,6 +388,13 @@ QUEUE_BACKENDS: "tuple[BackendCase, ...]" = (
         "mysql_service",
         _build_mysql_mysqlconnector,
         frozenset({"polling-only", "json-column"}),
+    ),
+    BackendCase(
+        "mysql-pymysql",
+        frozenset({"pymysql", "sqlspec"}),
+        "mysql_service",
+        _build_mysql_pymysql,
+        frozenset({"polling-only", "json-column", "sync-driver"}),
     ),
     BackendCase(
         "oracle-oracledb",

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -45,6 +45,7 @@ from litestar_queues.backends.sqlspec.stores import (
     PsqlpyQueueStore,
     PsycopgAsyncQueueStore,
     PsycopgSyncQueueStore,
+    PymysqlQueueStore,
     SqliteQueueStore,
     create_queue_store,
 )
@@ -257,6 +258,7 @@ blocked_prefixes = (
     "cockroach_asyncpg",
     "cockroach_psycopg",
     "mysql.connector",
+    "pymysql",
     "oracledb",
     "psqlpy",
     "psycopg",
@@ -268,6 +270,7 @@ blocked_prefixes = (
     "sqlspec.adapters.cockroach_psycopg",
     "sqlspec.adapters.duckdb",
     "sqlspec.adapters.mysqlconnector",
+    "sqlspec.adapters.pymysql",
     "sqlspec.adapters.oracledb",
     "sqlspec.adapters.psqlpy",
     "sqlspec.adapters.psycopg",
@@ -367,7 +370,6 @@ async def test_sqlspec_backend_exposes_config_type_and_builder_store(
         ("arrow_odbc", "sqlite", "ArrowOdbcConfig"),
         ("bigquery", "bigquery", "BigQueryConfig"),
         ("mssql_python", "tsql", "MssqlPythonAsyncConfig"),
-        ("pymysql", "mysql", "PyMysqlConfig"),
         ("spanner", "spanner", "SpannerConfig"),
     ),
 )
@@ -448,6 +450,7 @@ def test_sqlspec_backend_accepts_cockroach_sqlspec_adapters(
         ("mysqlconnector", "mysql", "MysqlConnectorAsyncConfig", {}, MysqlConnectorAsyncQueueStore, "ENGINE=InnoDB"),
         ("oracledb", "oracle", "OracleSyncConfig", {}, OracledbSyncQueueStore, "BLOB CHECK (args_json IS JSON)"),
         ("oracledb", "oracle", "OracleAsyncConfig", {}, OracledbAsyncQueueStore, "BLOB CHECK (args_json IS JSON)"),
+        ("pymysql", "mysql", "PyMysqlConfig", {}, PymysqlQueueStore, "ENGINE=InnoDB"),
         ("psqlpy", "postgres", "PsqlpyConfig", {}, PsqlpyQueueStore, 'WHERE "status" IN'),
         ("psycopg", "postgres", "PsycopgSyncConfig", {}, PsycopgSyncQueueStore, 'WHERE "status" IN'),
         ("psycopg", "postgres", "PsycopgAsyncConfig", {}, PsycopgAsyncQueueStore, 'WHERE "status" IN'),
@@ -479,6 +482,7 @@ async def test_sqlspec_backend_store_factory_covers_sqlspec_adapter_modules(
     (
         ("asyncpg", "postgres", True),
         ("asyncmy", "mysql", True),
+        ("pymysql", "mysql", True),
         ("psqlpy", "postgres", True),
         ("aiosqlite", "sqlite", False),
         ("duckdb", "duckdb", False),
@@ -591,6 +595,14 @@ def test_sqlspec_backend_rejects_invalid_table_names(table_name: "str") -> "None
             "`args_json` JSON NOT NULL",
             frozenset({"args_json", "kwargs_json", "metadata_json", "result_json"}),
         ),
+        (
+            "pymysql",
+            "mysql",
+            "PyMysqlConfig",
+            {},
+            "`args_json` JSON NOT NULL",
+            frozenset({"args_json", "kwargs_json", "metadata_json", "result_json"}),
+        ),
     ),
 )
 def test_sqlspec_store_capability_matrix_pins_json_and_bulk_capabilities(
@@ -624,6 +636,7 @@ def test_sqlspec_store_capability_matrix_pins_json_and_bulk_capabilities(
     (
         ("aiomysql", "AiomysqlConfig"),
         ("asyncmy", "AsyncmyConfig"),
+        ("pymysql", "PyMysqlConfig"),
         ("mysqlconnector", "MysqlConnectorSyncConfig"),
         ("mysqlconnector", "MysqlConnectorAsyncConfig"),
     ),

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -372,6 +372,7 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
         ("duckdb", "polling"),
         ("asyncmy", "polling"),
         ("aiomysql", "polling"),
+        ("pymysql", "polling"),
         ("mysqlconnector", "polling"),
         ("oracledb", "polling"),
         (None, "polling"),

--- a/src/tests/integration/test_backends_registry.py
+++ b/src/tests/integration/test_backends_registry.py
@@ -1,0 +1,12 @@
+"""Registry-level checks for the integration backend matrix."""
+
+from tests.integration._backends import QUEUE_BACKENDS
+
+
+def test_sqlspec_backend_registry_includes_mysql_pymysql_case() -> "None":
+    case = next((case for case in QUEUE_BACKENDS if case.name == "mysql-pymysql"), None)
+
+    assert case is not None
+    assert case.extras == frozenset({"pymysql", "sqlspec"})
+    assert case.service_attr == "mysql_service"
+    assert case.capabilities == frozenset({"polling-only", "json-column", "sync-driver"})

--- a/uv.lock
+++ b/uv.lock
@@ -1391,7 +1391,7 @@ dev = [
     { name = "sphinx-paramlinks" },
     { name = "sphinx-togglebutton" },
     { name = "sphinxcontrib-mermaid" },
-    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "cockroachdb", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg"] },
+    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "cockroachdb", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg", "pymysql"] },
     { name = "valkey" },
 ]
 docs = [
@@ -1425,7 +1425,7 @@ tests = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "redis" },
-    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "cockroachdb", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg"] },
+    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "cockroachdb", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg", "pymysql"] },
     { name = "valkey" },
 ]
 
@@ -1471,7 +1471,7 @@ dev = [
     { name = "sphinx-paramlinks", specifier = ">=0.6.0" },
     { name = "sphinx-togglebutton", specifier = ">=0.3.2" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
-    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "cockroachdb", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
+    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "cockroachdb", "pymysql", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]
 docs = [
@@ -1499,7 +1499,7 @@ tests = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "redis", specifier = ">=5.0.0" },
-    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "cockroachdb", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
+    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "cockroachdb", "pymysql", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]
 
@@ -3504,6 +3504,9 @@ psqlpy = [
 ]
 psycopg = [
     { name = "psycopg", extra = ["binary", "pool"] },
+]
+pymysql = [
+    { name = "pymysql" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- restore PyMySQL as a supported SQLSpec MySQL queue store
- reuse the MySQL store family for PyMySQL capability behavior and notifications

Refs #18.
