### PR TITLE
fix: harden Cloud Run dispatch and entrypoint

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -615,14 +615,22 @@ The dispatch worker stores the Cloud Run execution name on the queue record and
 does not claim the task locally. The Cloud Run container should run
 ``litestar-queues-cloudrun-worker`` or
 ``python -m litestar_queues.execution.cloudrun.entrypoint``. The entry point
-reads ``LITESTAR_QUEUES_TASK_ID``, loads configured task modules, claims the
-persisted record, updates heartbeats, executes the task through the shared queue
-service, and returns deterministic process exit codes.
+loads the queue configuration from ``LITESTAR_QUEUES_CONFIG_FACTORY`` before it
+reads the task id, so custom ``env_prefix`` values are honored for variables
+such as ``<PREFIX>_TASK_ID`` and ``<PREFIX>_TASK_MODULES``. It then loads
+configured task modules, claims the persisted record, updates heartbeats,
+executes the task through the shared queue service, and returns deterministic
+process exit codes. A missing or invalid config factory exits with a distinct
+configuration error instead of looking like a missing task record.
 
 If the Cloud Run API call fails before a remote execution owns the task, the
-backend can move the record to a fallback execution backend such as ``local``.
-Status checks that fail transiently are treated as still running so
-reconciliation does not create false terminal states.
+backend logs and publishes a task event. By default
+``fallback_execution_backend`` is ``None``, so the dispatch error surfaces and
+the record remains routed to ``cloudrun``. To opt in to local recovery, set a
+fallback explicitly, for example ``fallback_execution_backend="local"``. Status
+checks that fail transiently are treated as still running so reconciliation does
+not create false terminal states; a missing Cloud Run execution is treated as a
+failed execution so eligible records can retry.
 
 SQLSpec Event Notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1301,10 +1301,20 @@ async def _bridge_session(sqlspec_manager: "Any", sqlspec_config: "Any") -> "Asy
         try:
             yield _ManagedAsyncDriver(driver)
         except BaseException as exc:
+            await _rollback_sync_session(driver)
             if not await async_(session_cm.__exit__)(type(exc), exc, exc.__traceback__):
                 raise
         else:
+            await _rollback_sync_session(driver)
             await async_(session_cm.__exit__)(None, None, None)
+
+
+async def _rollback_sync_session(driver: "Any") -> "None":
+    """Best-effort cleanup for sync SQLSpec sessions before pool return."""
+    rollback = getattr(driver, "rollback", None)
+    if callable(rollback):
+        with suppress(Exception):
+            await async_(rollback)()
 
 
 async def _select_stream(driver: "Any", statement: "Any", *, chunk_size: "int | None" = None) -> "AsyncIterator[Any]":

--- a/src/litestar_queues/execution/cloudrun/_typing.py
+++ b/src/litestar_queues/execution/cloudrun/_typing.py
@@ -16,6 +16,8 @@ class CloudRunExecutionLike(Protocol):
 class CloudRunOperation(Protocol):
     """Protocol for Cloud Run long-running operations."""
 
+    metadata: "Any"
+
     async def result(self) -> "CloudRunExecutionLike":
         """Return the created Cloud Run execution."""
         ...

--- a/src/litestar_queues/execution/cloudrun/backend.py
+++ b/src/litestar_queues/execution/cloudrun/backend.py
@@ -1,8 +1,11 @@
 import json
+import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 
+from litestar_queues.events import QueueEvent
 from litestar_queues.exceptions import MissingDependencyError
 from litestar_queues.execution.base import BaseExecutionBackend
 from litestar_queues.execution.cloudrun.config import CloudRunExecutionConfig, _execution_config_from_queue_config
@@ -21,6 +24,8 @@ __all__ = ("CloudRunExecutionBackend", "CloudRunExecutionStatus")
 
 _GOOGLE_CLOUD_RUN_PACKAGE = "google-cloud-run"
 _CLOUDRUN_EXTRA = "cloudrun"
+_HTTP_NOT_FOUND = 404
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,15 +96,15 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         client = await self._get_jobs_client()
         try:
             operation = await client.run_job(request=request)
-            execution = await operation.result()
-        except Exception:
+            execution_ref = _require_operation_execution_ref(operation)
+        except Exception as exc:
+            await self._publish_dispatch_failure(service, record, exc)
             fallback = self.execution_config.fallback_execution_backend
             if fallback is None:
                 raise
             await service.get_queue_backend().set_execution_backend(record.id, fallback)
             return None
 
-        execution_ref = str(execution.name)
         await service.get_queue_backend().set_execution_ref(
             record.id, "cloudrun", execution_ref, execution_profile=record.execution_profile
         )
