### PR TITLE
fix: fence SQL queue lifecycle updates

### DIFF
--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -165,11 +165,15 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
             str(model.status) != "running" or int(model.retry_count) != expected_retry_count
         ):
             return None
+        if str(model.status) != "running":
+            return None
         model_type = self.model_type
+        retry_fence = expected_retry_count if expected_retry_count is not None else int(model.retry_count)
+        criteria = [model_type.id == task_id, model_type.status == "running", model_type.retry_count == retry_fence]
         if retry and int(model.retry_count) < int(model.max_retries):
-            await self.repository.session.execute(
+            update_result = await self.repository.session.execute(
                 update(model_type)
-                .where(model_type.id == task_id)
+                .where(*criteria)
                 .values(
                     status="pending",
                     started_at=None,
@@ -180,11 +184,13 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
             )
         else:
             now = _utc_now()
-            await self.repository.session.execute(
+            update_result = await self.repository.session.execute(
                 update(model_type)
-                .where(model_type.id == task_id)
+                .where(*criteria)
                 .values(status="failed", completed_at=now, heartbeat_at=now, error=error)
             )
+        if update_result.rowcount != 1:
+            return None
         updated = await self._select_task(task_id)
         return self.record_from_model(updated) if updated is not None else None
 
@@ -219,18 +225,27 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
     async def requeue_stale_running(self, *, stale_after: "timedelta") -> "StaleTaskRecoveryResult":
         cutoff = _utc_now() - stale_after
         model_type = self.model_type
-        criteria = [model_type.status == "running"]
-        if stale_after > timedelta(0):
-            criteria.append(or_(model_type.heartbeat_at.is_(None), model_type.heartbeat_at <= cutoff))
-        models = (await self.repository.session.execute(select(model_type).where(*criteria))).scalars().all()
+        stale_heartbeat = or_(model_type.heartbeat_at.is_(None), model_type.heartbeat_at <= cutoff)
+        select_criteria = [model_type.status == "running"]
+        use_heartbeat_cutoff = stale_after.total_seconds() > 0
+        if use_heartbeat_cutoff:
+            select_criteria.append(stale_heartbeat)
+        models = (await self.repository.session.execute(select(model_type).where(*select_criteria))).scalars().all()
         result = StaleTaskRecoveryResult()
         for model in models:
             metadata = _deserialize_json(model.metadata_json)
             requeue_on_stale = metadata.get("requeue_on_stale", True) is not False
+            update_criteria = [
+                model_type.id == model.id,
+                model_type.status == "running",
+                model_type.retry_count == int(model.retry_count),
+            ]
+            if use_heartbeat_cutoff:
+                update_criteria.append(stale_heartbeat)
             if requeue_on_stale and int(model.retry_count) < int(model.max_retries):
-                await self.repository.session.execute(
+                update_result = await self.repository.session.execute(
                     update(model_type)
-                    .where(model_type.id == model.id)
+                    .where(*update_criteria)
                     .values(
                         status="pending",
                         started_at=None,
@@ -238,21 +253,29 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
                         retry_count=int(model.retry_count) + 1,
                         error="Task heartbeat stale",
                     )
+                    .execution_options(synchronize_session=False)
                 )
-                result.requeued += 1
+                if update_result.rowcount == 1:
+                    result.requeued += 1
+                else:
+                    result.skipped += 1
             else:
                 now = _utc_now()
-                await self.repository.session.execute(
+                update_result = await self.repository.session.execute(
                     update(model_type)
-                    .where(model_type.id == model.id)
+                    .where(*update_criteria)
                     .values(status="failed", completed_at=now, heartbeat_at=now, error="Task heartbeat stale")
+                    .execution_options(synchronize_session=False)
                 )
-                result.failed += 1
-                task_id = UUID(str(model.id))
-                result.failed_task_ids.append(task_id)
-                if not requeue_on_stale:
-                    result.handler_needed += 1
-                    result.handler_needed_task_ids.append(task_id)
+                if update_result.rowcount == 1:
+                    result.failed += 1
+                    task_id = UUID(str(model.id))
+                    result.failed_task_ids.append(task_id)
+                    if not requeue_on_stale:
+                        result.handler_needed += 1
+                        result.handler_needed_task_ids.append(task_id)
+                else:
+                    result.skipped += 1
         return result
 
     async def set_execution_ref(

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -8,7 +8,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
-from sqlspec import SQLSpec, StatementStack
+from sqlspec import SQLSpec
 from sqlspec.extensions.events import normalize_event_channel_name, resolve_adapter_name
 from sqlspec.utils.sync_tools import async_
 
@@ -424,25 +424,23 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             async with self._session() as driver:
                 await driver.begin()
                 try:
-                    if expected_retry_count is not None:
-                        existing_row = await self._select_task(driver, task_id)
-                        if existing_row is None:
-                            await driver.rollback()
-                            return None
-                        existing = self._record_from_row(existing_row)
-                        if existing.status != "running" or existing.retry_count != expected_retry_count:
-                            await driver.rollback()
-                            self._increment_queue_metric("claim_lost")
-                            return None
                     updated = await driver.execute(
                         store.complete_task(
                             task_id=str(task_id),
                             completed_at=self._serialize_datetime(now),
                             heartbeat_at=self._serialize_datetime(now),
                             result_json=store.serialize_json("result_json", result),
+                            expected_retry_count=expected_retry_count,
                         )
                     )
-                    row = await self._select_task(driver, task_id) if updated.rows_affected else None
+                    rows_affected = _rows_affected(updated)
+                    row = await self._select_task(driver, task_id) if rows_affected == 1 or rows_affected < 0 else None
+                    if row is not None:
+                        completed_record = self._record_from_row(row)
+                        if completed_record.status != "completed" or (
+                            expected_retry_count is not None and completed_record.retry_count != expected_retry_count
+                        ):
+                            row = None
                     await driver.commit()
                 except Exception:
                     with suppress(Exception):
@@ -451,6 +449,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         completed = self._record_from_row(row) if row is not None else None
         if completed is not None:
             self._increment_queue_metric("complete")
+        elif expected_retry_count is not None:
+            self._increment_queue_metric("claim_lost")
         return completed
 
     async def fail_task(
@@ -466,32 +466,53 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                         return None
 
                     record = self._record_from_row(row)
-                    if expected_retry_count is not None and (
-                        record.status != "running" or record.retry_count != expected_retry_count
+                    if record.status != "running" or (
+                        expected_retry_count is not None and record.retry_count != expected_retry_count
                     ):
-                        await driver.rollback()
+                        await driver.commit()
                         self._increment_queue_metric("claim_lost")
                         return None
                     metric = "fail"
+                    retry_fence = expected_retry_count if expected_retry_count is not None else record.retry_count
                     if retry and record.retry_count < record.max_retries:
-                        await driver.execute(
+                        updated = await driver.execute(
                             self._get_store().retry_task(
-                                task_id=str(task_id), error=error, retry_count=record.retry_count + 1
+                                task_id=str(task_id),
+                                error=error,
+                                retry_count=record.retry_count + 1,
+                                expected_retry_count=retry_fence,
                             )
                         )
                         metric = "retry"
+                        expected_status = "pending"
+                        expected_retry_after_update = record.retry_count + 1
                     else:
                         now = _utc_now()
-                        await driver.execute(
+                        updated = await driver.execute(
                             self._get_store().fail_task(
                                 task_id=str(task_id),
                                 completed_at=self._serialize_datetime(now),
                                 heartbeat_at=self._serialize_datetime(now),
                                 error=error,
+                                expected_retry_count=retry_fence,
                             )
                         )
+                        expected_status = "failed"
+                        expected_retry_after_update = record.retry_count
 
-                    updated_row = await self._select_task(driver, task_id)
+                    rows_affected = _rows_affected(updated)
+                    if rows_affected == 1 or rows_affected < 0:
+                        updated_row = await self._select_task(driver, task_id)
+                        if updated_row is not None:
+                            candidate = self._record_from_row(updated_row)
+                            if (
+                                candidate.status != expected_status
+                                or candidate.retry_count != expected_retry_after_update
+                                or candidate.error != error
+                            ):
+                                updated_row = None
+                    else:
+                        updated_row = None
                     await driver.commit()
                 except Exception:
                     with suppress(Exception):
@@ -500,6 +521,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         updated_record = self._record_from_row(updated_row) if updated_row is not None else None
         if updated_record is not None:
             self._increment_queue_metric(metric)
+        else:
+            self._increment_queue_metric("claim_lost")
         return updated_record
 
     async def cancel_task(self, task_id: "UUID") -> "bool":
@@ -586,46 +609,70 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         cutoff = _utc_now() - stale_after
         store = self._get_store()
         result = StaleTaskRecoveryResult()
+        serialized_cutoff = self._serialize_datetime(cutoff)
         with self._observe_queue_operation("stale_recovered"):
             async with self._session() as driver:
-                rows = await driver.select(store.list_stale_running(cutoff=self._serialize_datetime(cutoff)))
-                stack = StatementStack()
-                for row in cast("list[dict[str, Any]]", rows):
-                    record = self._record_from_row(row)
-                    requeue_on_stale = record.metadata.get("requeue_on_stale", True) is not False
-                    if requeue_on_stale and record.retry_count < record.max_retries:
-                        stack = stack.push_execute(
-                            store.retry_task(
-                                task_id=str(record.id), error="Task heartbeat stale", retry_count=record.retry_count + 1
+                rows = await driver.select(store.list_stale_running(cutoff=serialized_cutoff))
+                if not rows:
+                    return result
+                # Reset any implicit read transaction the SELECT may have opened so
+                # stale-recovery writes run in a fresh transaction.
+                with suppress(Exception):
+                    await driver.rollback()
+                await driver.begin()
+                try:
+                    failed_handler_needed: "list[UUID]" = []
+                    for row in cast("list[dict[str, Any]]", rows):
+                        record = self._record_from_row(row)
+                        requeue_on_stale = record.metadata.get("requeue_on_stale", True) is not False
+                        if requeue_on_stale and record.retry_count < record.max_retries:
+                            updated = await driver.execute(
+                                store.retry_task(
+                                    task_id=str(record.id),
+                                    error="Task heartbeat stale",
+                                    retry_count=record.retry_count + 1,
+                                    expected_retry_count=record.retry_count,
+                                    heartbeat_cutoff=serialized_cutoff,
+                                )
                             )
-                        )
-                        result.requeued += 1
-                    else:
-                        now = _utc_now()
-                        stack = stack.push_execute(
-                            store.fail_task(
-                                task_id=str(record.id),
-                                completed_at=self._serialize_datetime(now),
-                                heartbeat_at=self._serialize_datetime(now),
-                                error="Task heartbeat stale",
+                            rows_affected = _rows_affected(updated)
+                            if rows_affected == 1 or (
+                                rows_affected < 0
+                                and await self._stale_retry_updated(driver, record.id, record.retry_count)
+                            ):
+                                result.requeued += 1
+                            else:
+                                result.skipped += 1
+                        else:
+                            now = _utc_now()
+                            updated = await driver.execute(
+                                store.fail_task(
+                                    task_id=str(record.id),
+                                    completed_at=self._serialize_datetime(now),
+                                    heartbeat_at=self._serialize_datetime(now),
+                                    error="Task heartbeat stale",
+                                    expected_retry_count=record.retry_count,
+                                    heartbeat_cutoff=serialized_cutoff,
+                                )
                             )
-                        )
-                        result.failed += 1
-                        result.failed_task_ids.append(record.id)
-                        if not requeue_on_stale:
-                            result.handler_needed += 1
-                            result.handler_needed_task_ids.append(record.id)
-                if stack:
-                    # Reset any implicit read transaction the SELECT may have opened so
-                    # SQLSpec's stack runner owns the write transaction.
+                            rows_affected = _rows_affected(updated)
+                            if rows_affected == 1 or (
+                                rows_affected < 0 and await self._stale_fail_updated(driver, record.id)
+                            ):
+                                result.failed += 1
+                                result.failed_task_ids.append(record.id)
+                                if not requeue_on_stale:
+                                    failed_handler_needed.append(record.id)
+                            else:
+                                result.skipped += 1
+                    for task_id in failed_handler_needed:
+                        result.handler_needed += 1
+                        result.handler_needed_task_ids.append(task_id)
+                    await driver.commit()
+                except Exception:
                     with suppress(Exception):
                         await driver.rollback()
-                    try:
-                        await driver.execute_stack(stack)
-                    except Exception:
-                        with suppress(Exception):
-                            await driver.rollback()
-                        raise
+                    raise
         recovered = result.requeued + result.failed
         if recovered:
             self._increment_queue_metric("stale_recovered", float(recovered))
@@ -1079,6 +1126,24 @@ class SQLSpecQueueBackend(BaseQueueBackend):
     async def _clear_key(self, driver: "Any", task_id: "UUID") -> "None":
         await driver.execute(self._get_store().clear_key(task_id=str(task_id)))
 
+    async def _stale_retry_updated(self, driver: "Any", task_id: "UUID", previous_retry_count: "int") -> "bool":
+        row = await self._select_task(driver, task_id)
+        if row is None:
+            return False
+        record = self._record_from_row(row)
+        return (
+            record.status == "pending"
+            and record.retry_count == previous_retry_count + 1
+            and record.error == "Task heartbeat stale"
+        )
+
+    async def _stale_fail_updated(self, driver: "Any", task_id: "UUID") -> "bool":
+        row = await self._select_task(driver, task_id)
+        if row is None:
+            return False
+        record = self._record_from_row(row)
+        return record.status == "failed" and record.error == "Task heartbeat stale"
+
     def _get_observability_runtime(self) -> "Any | None":
         if not self._queue_observability:
             return None
@@ -1356,6 +1421,10 @@ def _extract_count(result: "Any") -> "int":
         if isinstance(row, (list, tuple)):
             return int(row[0])
     return 0
+
+
+def _rows_affected(result: "Any") -> "int":
+    return int(getattr(result, "rows_affected", 0) or 0)
 
 
 def _serialize_datetime(value: "datetime | None") -> "datetime | None":

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -240,9 +240,17 @@ class SQLSpecQueueStore:
             .where(f"{self._col('scheduled_at')} IS NULL OR {self._col('scheduled_at')} <= :due_at", due_at=due_at)
         )
 
-    def complete_task(self, *, task_id: "str", completed_at: "Any", heartbeat_at: "Any", result_json: "Any") -> "Any":
+    def complete_task(
+        self,
+        *,
+        task_id: "str",
+        completed_at: "Any",
+        heartbeat_at: "Any",
+        result_json: "Any",
+        expected_retry_count: "int | None" = None,
+    ) -> "Any":
         """Return an UPDATE statement that completes a task."""
-        return (
+        statement = (
             sql
             .update(self.table_name)
             .set(
@@ -256,10 +264,23 @@ class SQLSpecQueueStore:
             )
             .where_eq(self._col("id"), task_id)
         )
+        if expected_retry_count is not None:
+            statement = statement.where_eq(self._col("status"), "running").where_eq(
+                self._col("retry_count"), expected_retry_count
+            )
+        return statement
 
-    def retry_task(self, *, task_id: "str", error: "str", retry_count: "int") -> "Any":
+    def retry_task(
+        self,
+        *,
+        task_id: "str",
+        error: "str",
+        retry_count: "int",
+        expected_retry_count: "int | None" = None,
+        heartbeat_cutoff: "Any | None" = None,
+    ) -> "Any":
         """Return an UPDATE statement that schedules a retry."""
-        return (
+        statement = (
             sql
             .update(self.table_name)
             .set(
@@ -272,11 +293,29 @@ class SQLSpecQueueStore:
                 })
             )
             .where_eq(self._col("id"), task_id)
+            .where_eq(self._col("status"), "running")
         )
+        if expected_retry_count is not None:
+            statement = statement.where_eq(self._col("retry_count"), expected_retry_count)
+        if heartbeat_cutoff is not None:
+            statement = statement.where(
+                f"{self._col('heartbeat_at')} IS NULL OR {self._col('heartbeat_at')} < :heartbeat_cutoff",
+                heartbeat_cutoff=heartbeat_cutoff,
+            )
+        return statement
 
-    def fail_task(self, *, task_id: "str", completed_at: "Any", heartbeat_at: "Any", error: "str") -> "Any":
+    def fail_task(
+        self,
+        *,
+        task_id: "str",
+        completed_at: "Any",
+        heartbeat_at: "Any",
+        error: "str",
+        expected_retry_count: "int | None" = None,
+        heartbeat_cutoff: "Any | None" = None,
+    ) -> "Any":
         """Return an UPDATE statement that permanently fails a task."""
-        return (
+        statement = (
             sql
             .update(self.table_name)
             .set(
@@ -288,7 +327,16 @@ class SQLSpecQueueStore:
                 })
             )
             .where_eq(self._col("id"), task_id)
+            .where_eq(self._col("status"), "running")
         )
+        if expected_retry_count is not None:
+            statement = statement.where_eq(self._col("retry_count"), expected_retry_count)
+        if heartbeat_cutoff is not None:
+            statement = statement.where(
+                f"{self._col('heartbeat_at')} IS NULL OR {self._col('heartbeat_at')} < :heartbeat_cutoff",
+                heartbeat_cutoff=heartbeat_cutoff,
+            )
+        return statement
 
     def cancel_task(self, *, task_id: "str", completed_at: "Any") -> "Any":
         """Return an UPDATE statement that cancels a due task."""

--- a/src/tests/integration/backends/advanced_alchemy/test_stale_recovery_fencing.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_stale_recovery_fencing.py
@@ -1,0 +1,135 @@
+"""Advanced Alchemy stale-recovery fencing regression tests."""
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("advanced_alchemy")
+pytest.importorskip("aiosqlite")
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from litestar_queues.backends.advanced_alchemy.service import QueueTaskService, _serialize_json
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyQueueBackend
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_advanced_alchemy_stale_recovery_does_not_requeue_task_completed_after_stale_select(
+    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    record = await advanced_alchemy_backend.enqueue("tasks.stale.completed", max_retries=2)
+    claimed = await advanced_alchemy_backend.claim_task(record.id)
+
+    assert claimed is not None
+
+    completed = False
+    model_type = advanced_alchemy_backend._model_class
+    original_execute = AsyncSession.execute
+
+    async def execute_with_completion(self: "AsyncSession", statement: "Any", *args: "Any", **kwargs: "Any") -> "Any":
+        nonlocal completed
+        result = await original_execute(self, statement, *args, **kwargs)
+        if not completed and _selects_model(statement, model_type):
+            completed = True
+            await _complete_task_on_session(self, model_type, claimed.id)
+        return result
+
+    monkeypatch.setattr(AsyncSession, "execute", execute_with_completion)
+
+    recovery = await advanced_alchemy_backend.requeue_stale_running(stale_after=timedelta(seconds=-1))
+    stored = await advanced_alchemy_backend.get_task(record.id)
+
+    assert recovery.requeued == 0
+    assert recovery.failed == 0
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.retry_count == claimed.retry_count
+
+
+async def test_advanced_alchemy_expected_retry_count_prevents_stale_owner_from_failing_reclaimed_task(
+    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    record = await advanced_alchemy_backend.enqueue("tasks.stale.owner", max_retries=2)
+    claimed = await advanced_alchemy_backend.claim_task(record.id)
+
+    assert claimed is not None
+
+    interleaved = False
+    original_select_task = QueueTaskService._select_task
+
+    async def select_task_with_reclaim(self: "QueueTaskService", task_id: "UUID") -> "Any | None":
+        nonlocal interleaved
+        model = await original_select_task(self, task_id)
+        if task_id == claimed.id and not interleaved:
+            interleaved = True
+            await _requeue_and_claim_on_session(
+                self.repository.session, self.model_type, claimed.id, claimed.retry_count
+            )
+        return model
+
+    monkeypatch.setattr(QueueTaskService, "_select_task", select_task_with_reclaim)
+
+    stale_failure = await advanced_alchemy_backend.fail_task(
+        claimed.id, "stale owner failed", retry=False, expected_retry_count=claimed.retry_count
+    )
+    stored = await advanced_alchemy_backend.get_task(record.id)
+
+    assert stale_failure is None
+    assert stored is not None
+    assert stored.status == "running"
+    assert stored.retry_count == claimed.retry_count + 1
+    assert stored.error == "Task heartbeat stale"
+
+
+def _selects_model(statement: "Any", model_type: "type[Any]") -> "bool":
+    if not getattr(statement, "is_select", False):
+        return False
+    return any(description.get("entity") is model_type for description in getattr(statement, "column_descriptions", ()))
+
+
+async def _complete_task_on_session(session: "AsyncSession", model_type: "type[Any]", task_id: "UUID") -> "None":
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        update(model_type)
+        .where(model_type.id == task_id)
+        .values(
+            status="completed",
+            completed_at=now,
+            heartbeat_at=now,
+            result_json=_serialize_json({"ok": True}),
+            error=None,
+        )
+        .execution_options(synchronize_session=False)
+    )
+
+
+async def _requeue_and_claim_on_session(
+    session: "AsyncSession", model_type: "type[Any]", task_id: "UUID", retry_count: "int"
+) -> "None":
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        update(model_type)
+        .where(model_type.id == task_id)
+        .values(
+            status="pending",
+            started_at=None,
+            heartbeat_at=None,
+            retry_count=retry_count + 1,
+            error="Task heartbeat stale",
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.execute(
+        update(model_type)
+        .where(model_type.id == task_id)
+        .values(status="running", started_at=now, heartbeat_at=now)
+        .execution_options(synchronize_session=False)
+    )

--- a/src/tests/integration/backends/sqlspec/test_stale_recovery_fencing.py
+++ b/src/tests/integration/backends/sqlspec/test_stale_recovery_fencing.py
@@ -1,0 +1,136 @@
+"""SQLSpec stale-recovery fencing regression tests."""
+
+import contextlib
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+pytest.importorskip("sqlspec")
+
+from litestar_queues.backends.sqlspec import SQLSpecQueueBackend
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
+    from uuid import UUID
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_sqlspec_stale_recovery_does_not_requeue_task_completed_after_stale_select(
+    sqlspec_backend: "SQLSpecQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    record = await sqlspec_backend.enqueue("tasks.stale.completed", max_retries=2)
+    claimed = await sqlspec_backend.claim_task(record.id)
+
+    assert claimed is not None
+
+    completed = False
+    original_session = SQLSpecQueueBackend._session
+
+    async def complete_after_stale_select(driver: "Any") -> "None":
+        nonlocal completed
+        if completed:
+            return
+        completed = True
+        await _complete_task_on_driver(sqlspec_backend, driver, claimed.id)
+
+    @contextlib.asynccontextmanager
+    async def interleaving_session(self: "SQLSpecQueueBackend") -> "AsyncIterator[Any]":
+        async with original_session(self) as driver:
+            if self is sqlspec_backend:
+                yield _SelectHookDriver(driver, complete_after_stale_select)
+            else:
+                yield driver
+
+    monkeypatch.setattr(SQLSpecQueueBackend, "_session", interleaving_session)
+
+    recovery = await sqlspec_backend.requeue_stale_running(stale_after=timedelta(seconds=-1))
+    stored = await sqlspec_backend.get_task(record.id)
+
+    assert recovery.requeued == 0
+    assert recovery.failed == 0
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.retry_count == claimed.retry_count
+
+
+async def test_sqlspec_expected_retry_count_prevents_stale_owner_from_failing_reclaimed_task(
+    sqlspec_backend: "SQLSpecQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    record = await sqlspec_backend.enqueue("tasks.stale.owner", max_retries=2)
+    claimed = await sqlspec_backend.claim_task(record.id)
+
+    assert claimed is not None
+
+    interleaved = False
+    original_select_task = SQLSpecQueueBackend._select_task
+
+    async def select_task_with_reclaim(
+        self: "SQLSpecQueueBackend", driver: "Any", task_id: "UUID"
+    ) -> "dict[str, Any] | None":
+        nonlocal interleaved
+        row = await original_select_task(self, driver, task_id)
+        if self is sqlspec_backend and task_id == claimed.id and not interleaved:
+            interleaved = True
+            await _requeue_and_claim_on_driver(self, driver, claimed.id, claimed.retry_count)
+        return row
+
+    monkeypatch.setattr(SQLSpecQueueBackend, "_select_task", select_task_with_reclaim)
+
+    stale_failure = await sqlspec_backend.fail_task(
+        claimed.id, "stale owner failed", retry=False, expected_retry_count=claimed.retry_count
+    )
+    stored = await sqlspec_backend.get_task(record.id)
+
+    assert stale_failure is None
+    assert stored is not None
+    assert stored.status == "running"
+    assert stored.retry_count == claimed.retry_count + 1
+    assert stored.error == "Task heartbeat stale"
+
+
+class _SelectHookDriver:
+    def __init__(self, driver: "Any", after_select: "Callable[[Any], Awaitable[None]]") -> "None":
+        self._driver = driver
+        self._after_select = after_select
+
+    def __getattr__(self, name: "str") -> "Any":
+        return getattr(self._driver, name)
+
+    async def select(self, *args: "Any", **kwargs: "Any") -> "Any":
+        rows = await self._driver.select(*args, **kwargs)
+        if rows:
+            await self._after_select(self._driver)
+        return rows
+
+
+async def _complete_task_on_driver(backend: "SQLSpecQueueBackend", driver: "Any", task_id: "UUID") -> "None":
+    store = backend._get_store()
+    now = backend._serialize_datetime(datetime.now(timezone.utc))
+    try:
+        await driver.execute(
+            store.complete_task(
+                task_id=str(task_id),
+                completed_at=now,
+                heartbeat_at=now,
+                result_json=store.serialize_json("result_json", {"ok": True}),
+            )
+        )
+        await driver.commit()
+    except Exception:
+        with contextlib.suppress(Exception):
+            await driver.rollback()
+        raise
+
+
+async def _requeue_and_claim_on_driver(
+    backend: "SQLSpecQueueBackend", driver: "Any", task_id: "UUID", retry_count: "int"
+) -> "None":
+    store = backend._get_store()
+    now = backend._serialize_datetime(datetime.now(timezone.utc))
+    await driver.execute(
+        store.retry_task(task_id=str(task_id), error="Task heartbeat stale", retry_count=retry_count + 1)
+    )
+    await driver.execute(store.claim_task(task_id=str(task_id), due_at=now, started_at=now, heartbeat_at=now))


### PR DESCRIPTION
## Summary

- fence SQLSpec lifecycle and stale-recovery writes with task status, retry count, and stale heartbeat predicates where applicable
- make stale recovery count only rows that actually win the update, including validation for SQLSpec drivers with unknown rowcount results
- apply equivalent Advanced Alchemy fail/retry and stale-recovery fencing while preserving existing direct completion and force-stale behavior
- add regression tests for completed-task resurrection and stale-owner stomp races across both SQL backends

Fixes #36