### PR TITLE
feat: add Cockroach SQLSpec queue stores

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -187,6 +187,9 @@ claim/update statements where the database supports them.
    * - ``asyncpg``
      - ``AsyncpgQueueStore``
      - PostgreSQL behavior.
+   * - ``cockroach_asyncpg``
+     - ``CockroachAsyncpgQueueStore``
+     - CockroachDB behavior on the asyncpg driver.
    * - ``duckdb``
      - ``DuckDBQueueStore``
      - DuckDB-specific DDL and JSON behavior.
@@ -202,6 +205,10 @@ claim/update statements where the database supports them.
    * - ``psycopg``
      - ``PsycopgAsyncQueueStore`` or ``PsycopgSyncQueueStore``
      - Async and sync variants are selected from the SQLSpec config type.
+   * - ``cockroach_psycopg``
+     - ``CockroachPsycopgAsyncQueueStore`` or ``CockroachPsycopgSyncQueueStore``
+     - CockroachDB behavior on psycopg; async and sync variants are selected
+       from the SQLSpec config type.
    * - ``sqlite``
      - ``SqliteQueueStore``
      - Sync SQLite behavior.
@@ -249,6 +256,14 @@ advertises, then fall back to the portable path when a capability is absent.
        use SQLSpec's durable table queue.
      - Stale-recovery statement batches use SQLSpec ``StatementStack``; psycopg
        can collapse the batch through the driver pipeline.