@@ -113,32 +118,41 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         """
         if record.execution_ref is None:
             return None
+        queue_backend = service.get_queue_backend()
+        current = await queue_backend.get_task(record.id) or record
+        if current.status in {"completed", "failed", "cancelled"}:
+            return None
 
         status = await self.check_execution_status(record.execution_ref)
         if status.running:
             return None
-        if record.status != "running":
-            return None
 
-        queue_backend = service.get_queue_backend()
+        expected_retry_count = current.retry_count if current.status == "running" else None
         if status.succeeded:
+            if current.status != "running":
+                return None
             return await queue_backend.complete_task(
-                record.id,
-                result=record.result
-                if record.result is not None
-                else {"cloudrun_execution": record.execution_ref, "status": "succeeded"},
-                expected_retry_count=record.retry_count,
+                current.id,
+                result=current.result
+                if current.result is not None
+                else {"cloudrun_execution": current.execution_ref, "status": "succeeded"},
+                expected_retry_count=expected_retry_count,
             )
 
         if status.cancelled:
             return await queue_backend.fail_task(
-                record.id, "Cloud Run execution cancelled", retry=False, expected_retry_count=record.retry_count
+                current.id, "Cloud Run execution cancelled", retry=False, expected_retry_count=expected_retry_count
             )
 
         if status.failed:
-            return await queue_backend.fail_task(
-                record.id, status.error or "Cloud Run execution failed", expected_retry_count=record.retry_count
+            updated = await queue_backend.fail_task(
+                current.id, status.error or "Cloud Run execution failed", expected_retry_count=expected_retry_count
             )
+            if updated is not None and updated.status in {"pending", "scheduled"}:
+                return await queue_backend.set_execution_backend(
+                    updated.id, updated.execution_backend, execution_profile=updated.execution_profile
+                )
+            return updated
 
         return None
 
@@ -159,6 +173,11 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         try:
             execution = await (await self._get_executions_client()).get_execution(name=execution_ref)
         except Exception as exc:
+            if _is_not_found_error(exc):
+                return CloudRunExecutionStatus(running=False, failed=True, error="Cloud Run execution not found")
+            logger.warning(
+                "Cloud Run status probe failed", exc_info=True, extra={"cloudrun_execution_ref": execution_ref}
+            )
             return CloudRunExecutionStatus(running=True, error=str(exc))
 
         succeeded = int(getattr(execution, "succeeded_count", 0) or 0) > 0
@@ -229,6 +248,49 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
             self.executions_client = cast("CloudRunExecutionsClient", run_v2.ExecutionsAsyncClient())
         return self.executions_client
 
+    async def _publish_dispatch_failure(
+        self, service: "QueueService", record: "QueuedTaskRecord", exc: "BaseException"
+    ) -> "None":
+        fallback = self.execution_config.fallback_execution_backend
+        logger.warning(
+            "Cloud Run dispatch failed",
+            exc_info=(type(exc), exc, exc.__traceback__),
+            extra={
+                "queue_task_id": str(record.id),
+                "queue_task_name": record.task_name,
+                "queue_task_queue": record.queue,
+                "queue_task_execution_backend": record.execution_backend,
+                "queue_task_execution_profile": record.execution_profile,
+                "cloudrun_fallback_execution_backend": fallback,
+            },
+        )
+        try:
+            await service.get_event_publisher().publish(
+                QueueEvent(
+                    type="task.event",
+                    scope="task",
+                    task_id=str(record.id),
+                    task_name=record.task_name,
+                    queue=record.queue,
+                    execution_backend=record.execution_backend,
+                    execution_profile=record.execution_profile,
+                    attempt=record.retry_count + 1,
+                    level="warning",
+                    message="Cloud Run dispatch failed",
+                    payload={
+                        "phase": "cloudrun.dispatch_fallback",
+                        "error": str(exc),
+                        "fallback_execution_backend": fallback,
+                    },
+                )
+            )
+        except Exception:
+            logger.warning(
+                "Cloud Run dispatch failure event publish failed",
+                exc_info=True,
+                extra={"queue_task_id": str(record.id)},
+            )
+
 
 def _execution_error(execution: "CloudRunExecutionLike") -> "str | None":
     conditions = getattr(execution, "conditions", None) or []
@@ -237,3 +299,43 @@ def _execution_error(execution: "CloudRunExecutionLike") -> "str | None":
         if message:
             return str(message)
     return None
+
+
+def _operation_execution_ref(operation: "object") -> "str | None":
+    return _execution_ref_from_value(getattr(operation, "metadata", None))
+
+
+def _require_operation_execution_ref(operation: "object") -> "str":
+    execution_ref = _operation_execution_ref(operation)
+    if execution_ref is None:
+        msg = "Cloud Run run_job operation did not include execution metadata."
+        raise RuntimeError(msg)
+    return execution_ref
+
+
+def _execution_ref_from_value(value: "object") -> "str | None":
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    name = getattr(value, "name", None)
+    if name:
+        return str(name)
+    if isinstance(value, Mapping):
+        mapped_name = value.get("name")
+        if mapped_name:
+            return str(mapped_name)
+        mapped_execution = value.get("execution")
+        if mapped_execution is not None:
+            return _execution_ref_from_value(mapped_execution)
+    execution = getattr(value, "execution", None)
+    if execution is not None:
+        return _execution_ref_from_value(execution)
+    return None
+
+
+def _is_not_found_error(exc: "BaseException") -> "bool":
+    if exc.__class__.__name__ == "NotFound":
+        return True
+    status_code = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    return status_code == _HTTP_NOT_FOUND

--- a/src/litestar_queues/execution/cloudrun/config.py
+++ b/src/litestar_queues/execution/cloudrun/config.py
@@ -22,7 +22,7 @@ class CloudRunExecutionConfig:
     poll_interval: "float" = 5.0
     env_prefix: "str" = "LITESTAR_QUEUES"
     extra_env: "dict[str, str]" = field(default_factory=dict)
-    fallback_execution_backend: "str | None" = "local"
+    fallback_execution_backend: "str | None" = None
 
     def resolve_job_name(self, profile: "str | None" = None) -> "str":
         """Return the Cloud Run Job name for a profile.

--- a/src/litestar_queues/execution/cloudrun/entrypoint.py
+++ b/src/litestar_queues/execution/cloudrun/entrypoint.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import logging
 import os
 from enum import IntEnum
 from importlib import import_module
@@ -7,13 +8,17 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 from litestar_queues.config import QueueConfig
+from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.service import QueueService
 from litestar_queues.task import load_task_modules
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Mapping
 
+    from litestar_queues.models import QueuedTaskRecord
+
 __all__ = ("CloudRunExitCode", "execute_cloudrun_task", "main")
+logger = logging.getLogger(__name__)
 
 
 class CloudRunExitCode(IntEnum):
@@ -27,6 +32,7 @@ class CloudRunExitCode(IntEnum):
     UNKNOWN_TASK = 5
     CLAIM_LOST = 6
     CANCELLED = 7
+    MISSING_CONFIG_FACTORY = 8
 
 
 async def execute_cloudrun_task(
@@ -42,15 +48,38 @@ async def execute_cloudrun_task(
         A deterministic process exit code.
     """
     environ = env or os.environ
-    task_id_raw = environ.get(_env_name(config, "TASK_ID"))
-    if not task_id_raw:
-        return CloudRunExitCode.MISSING_TASK_ID
-    try:
-        task_id = UUID(task_id_raw)
-    except ValueError:
-        return CloudRunExitCode.INVALID_TASK_ID
+    if _requires_config_factory(
+        config=config, service=service, service_factory=service_factory
+    ) and not _has_config_factory(config, environ):
+        task_id_raw = environ.get(_env_name(config, "TASK_ID"))
+        if not task_id_raw:
+            return CloudRunExitCode.MISSING_TASK_ID
+        try:
+            UUID(task_id_raw)
+        except ValueError:
+            return CloudRunExitCode.INVALID_TASK_ID
+        logger.error("Cloud Run task process missing CONFIG_FACTORY", extra={"cloudrun_task_id": task_id_raw})
+        return CloudRunExitCode.MISSING_CONFIG_FACTORY
 
-    async with _provide_service(config=config, service=service, service_factory=service_factory, env=environ) as queue:
+    async with contextlib.AsyncExitStack() as stack:
+        try:
+            queue = await stack.enter_async_context(
+                _provide_service(config=config, service=service, service_factory=service_factory, env=environ)
+            )
+        except Exception:
+            if _requires_config_factory(config=config, service=service, service_factory=service_factory):
+                logger.exception("Cloud Run task process could not load CONFIG_FACTORY")
+                return CloudRunExitCode.MISSING_CONFIG_FACTORY
+            raise
+
+        task_id_raw = environ.get(_env_name(queue.config, "TASK_ID"))
+        if not task_id_raw:
+            return CloudRunExitCode.MISSING_TASK_ID
+        try:
+            task_id = UUID(task_id_raw)
+        except ValueError:
+            return CloudRunExitCode.INVALID_TASK_ID
+
         _load_configured_task_modules(queue.config, environ)
         record = await queue.get_task(task_id)
         if record is None:
@@ -69,33 +98,7 @@ async def execute_cloudrun_task(
             await queue.publish_claim_lost(record, phase="claim")
             return CloudRunExitCode.CLAIM_LOST
 
-        expected_retry_count = claimed.retry_count
-        heartbeat_task = asyncio.create_task(
-            _heartbeat_loop(queue, claimed.id, expected_retry_count=expected_retry_count)
-        )
-        execution_task = asyncio.create_task(queue.execute_record(claimed))
-        try:
-            done, _pending = await asyncio.wait({heartbeat_task, execution_task}, return_when=asyncio.FIRST_COMPLETED)
-            if heartbeat_task in done and not heartbeat_task.result():
-                execution_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await execution_task
-                await queue.publish_claim_lost(claimed, phase="heartbeat", expected_retry_count=expected_retry_count)
-                return CloudRunExitCode.CLAIM_LOST
-            updated = await execution_task
-        except asyncio.CancelledError:
-            return CloudRunExitCode.CANCELLED
-        finally:
-            heartbeat_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await heartbeat_task
-            await queue.get_queue_backend().null_heartbeats([claimed.id], expected_retry_count=expected_retry_count)
-
-    if updated.status == "completed":
-        return CloudRunExitCode.SUCCESS
-    if updated.status == "cancelled":
-        return CloudRunExitCode.CANCELLED
-    return CloudRunExitCode.FAILURE
+        return await _execute_claimed_record(queue, claimed)
 
 
 def main() -> "None":
@@ -105,6 +108,34 @@ def main() -> "None":
         SystemExit: Always raised with the execution exit code.
     """
     raise SystemExit(int(asyncio.run(execute_cloudrun_task())))
+
+
+async def _execute_claimed_record(queue: "QueueService", claimed: "QueuedTaskRecord") -> "CloudRunExitCode":
+    expected_retry_count = claimed.retry_count
+    heartbeat_task = asyncio.create_task(_heartbeat_loop(queue, claimed.id, expected_retry_count=expected_retry_count))
+    execution_task = asyncio.create_task(queue.execute_record(claimed))
+    try:
+        done, _pending = await asyncio.wait({heartbeat_task, execution_task}, return_when=asyncio.FIRST_COMPLETED)
+        if heartbeat_task in done and not heartbeat_task.result():
+            execution_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await execution_task
+            await queue.publish_claim_lost(claimed, phase="heartbeat", expected_retry_count=expected_retry_count)
+            return CloudRunExitCode.CLAIM_LOST
+        updated = await execution_task
+    except asyncio.CancelledError:
+        return CloudRunExitCode.CANCELLED
+    finally:
+        heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat_task
+        await queue.get_queue_backend().null_heartbeats([claimed.id], expected_retry_count=expected_retry_count)
+
+    if updated.status == "completed":
+        return CloudRunExitCode.SUCCESS
+    if updated.status == "cancelled":
+        return CloudRunExitCode.CANCELLED
+    return CloudRunExitCode.FAILURE
 
 
 async def _heartbeat_loop(queue: "QueueService", task_id: "UUID", *, expected_retry_count: "int") -> "bool":
@@ -142,8 +173,22 @@ async def _provide_service(
             yield queue
         return
 
-    async with QueueService(config or QueueConfig()) as queue:
+    if config is None:
+        msg = "Cloud Run task process requires CONFIG_FACTORY when no QueueConfig or QueueService is provided."
+        raise QueueConfigurationError(msg)
+
+    async with QueueService(config) as queue:
         yield queue
+
+
+def _requires_config_factory(
+    *, config: "QueueConfig | None", service: "QueueService | None", service_factory: "Callable[[], Any] | None"
+) -> "bool":
+    return config is None and service is None and service_factory is None
+
+
+def _has_config_factory(config: "QueueConfig | None", env: "Mapping[str, str]") -> "bool":
+    return bool(env.get(_env_name(config, "CONFIG_FACTORY")))
 
 
 def _load_config_factory(config: "QueueConfig | None", env: "Mapping[str, str]") -> "Callable[[], Any] | None":

--- a/src/litestar_queues/task.py
+++ b/src/litestar_queues/task.py
@@ -584,13 +584,13 @@ def load_task_modules(modules: "tuple[str, ...] | list[str]", *, force_reload: "
     for module_name in modules:
         if module_name in _loaded_modules and not force_reload:
             continue
-        _loaded_modules.add(module_name)
-        if force_reload or module_name in sys.modules:
+        if force_reload and module_name in sys.modules:
             module = reload(sys.modules[module_name])
         else:
             module = import_module(module_name)
-        loaded += 1
-        loaded += _load_child_modules(module, force_reload=force_reload)
+        child_count = _load_child_modules(module, force_reload=force_reload)
+        _loaded_modules.add(module_name)
+        loaded += 1 + child_count
     return loaded
 
 

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -28,6 +28,7 @@ from sqlspec.adapters.aiosqlite import AiosqliteConfig
 from litestar_queues import QueueConfig, QueueService, task
 from litestar_queues.backends import get_queue_backend_class, list_queue_backends
 from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueBackend
+from litestar_queues.backends.sqlspec.backend import _bridge_session
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.backends.sqlspec.stores import (
     AiomysqlQueueStore,
@@ -537,6 +538,16 @@ def test_sqlspec_store_select_claimable_uses_skip_locked_on_supporting_dialect()
     assert 'FROM "queue_tasks"' in built.sql
 
 
+async def test_sqlspec_sync_bridge_rolls_back_read_transactions_before_pool_return() -> "None":
+    """Sync sessions must not return pooled connections with stale read snapshots."""
+    manager = _FakeSyncSQLSpec()
+
+    async with _bridge_session(manager, _FakeSyncConfig()) as driver:
+        assert await driver.select("SELECT 1") == []
+
+    assert manager.driver.rollback_count == 1
+
+
 @pytest.mark.parametrize(
     ("table_name", "expected"),
     (
@@ -905,3 +916,42 @@ async def test_queue_service_uses_sqlspec_backend_from_config(
     completed_status = result.status
     assert completed_status == "completed"
     assert result.result == "queue"
+
+
+class _FakeSyncConfig:
+    is_async = False
+
+
+class _FakeSyncSQLSpec:
+    def __init__(self) -> "None":
+        self.driver = _FakeSyncDriver()
+        self.session = _FakeSyncSession(self.driver)
+
+    def provide_session(self, config: "_FakeSyncConfig") -> "_FakeSyncSession":
+        return self.session
+
+
+class _FakeSyncSession:
+    def __init__(self, driver: "_FakeSyncDriver") -> "None":
+        self.driver = driver
+        self.exit_count = 0
+
+    def __enter__(self) -> "_FakeSyncDriver":
+        return self.driver
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        _ = (exc_type, exc, traceback)
+        self.exit_count += 1
+
+
+class _FakeSyncDriver:
+    def __init__(self) -> "None":
+        self.rollback_count = 0
+        self.selected: "list[object]" = []
+
+    def select(self, statement: "object") -> "list[object]":
+        self.selected.append(statement)
+        return []
+
+    def rollback(self) -> "None":
+        self.rollback_count += 1

--- a/src/tests/integration/execution/cloudrun/helpers.py
+++ b/src/tests/integration/execution/cloudrun/helpers.py
@@ -1,0 +1,106 @@
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from litestar_queues.service import QueueService
+
+
+class RunJobEnv(TypedDict):
+    name: "str"
+    value: "str"
+
+
+class RunJobContainerOverride(TypedDict):
+    env: "list[RunJobEnv]"
+
+
+class RunJobOverrides(TypedDict):
+    container_overrides: "list[RunJobContainerOverride]"
+    timeout: "str"
+
+
+class RunJobRequest(TypedDict):
+    name: "str"
+    overrides: "RunJobOverrides"
+
+
+@dataclass(slots=True)
+class FakeCloudRunExecution:
+    name: "str" = "projects/test/locations/us-central1/jobs/worker/executions/run-1"
+    succeeded_count: "int" = 0
+    failed_count: "int" = 0
+    cancelled_count: "int" = 0
+    conditions: "list[object] | None" = None
+
+
+class FakeOperation:
+    def __init__(
+        self, execution: "FakeCloudRunExecution", *, block_result: "bool" = False, metadata: "object | None" = None
+    ) -> "None":
+        self.execution = execution
+        self.metadata = execution if metadata is None else metadata
+        self.result_called = False
+        self._result_ready = asyncio.Event() if block_result else None
+
+    async def result(self) -> "FakeCloudRunExecution":
+        self.result_called = True
+        if self._result_ready is not None:
+            await self._result_ready.wait()
+        return self.execution
+
+
+class FakeJobsClient:
+    def __init__(
+        self,
+        execution: "FakeCloudRunExecution | None" = None,
+        *,
+        error: "Exception | None" = None,
+        block_result: "bool" = False,
+        metadata: "object | None" = None,
+    ) -> "None":
+        self.execution = execution or FakeCloudRunExecution()
+        self.error = error
+        self.block_result = block_result
+        self.metadata = metadata
+        self.requests: "list[RunJobRequest]" = []
+        self.operations: "list[FakeOperation]" = []
+
+    async def run_job(self, *, request: "RunJobRequest") -> "FakeOperation":
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        operation = FakeOperation(self.execution, block_result=self.block_result, metadata=self.metadata)
+        self.operations.append(operation)
+        return operation
+
+
+class FakeExecutionsClient:
+    def __init__(self, execution: "FakeCloudRunExecution | Exception") -> "None":
+        self.execution = execution
+        self.names: "list[str]" = []
+
+    async def get_execution(self, *, name: "str") -> "FakeCloudRunExecution":
+        self.names.append(name)
+        if isinstance(self.execution, Exception):
+            raise self.execution
+        return self.execution
+
+
+class NoopServiceContext:
+    def __init__(self, service: "QueueService") -> "None":
+        self.service = service
+
+    async def __aenter__(self) -> "QueueService":
+        return self.service
+
+    async def __aexit__(self, *_exc_info: object) -> "None":
+        return None
+
+
+NotFoundError = type("NotFound", (Exception,), {})
+
+
+def env_map(request: "RunJobRequest") -> "dict[str, str]":
+    env = request["overrides"]["container_overrides"][0]["env"]
+    return {item["name"]: item["value"] for item in env}

--- a/src/tests/integration/execution/cloudrun/test_emulator.py
+++ b/src/tests/integration/execution/cloudrun/test_emulator.py
@@ -1,15 +1,26 @@
 import asyncio
+import importlib
+import logging
 import subprocess
 import sys
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, TypedDict, cast
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
 
 import pytest
 
 from litestar_queues import QueueConfig, QueueService, Worker, task
 from litestar_queues.backends import InMemoryQueueBackend
-from litestar_queues.task import clear_task_registry
+from litestar_queues.task import clear_task_registry, get_task_registry, load_task_modules
+from tests.integration.execution.cloudrun.helpers import (
+    FakeCloudRunExecution,
+    FakeExecutionsClient,
+    FakeJobsClient,
+    NoopServiceContext,
+    NotFoundError,
+    env_map,
+)
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -19,75 +30,49 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.anyio
 
 
-class RunJobEnv(TypedDict):
-    name: "str"
-    value: "str"
-
-
-class RunJobContainerOverride(TypedDict):
-    env: "list[RunJobEnv]"
-
-
-class RunJobOverrides(TypedDict):
-    container_overrides: "list[RunJobContainerOverride]"
-    timeout: "str"
-
-
-class RunJobRequest(TypedDict):
-    name: "str"
-    overrides: "RunJobOverrides"
-
-
 @pytest.fixture(autouse=True)
 def clean_task_registry() -> "None":
     clear_task_registry()
 
 
-@dataclass(slots=True)
-class FakeCloudRunExecution:
-    name: "str" = "projects/test/locations/us-central1/jobs/worker/executions/run-1"
-    succeeded_count: "int" = 0
-    failed_count: "int" = 0
-    cancelled_count: "int" = 0
-    conditions: "list[object] | None" = None
+def test_load_task_modules_force_reload_imports_never_imported_module(tmp_path: "Any", monkeypatch: "Any") -> "None":
+    package_dir = tmp_path / "dynamic_tasks"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("")
+    (package_dir / "jobs.py").write_text(
+        "from litestar_queues import task\n@task('dynamic.force_reload')\ndef run():\n    return 'ok'\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    sys.modules.pop("dynamic_tasks.jobs", None)
+
+    loaded = load_task_modules(("dynamic_tasks.jobs",), force_reload=True)
+
+    assert loaded == 1
+    assert "dynamic.force_reload" in get_task_registry()
 
 
-class FakeOperation:
-    def __init__(self, execution: "FakeCloudRunExecution") -> "None":
-        self.execution = execution
+def test_load_task_modules_failed_import_does_not_poison_loaded_cache(tmp_path: "Any", monkeypatch: "Any") -> "None":
+    package_dir = tmp_path / "recovering_tasks"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("")
+    module_path = package_dir / "jobs.py"
+    module_path.write_text("raise RuntimeError('temporary import failure')\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(sys, "dont_write_bytecode", True)
 
-    async def result(self) -> "FakeCloudRunExecution":
-        return self.execution
+    with pytest.raises(RuntimeError, match="temporary import failure"):
+        load_task_modules(("recovering_tasks.jobs",))
 
+    module_path.write_text(
+        "from litestar_queues import task\n@task('dynamic.recovered')\ndef run():\n    return 'ok'\n"
+    )
+    sys.modules.pop("recovering_tasks.jobs", None)
+    importlib.invalidate_caches()
 
-class FakeJobsClient:
-    def __init__(self, execution: "FakeCloudRunExecution | None" = None, *, error: "Exception | None" = None) -> "None":
-        self.execution = execution or FakeCloudRunExecution()
-        self.error = error
-        self.requests: "list[RunJobRequest]" = []
+    loaded = load_task_modules(("recovering_tasks.jobs",))
 
-    async def run_job(self, *, request: "RunJobRequest") -> "FakeOperation":
-        self.requests.append(request)
-        if self.error is not None:
-            raise self.error
-        return FakeOperation(self.execution)
-
-
-class FakeExecutionsClient:
-    def __init__(self, execution: "FakeCloudRunExecution | Exception") -> "None":
-        self.execution = execution
-        self.names: "list[str]" = []
-
-    async def get_execution(self, *, name: "str") -> "FakeCloudRunExecution":
-        self.names.append(name)
-        if isinstance(self.execution, Exception):
-            raise self.execution
-        return self.execution
-
-
-def _env_map(request: "RunJobRequest") -> "dict[str, str]":
-    env = request["overrides"]["container_overrides"][0]["env"]
-    return {item["name"]: item["value"] for item in env}
+    assert loaded == 1
+    assert "dynamic.recovered" in get_task_registry()
 
 
 async def test_cloudrun_dispatch_builds_generic_run_job_request_and_stores_execution_ref() -> "None":
@@ -125,7 +110,7 @@ async def test_cloudrun_dispatch_builds_generic_run_job_request_and_stores_execu
         await service.close()
 
     request = jobs_client.requests[0]
-    env = _env_map(request)
+    env = env_map(request)
 
     assert execution_ref == "projects/test/locations/us-central1/jobs/worker/executions/run-1"
     assert request["name"] == "projects/test-project/locations/us-central1/jobs/heavy-worker"
@@ -142,7 +127,75 @@ async def test_cloudrun_dispatch_builds_generic_run_job_request_and_stores_execu
     assert stored.status == "pending"
 
 
+async def test_cloudrun_dispatch_returns_without_waiting_for_operation_result() -> "None":
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    @task("tasks.remote_nonblocking")
+    async def remote_task() -> "str":
+        return "ok"
+
+    queue_backend = InMemoryQueueBackend()
+    jobs_client = FakeJobsClient(block_result=True)
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        jobs_client=cast("CloudRunJobsClient", jobs_client),
+    )
+    service = QueueService(
+        QueueConfig(execution_backend="cloudrun"), queue_backend=queue_backend, execution_backend=backend
+    )
+    await service.open()
+    try:
+        record = await queue_backend.enqueue(remote_task.name, execution_backend="cloudrun")
+
+        execution_ref = await asyncio.wait_for(backend.dispatch(service, record), timeout=0.05)
+        stored = await queue_backend.get_task(record.id)
+    finally:
+        await service.close()
+
+    assert execution_ref == "projects/test/locations/us-central1/jobs/worker/executions/run-1"
+    assert jobs_client.operations[0].result_called is False
+    assert stored is not None
+    assert stored.execution_ref == execution_ref
+
+
+async def test_cloudrun_dispatch_failure_default_surfaces_and_preserves_backend(
+    caplog: "pytest.LogCaptureFixture",
+) -> "None":
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    @task("tasks.remote_default_failure")
+    async def remote_task() -> "str":
+        return "ok"
+
+    queue_backend = InMemoryQueueBackend()
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        jobs_client=cast("CloudRunJobsClient", FakeJobsClient(error=RuntimeError("api unavailable"))),
+    )
+    service = QueueService(
+        QueueConfig(execution_backend="cloudrun"), queue_backend=queue_backend, execution_backend=backend
+    )
+    await service.open()
+    try:
+        record = await queue_backend.enqueue(remote_task.name, execution_backend="cloudrun")
+
+        with (
+            caplog.at_level(logging.WARNING, logger="litestar_queues.execution.cloudrun.backend"),
+            pytest.raises(RuntimeError, match="api unavailable"),
+        ):
+            await backend.dispatch(service, record)
+        stored = await queue_backend.get_task(record.id)
+    finally:
+        await service.close()
+
+    assert "Cloud Run dispatch failed" in caplog.text
+    assert stored is not None
+    assert stored.execution_backend == "cloudrun"
+    assert stored.execution_ref is None
+
+
 async def test_cloudrun_dispatch_failure_falls_back_to_local_when_remote_has_not_taken_ownership() -> "None":
+    from litestar_queues.events import InMemoryQueueEventSink, QueueEventConfig
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
 
     @task("tasks.remote")
@@ -156,8 +209,11 @@ async def test_cloudrun_dispatch_failure_falls_back_to_local_when_remote_has_not
         ),
         jobs_client=cast("CloudRunJobsClient", FakeJobsClient(error=RuntimeError("api unavailable"))),
     )
+    event_sink = InMemoryQueueEventSink()
     service = QueueService(
-        QueueConfig(execution_backend="cloudrun"), queue_backend=queue_backend, execution_backend=backend
+        QueueConfig(execution_backend="cloudrun", event_config=QueueEventConfig(enabled=True, sink=event_sink)),
+        queue_backend=queue_backend,
+        execution_backend=backend,
     )
     await service.open()
     try:
@@ -172,6 +228,10 @@ async def test_cloudrun_dispatch_failure_falls_back_to_local_when_remote_has_not
     assert stored is not None
     assert stored.execution_backend == "local"
     assert stored.execution_ref is None
+    assert any(
+        event.type == "task.event" and event.payload.get("phase") == "cloudrun.dispatch_fallback"
+        for event in event_sink.events
+    )
 
 
 @pytest.mark.parametrize(
@@ -244,6 +304,37 @@ async def test_cloudrun_reconcile_treats_transient_status_errors_as_running() ->
     assert updated is None
     assert stored is not None
     assert stored.status == "running"
+
+
+async def test_cloudrun_reconcile_retries_preclaim_not_found_and_clears_execution_ref() -> "None":
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    queue_backend = InMemoryQueueBackend()
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        executions_client=FakeExecutionsClient(NotFoundError("execution not found")),
+    )
+    service = QueueService(
+        QueueConfig(execution_backend="cloudrun"), queue_backend=queue_backend, execution_backend=backend
+    )
+    await service.open()
+    try:
+        record = await queue_backend.enqueue("tasks.remote", execution_backend="cloudrun", max_retries=1)
+        await queue_backend.set_execution_ref(record.id, "cloudrun", "executions/missing")
+
+        updated = await backend.reconcile(service, record)
+        stored = await queue_backend.get_task(record.id)
+    finally:
+        await service.close()
+
+    assert updated is not None
+    assert updated.status == "pending"
+    assert updated.retry_count == 1
+    assert updated.execution_ref is None
+    assert stored is not None
+    assert stored.status == "pending"
+    assert stored.retry_count == 1
+    assert stored.execution_ref is None
 
 
 async def test_cloudrun_reconcile_does_not_terminal_write_after_stale_retry_reassigns_row() -> "None":
@@ -346,6 +437,48 @@ async def test_cloudrun_entrypoint_claims_and_executes_persisted_record() -> "No
     assert exit_code == CloudRunExitCode.SUCCESS
     assert result.status == "completed"
     assert result.result == 42
+
+
+async def test_cloudrun_entrypoint_loads_config_factory_before_prefixed_task_id() -> "None":
+    from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
+    from litestar_queues.execution.cloudrun.entrypoint import CloudRunExitCode, execute_cloudrun_task
+
+    @task("tasks.entrypoint_prefixed")
+    async def entrypoint_prefixed(value: "int") -> "int":
+        return value + 1
+
+    queue_backend = InMemoryQueueBackend()
+    config = QueueConfig(
+        execution_backend=CloudRunExecutionConfig(project_id="test-project", job_name="worker", env_prefix="PREFIX")
+    )
+    factory_module = ModuleType("cloudrun_test_config_factory")
+    sys.modules[factory_module.__name__] = factory_module
+    try:
+        async with QueueService(config, queue_backend=queue_backend) as service:
+            factory_module.create_service = lambda: NoopServiceContext(service)  # type: ignore[attr-defined]
+            result = await service.enqueue(entrypoint_prefixed.using(execution_backend="cloudrun"), 41)
+
+            exit_code = await execute_cloudrun_task(
+                env={
+                    "LITESTAR_QUEUES_CONFIG_FACTORY": f"{factory_module.__name__}:create_service",
+                    "PREFIX_TASK_ID": str(result.id),
+                }
+            )
+            await result.refresh()
+    finally:
+        sys.modules.pop(factory_module.__name__, None)
+
+    assert exit_code == CloudRunExitCode.SUCCESS
+    assert result.status == "completed"
+    assert result.result == 42
+
+
+async def test_cloudrun_entrypoint_requires_config_factory_without_service_or_config() -> "None":
+    from litestar_queues.execution.cloudrun.entrypoint import CloudRunExitCode, execute_cloudrun_task
+
+    exit_code = await execute_cloudrun_task(env={"LITESTAR_QUEUES_TASK_ID": str(uuid4())})
+
+    assert exit_code == CloudRunExitCode.MISSING_CONFIG_FACTORY
 
 
 async def test_cloudrun_entrypoint_returns_claim_lost_when_heartbeat_loses_ownership() -> "None":


### PR DESCRIPTION
## Summary

- make Cloud Run dispatch non-blocking by reading the execution reference from operation metadata instead of waiting for the job execution to complete
- make dispatch failures visible with warning logs and task events, while defaulting `fallback_execution_backend` to `None`
- fix fresh-container task module loading, pre-claim Cloud Run failure reconciliation, and entrypoint `CONFIG_FACTORY`/custom env-prefix handling
- clean up sync SQLSpec sessions before returning bridged drivers to the pool, preventing PyMySQL stale read snapshots under the full xdist suite
- reorganize Cloud Run test fakes into a helper module and document the fallback/config behavior

Fixes #34
Fixes #35