+   * - ``cockroach_asyncpg`` / ``cockroach_psycopg``
+     - Optimistic compare-and-swap.
+     - ``JSONB`` with native decoded JSON columns where the driver returns
+       Python values.
+     - Arrow ``load_from_records`` path.
+     - Polling.
+     - CockroachDB keeps PostgreSQL-compatible DDL, but the queue backend
+       stays on the portable claim path instead of relying on ``SKIP LOCKED``.
    * - ``psqlpy``
      - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
        dialect support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ tests = [
   "pytest-sugar",
   "pytest-xdist",
   # Real-service fixtures for the integration tier
-  "pytest-databases[postgres,mysql,oracle,redis,valkey]>=0.19.0",
+  "pytest-databases[postgres,mysql,oracle,redis,valkey,cockroachdb]>=0.19.0",
   # Redis + Valkey clients used directly by integration tests
   "redis>=5.0.0",
   "valkey>=6.0.0",
@@ -123,7 +123,7 @@ tests = [
   "numpy",
   "advanced-alchemy>=1.10.0",
   # SQLSpec adapters covered by the default integration matrix
-  "sqlspec[aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,litestar,mysql-connector]>=0.52.0",
+  "sqlspec[aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,cockroachdb,litestar,mysql-connector]>=0.52.0",
 ]
 
 #####################

--- a/src/litestar_queues/backends/sqlspec/stores/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/stores/__init__.py
@@ -5,6 +5,11 @@ from litestar_queues.backends.sqlspec.stores.aiosqlite import AiosqliteQueueStor
 from litestar_queues.backends.sqlspec.stores.asyncmy import AsyncmyQueueStore
 from litestar_queues.backends.sqlspec.stores.asyncpg import AsyncpgQueueStore
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore
+from litestar_queues.backends.sqlspec.stores.cockroach_asyncpg import CockroachAsyncpgQueueStore
+from litestar_queues.backends.sqlspec.stores.cockroach_psycopg import (
+    CockroachPsycopgAsyncQueueStore,
+    CockroachPsycopgSyncQueueStore,
+)
 from litestar_queues.backends.sqlspec.stores.duckdb import DuckDBQueueStore
 from litestar_queues.backends.sqlspec.stores.factory import create_queue_store
 from litestar_queues.backends.sqlspec.stores.mysqlconnector import (
@@ -21,6 +26,9 @@ __all__ = (
     "AiosqliteQueueStore",
     "AsyncmyQueueStore",
     "AsyncpgQueueStore",
+    "CockroachAsyncpgQueueStore",
+    "CockroachPsycopgAsyncQueueStore",
+    "CockroachPsycopgSyncQueueStore",
     "DuckDBQueueStore",
     "MysqlConnectorAsyncQueueStore",
     "MysqlConnectorSyncQueueStore",

--- a/src/litestar_queues/backends/sqlspec/stores/_families.py
+++ b/src/litestar_queues/backends/sqlspec/stores/_families.py
@@ -6,7 +6,7 @@ from sqlspec import sql
 
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore
 
-__all__ = ("MySQLQueueStore", "PostgresQueueStore")
+__all__ = ("CockroachQueueStore", "MySQLQueueStore", "PostgresQueueStore")
 
 
 class PostgresQueueStore(SQLSpecQueueStore):
@@ -76,6 +76,20 @@ class PostgresQueueStore(SQLSpecQueueStore):
 
     def _timestamp_type(self) -> "str":
         return "TIMESTAMPTZ"
+
+
+class CockroachQueueStore(PostgresQueueStore):
+    """Cockroach-family queue store with Postgres-compatible DDL."""
+
+    __slots__ = ()
+
+    data_dictionary_dialect: "ClassVar[str | None]" = "cockroachdb"
+    table_storage_parameters: "ClassVar[bool]" = False
+
+    @property
+    def supports_skip_locked(self) -> "bool":
+        """Cockroach claim transactions stay on the portable CAS path."""
+        return False
 
 
 class MySQLQueueStore(SQLSpecQueueStore):

--- a/src/litestar_queues/backends/sqlspec/stores/cockroach_asyncpg/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/stores/cockroach_asyncpg/__init__.py
@@ -1,0 +1,5 @@
+"""cockroach_asyncpg SQLSpec queue store."""
+
+from litestar_queues.backends.sqlspec.stores.cockroach_asyncpg.store import CockroachAsyncpgQueueStore
+
+__all__ = ("CockroachAsyncpgQueueStore",)

--- a/src/litestar_queues/backends/sqlspec/stores/cockroach_asyncpg/store.py
+++ b/src/litestar_queues/backends/sqlspec/stores/cockroach_asyncpg/store.py
@@ -1,0 +1,11 @@
+"""cockroach_asyncpg SQLSpec queue store."""
+
+from litestar_queues.backends.sqlspec.stores._families import CockroachQueueStore
+
+__all__ = ("CockroachAsyncpgQueueStore",)
+
+
+class CockroachAsyncpgQueueStore(CockroachQueueStore):
+    """cockroach_asyncpg SQLSpec queue statement store."""
+
+    __slots__ = ()

--- a/src/litestar_queues/backends/sqlspec/stores/cockroach_psycopg/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/stores/cockroach_psycopg/__init__.py
@@ -1,0 +1,8 @@
+"""cockroach_psycopg SQLSpec queue stores."""
+
+from litestar_queues.backends.sqlspec.stores.cockroach_psycopg.store import (
+    CockroachPsycopgAsyncQueueStore,
+    CockroachPsycopgSyncQueueStore,
+)
+
+__all__ = ("CockroachPsycopgAsyncQueueStore", "CockroachPsycopgSyncQueueStore")

--- a/src/litestar_queues/backends/sqlspec/stores/cockroach_psycopg/store.py
+++ b/src/litestar_queues/backends/sqlspec/stores/cockroach_psycopg/store.py
@@ -1,0 +1,17 @@
+"""cockroach_psycopg SQLSpec queue stores."""
+
+from litestar_queues.backends.sqlspec.stores._families import CockroachQueueStore
+
+__all__ = ("CockroachPsycopgAsyncQueueStore", "CockroachPsycopgSyncQueueStore")
+
+
+class CockroachPsycopgSyncQueueStore(CockroachQueueStore):
+    """cockroach_psycopg sync SQLSpec queue statement store."""
+
+    __slots__ = ()
+
+
+class CockroachPsycopgAsyncQueueStore(CockroachQueueStore):
+    """cockroach_psycopg async SQLSpec queue statement store."""
+
+    __slots__ = ()

--- a/src/litestar_queues/backends/sqlspec/stores/factory.py
+++ b/src/litestar_queues/backends/sqlspec/stores/factory.py
@@ -7,6 +7,11 @@ from litestar_queues.backends.sqlspec.stores.aiosqlite import AiosqliteQueueStor
 from litestar_queues.backends.sqlspec.stores.asyncmy import AsyncmyQueueStore
 from litestar_queues.backends.sqlspec.stores.asyncpg import AsyncpgQueueStore
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore, _adapter_name
+from litestar_queues.backends.sqlspec.stores.cockroach_asyncpg import CockroachAsyncpgQueueStore
+from litestar_queues.backends.sqlspec.stores.cockroach_psycopg import (
+    CockroachPsycopgAsyncQueueStore,
+    CockroachPsycopgSyncQueueStore,
+)
 from litestar_queues.backends.sqlspec.stores.duckdb import DuckDBQueueStore
 from litestar_queues.backends.sqlspec.stores.mysqlconnector import (
     MysqlConnectorAsyncQueueStore,
@@ -28,11 +33,12 @@ _ADAPTER_STORE_TYPES: "dict[str, type[SQLSpecQueueStore]]" = {
     "aiosqlite": AiosqliteQueueStore,
     "asyncmy": AsyncmyQueueStore,
     "asyncpg": AsyncpgQueueStore,
+    "cockroach_asyncpg": CockroachAsyncpgQueueStore,
     "duckdb": DuckDBQueueStore,
     "psqlpy": PsqlpyQueueStore,
     "sqlite": SqliteQueueStore,
 }
-_ASYNC_OR_SYNC_ADAPTER_NAMES = frozenset({"mysqlconnector", "oracledb", "psycopg"})
+_ASYNC_OR_SYNC_ADAPTER_NAMES = frozenset({"cockroach_psycopg", "mysqlconnector", "oracledb", "psycopg"})
 _SUPPORTED_ADAPTER_NAMES = frozenset(_ADAPTER_STORE_TYPES) | _ASYNC_OR_SYNC_ADAPTER_NAMES
 
 
@@ -72,6 +78,10 @@ def _adapter_store_type(config: "Any") -> "type[SQLSpecQueueStore]":
     if name == "psycopg":
         return _async_or_sync_store_type(
             config, async_store_type=PsycopgAsyncQueueStore, sync_store_type=PsycopgSyncQueueStore
+        )
+    if name == "cockroach_psycopg":
+        return _async_or_sync_store_type(
+            config, async_store_type=CockroachPsycopgAsyncQueueStore, sync_store_type=CockroachPsycopgSyncQueueStore
         )
     if name in _ADAPTER_STORE_TYPES:
         return _ADAPTER_STORE_TYPES[name]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 # at the project root because pytest requires ``pytest_plugins`` to live in the
 # top-level conftest.
 pytest_plugins = [
+    "pytest_databases.docker.cockroachdb",
     "pytest_databases.docker.postgres",
     "pytest_databases.docker.mysql",
     "pytest_databases.docker.oracle",

--- a/src/tests/integration/_backends.py
+++ b/src/tests/integration/_backends.py
@@ -49,6 +49,15 @@ class OracleService(Protocol):
     service_name: "str"
 
 
+class CockroachService(Protocol):
+    """pytest-databases Cockroach service attributes used by backend builders."""
+
+    host: "str"
+    port: "int"
+    database: "str"
+    driver_opts: "dict[str, str]"
+
+
 @dataclass(frozen=True, slots=True)
 class FixtureCtx:
     """Per-test fixture context handed to a BackendCase builder."""
@@ -175,6 +184,37 @@ async def _build_postgres_psqlpy(ctx: "FixtureCtx") -> "BaseQueueBackend":
     )
 
 
+async def _build_cockroach_asyncpg(ctx: "FixtureCtx") -> "BaseQueueBackend":
+    from sqlspec.adapters.cockroach_asyncpg import CockroachAsyncpgConfig
+
+    svc = cast("CockroachService", ctx.service)
+    assert svc is not None
+    return _sqlspec_backend(
+        CockroachAsyncpgConfig(
+            connection_config={
+                "host": svc.host,
+                "port": svc.port,
+                "user": "root",
+                "password": "",
+                "database": svc.database,
+                "ssl": False,
+            }
+        ),
+        table_name=ctx.table_name,
+    )
+
+
+async def _build_cockroach_psycopg(ctx: "FixtureCtx") -> "BaseQueueBackend":
+    from sqlspec.adapters.cockroach_psycopg import CockroachPsycopgAsyncConfig
+
+    svc = cast("CockroachService", ctx.service)
+    assert svc is not None
+    conninfo = f"postgresql://root@{svc.host}:{svc.port}/{svc.database}?sslmode=disable"
+    return _sqlspec_backend(
+        CockroachPsycopgAsyncConfig(connection_config={"conninfo": conninfo}), table_name=ctx.table_name
+    )
+
+
 async def _build_mysql_asyncmy(ctx: "FixtureCtx") -> "BaseQueueBackend":
     from sqlspec.adapters.asyncmy import AsyncmyConfig
 
@@ -294,6 +334,20 @@ QUEUE_BACKENDS: "tuple[BackendCase, ...]" = (
         "postgres_service",
         _build_postgres_psqlpy,
         frozenset({"listen-notify", "json-column"}),
+    ),
+    BackendCase(
+        "cockroach-asyncpg",
+        frozenset({"asyncpg", "sqlspec"}),
+        "cockroachdb_service",
+        _build_cockroach_asyncpg,
+        frozenset({"polling-only", "json-column"}),
+    ),
+    BackendCase(
+        "cockroach-psycopg",
+        frozenset({"psycopg", "sqlspec"}),
+        "cockroachdb_service",
+        _build_cockroach_psycopg,
+        frozenset({"polling-only", "json-column"}),
     ),
     BackendCase(
         "mysql-asyncmy",

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -34,6 +34,9 @@ from litestar_queues.backends.sqlspec.stores import (
     AiosqliteQueueStore,
     AsyncmyQueueStore,
     AsyncpgQueueStore,
+    CockroachAsyncpgQueueStore,
+    CockroachPsycopgAsyncQueueStore,
+    CockroachPsycopgSyncQueueStore,
     DuckDBQueueStore,
     MysqlConnectorAsyncQueueStore,
     MysqlConnectorSyncQueueStore,
@@ -251,6 +254,8 @@ blocked_prefixes = (
     "asyncmy",
     "asyncpg",
     "duckdb",
+    "cockroach_asyncpg",
+    "cockroach_psycopg",
     "mysql.connector",
     "oracledb",
     "psqlpy",
@@ -259,6 +264,8 @@ blocked_prefixes = (
     "sqlspec.adapters.aiosqlite",
     "sqlspec.adapters.asyncmy",
     "sqlspec.adapters.asyncpg",
+    "sqlspec.adapters.cockroach_asyncpg",
+    "sqlspec.adapters.cockroach_psycopg",
     "sqlspec.adapters.duckdb",
     "sqlspec.adapters.mysqlconnector",
     "sqlspec.adapters.oracledb",
@@ -281,6 +288,9 @@ from litestar_queues.backends.sqlspec.stores import (
     AsyncmyQueueStore,
     AsyncpgQueueStore,
     DuckDBQueueStore,
+    CockroachAsyncpgQueueStore,
+    CockroachPsycopgAsyncQueueStore,
+    CockroachPsycopgSyncQueueStore,
     MysqlConnectorAsyncQueueStore,
     MysqlConnectorSyncQueueStore,
     OracledbAsyncQueueStore,
@@ -305,6 +315,9 @@ expected = (
     ("aiosqlite", "sqlite", "AiosqliteConfig", AiosqliteQueueStore),
     ("asyncmy", "mysql", "AsyncmyConfig", AsyncmyQueueStore),
     ("asyncpg", "postgres", "AsyncpgConfig", AsyncpgQueueStore),
+    ("cockroach_asyncpg", "postgres", "CockroachAsyncpgConfig", CockroachAsyncpgQueueStore),
+    ("cockroach_psycopg", "postgres", "CockroachPsycopgAsyncConfig", CockroachPsycopgAsyncQueueStore),
+    ("cockroach_psycopg", "postgres", "CockroachPsycopgSyncConfig", CockroachPsycopgSyncQueueStore),
     ("duckdb", "duckdb", "DuckDBConfig", DuckDBQueueStore),
     ("mysqlconnector", "mysql", "MysqlConnectorSyncConfig", MysqlConnectorSyncQueueStore),
     ("mysqlconnector", "mysql", "MysqlConnectorAsyncConfig", MysqlConnectorAsyncQueueStore),
@@ -353,8 +366,6 @@ async def test_sqlspec_backend_exposes_config_type_and_builder_store(
         ("adbc", "sqlite", "AdbcConfig"),
         ("arrow_odbc", "sqlite", "ArrowOdbcConfig"),
         ("bigquery", "bigquery", "BigQueryConfig"),
-        ("cockroach_asyncpg", "postgres", "CockroachAsyncpgConfig"),
-        ("cockroach_psycopg", "postgres", "CockroachPsycopgAsyncConfig"),
         ("mssql_python", "tsql", "MssqlPythonAsyncConfig"),
         ("pymysql", "mysql", "PyMysqlConfig"),
         ("spanner", "spanner", "SpannerConfig"),
@@ -371,6 +382,30 @@ def test_sqlspec_backend_rejects_unsupported_sqlspec_adapter(
 
 
 @pytest.mark.parametrize(
+    ("adapter_name", "config_type_name", "expected_store_name"),
+    (
+        ("cockroach_asyncpg", "CockroachAsyncpgConfig", "CockroachAsyncpgQueueStore"),
+        ("cockroach_psycopg", "CockroachPsycopgAsyncConfig", "CockroachPsycopgAsyncQueueStore"),
+        ("cockroach_psycopg", "CockroachPsycopgSyncConfig", "CockroachPsycopgSyncQueueStore"),
+    ),
+)
+def test_sqlspec_backend_accepts_cockroach_sqlspec_adapters(
+    adapter_name: "str", config_type_name: "str", expected_store_name: "str"
+) -> "None":
+    store = create_queue_store(
+        _fake_adapter_config(adapter_name, dialect="postgres", config_type_name=config_type_name),
+        table_name="queue_tasks",
+    )
+
+    created_statements = "\n".join(store.create_statements())
+    assert store.__class__.__module__.startswith(f"litestar_queues.backends.sqlspec.stores.{adapter_name}.")
+    assert store.__class__.__name__ == expected_store_name
+    assert "WITH (fillfactor = 80)" not in created_statements
+    assert "autovacuum_vacuum_scale_factor" not in created_statements
+    assert store.supports_skip_locked is False
+
+
+@pytest.mark.parametrize(
     (
         "adapter_name",
         "dialect",
@@ -384,6 +419,30 @@ def test_sqlspec_backend_rejects_unsupported_sqlspec_adapter(
         ("aiosqlite", "sqlite", "AiosqliteConfig", {}, AiosqliteQueueStore, '"queue_tasks"'),
         ("asyncmy", "mysql", "AsyncmyConfig", {}, AsyncmyQueueStore, "ENGINE=InnoDB"),
         ("asyncpg", "postgres", "AsyncpgConfig", {}, AsyncpgQueueStore, 'WHERE "status" IN'),
+        (
+            "cockroach_asyncpg",
+            "postgres",
+            "CockroachAsyncpgConfig",
+            {},
+            CockroachAsyncpgQueueStore,
+            'WHERE "status" IN',
+        ),
+        (
+            "cockroach_psycopg",
+            "postgres",
+            "CockroachPsycopgAsyncConfig",
+            {},
+            CockroachPsycopgAsyncQueueStore,
+            'WHERE "status" IN',
+        ),
+        (
+            "cockroach_psycopg",
+            "postgres",
+            "CockroachPsycopgSyncConfig",
+            {},
+            CockroachPsycopgSyncQueueStore,
+            'WHERE "status" IN',
+        ),
         ("duckdb", "duckdb", "DuckDBConfig", {}, DuckDBQueueStore, "JSON"),
         ("mysqlconnector", "mysql", "MysqlConnectorSyncConfig", {}, MysqlConnectorSyncQueueStore, "ENGINE=InnoDB"),
         ("mysqlconnector", "mysql", "MysqlConnectorAsyncConfig", {}, MysqlConnectorAsyncQueueStore, "ENGINE=InnoDB"),

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -365,6 +365,8 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
         ("asyncpg", "listen_notify_durable"),
         ("psycopg", "table_queue"),
         ("psqlpy", "table_queue"),
+        ("cockroach_asyncpg", "polling"),
+        ("cockroach_psycopg", "polling"),
         ("aiosqlite", "polling"),
         ("sqlite", "polling"),
         ("duckdb", "polling"),

--- a/uv.lock
+++ b/uv.lock
@@ -1371,7 +1371,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extra = ["oracle", "postgres", "redis", "valkey"] },
+    { name = "pytest-databases", extra = ["cockroachdb", "oracle", "postgres", "redis", "valkey"] },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -1391,7 +1391,7 @@ dev = [
     { name = "sphinx-paramlinks" },
     { name = "sphinx-togglebutton" },
     { name = "sphinxcontrib-mermaid" },
-    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg"] },
+    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "cockroachdb", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg"] },
     { name = "valkey" },
 ]
 docs = [
@@ -1419,13 +1419,13 @@ tests = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extra = ["oracle", "postgres", "redis", "valkey"] },
+    { name = "pytest-databases", extra = ["cockroachdb", "oracle", "postgres", "redis", "valkey"] },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "redis" },
-    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg"] },
+    { name = "sqlspec", extra = ["aiomysql", "aiosqlite", "asyncmy", "asyncpg", "cockroachdb", "duckdb", "litestar", "mysql-connector", "oracledb", "psqlpy", "psycopg"] },
     { name = "valkey" },
 ]
 
@@ -1455,7 +1455,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extras = ["postgres", "mysql", "oracle", "redis", "valkey"], specifier = ">=0.19.0" },
+    { name = "pytest-databases", extras = ["postgres", "mysql", "oracle", "redis", "valkey", "cockroachdb"], specifier = ">=0.19.0" },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -1471,7 +1471,7 @@ dev = [
     { name = "sphinx-paramlinks", specifier = ">=0.6.0" },
     { name = "sphinx-togglebutton", specifier = ">=0.3.2" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
-    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
+    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "cockroachdb", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]
 docs = [
@@ -1493,13 +1493,13 @@ tests = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extras = ["postgres", "mysql", "oracle", "redis", "valkey"], specifier = ">=0.19.0" },
+    { name = "pytest-databases", extras = ["postgres", "mysql", "oracle", "redis", "valkey", "cockroachdb"], specifier = ">=0.19.0" },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "redis", specifier = ">=5.0.0" },
-    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
+    { name = "sqlspec", extras = ["aiosqlite", "oracledb", "aiomysql", "psycopg", "asyncpg", "duckdb", "psqlpy", "asyncmy", "cockroachdb", "litestar", "mysql-connector"], specifier = ">=0.52.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]
 
@@ -2761,6 +2761,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+cockroachdb = [
+    { name = "psycopg" },
+]
 oracle = [
     { name = "oracledb" },
 ]
@@ -3478,6 +3481,10 @@ asyncmy = [
 ]
 asyncpg = [
     { name = "asyncpg" },
+]
+cockroachdb = [
+    { name = "asyncpg" },
+    { name = "psycopg", extra = ["binary", "pool"] },
 ]
 duckdb = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

- add CockroachDB SQLSpec queue stores for asyncpg and psycopg adapter configs
- use PostgreSQL-compatible DDL with portable compare-and-swap claiming

Refs #17.
