### PR TITLE
fix: harden worker claim loop

### DIFF
--- a/src/litestar_queues/_cli.py
+++ b/src/litestar_queues/_cli.py
@@ -118,26 +118,13 @@ async def _run_worker(
     )
 
     loop = asyncio.get_running_loop()
-    stop_count = {"n": 0}
-    stop_task: "asyncio.Task[None] | None" = None
-    forced_stop = {"value": False}
-
-    def _request_stop() -> "None":
-        nonlocal stop_task
-        stop_count["n"] += 1
-        if stop_count["n"] >= FORCE_STOP_SIGNAL_COUNT:
-            forced_stop["value"] = True
-            if stop_task is None or stop_task.done():
-                stop_task = asyncio.create_task(worker.stop(force=True))
-            return
-        if stop_task is None or stop_task.done():
-            stop_task = asyncio.create_task(worker.stop())
+    stop_coordinator = _WorkerStopCoordinator(worker)
 
     def _register_signal_handler(sig: "signal.Signals") -> "None":
         try:
-            loop.add_signal_handler(sig, _request_stop)
+            loop.add_signal_handler(sig, stop_coordinator.request_stop)
         except NotImplementedError:
-            signal.signal(sig, lambda *_: _request_stop())
+            signal.signal(sig, lambda *_: stop_coordinator.request_stop())
 
     for sig in (signal.SIGTERM, signal.SIGINT):
         _register_signal_handler(sig)
@@ -149,7 +136,8 @@ async def _run_worker(
     try:
         try:
             await asyncio.wait_for(worker_task, timeout=None)
-            if forced_stop["value"]:
+            await stop_coordinator.wait()
+            if stop_coordinator.forced_stop or stop_coordinator.drain_escalated:
                 exit_code = 2
         except asyncio.CancelledError:
             with contextlib.suppress(BaseException):
@@ -159,9 +147,46 @@ async def _run_worker(
             exit_code = 1
     finally:
         with contextlib.suppress(Exception):
+            await stop_coordinator.finish(timeout=drain_timeout + config.worker_final_cancel_timeout)
             await asyncio.wait_for(worker.stop(), timeout=drain_timeout)
         await service.close()
     return exit_code
+
+
+class _WorkerStopCoordinator:
+    __slots__ = ("drain_escalated", "forced_stop", "stop_count", "stop_task", "worker")
+
+    def __init__(self, worker: "Worker") -> "None":
+        self.worker = worker
+        self.stop_count = 0
+        self.stop_task: "asyncio.Task[None] | None" = None
+        self.forced_stop = False
+        self.drain_escalated = False
+
+    def request_stop(self) -> "None":
+        self.stop_count += 1
+        if self.stop_count >= FORCE_STOP_SIGNAL_COUNT:
+            self.forced_stop = True
+            self._schedule_stop(force=True)
+            return
+        self._schedule_stop()
+
+    async def wait(self) -> "None":
+        if self.stop_task is not None:
+            await self.stop_task
+
+    async def finish(self, *, timeout: "float") -> "None":
+        if self.stop_task is not None and not self.stop_task.done():
+            await asyncio.wait_for(self.stop_task, timeout=timeout)
+
+    def _schedule_stop(self, *, force: "bool" = False) -> "None":
+        if self.stop_task is None or self.stop_task.done():
+            self.stop_task = asyncio.create_task(self._stop_worker(force=force))
+
+    async def _stop_worker(self, *, force: "bool" = False) -> "None":
+        escalated = await self.worker.stop(force=force)
+        if escalated:
+            self.drain_escalated = True
 
 
 async def _status_run(plugin: "QueuePlugin", queue_filter: "str | None", as_json: "bool") -> "int":

--- a/src/litestar_queues/models.py
+++ b/src/litestar_queues/models.py
@@ -92,6 +92,10 @@ class EnqueueSpec:
     execution_profile: "str | None" = None
     metadata: "dict[str, Any] | None" = None
 
+    def __post_init__(self) -> "None":
+        if self.scheduled_at is not None:
+            self.scheduled_at = _ensure_utc_datetime(self.scheduled_at)
+
 
 @dataclass(slots=True)
 class QueuedTaskRecord:
@@ -119,6 +123,10 @@ class QueuedTaskRecord:
     key: "str | None" = None
     metadata: "dict[str, Any]" = field(default_factory=dict)
 
+    def __post_init__(self) -> "None":
+        if self.scheduled_at is not None:
+            self.scheduled_at = _ensure_utc_datetime(self.scheduled_at)
+
     @property
     def is_terminal(self) -> "bool":
         """Whether the record is in a terminal state."""
@@ -128,3 +136,9 @@ class QueuedTaskRecord:
     def is_due(self) -> "bool":
         """Whether the record is eligible to be claimed now."""
         return self.scheduled_at is None or self.scheduled_at <= datetime.now(timezone.utc)
+
+
+def _ensure_utc_datetime(value: "datetime") -> "datetime":
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/src/litestar_queues/plugin.py
+++ b/src/litestar_queues/plugin.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, cast
 
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
     from litestar_queues.events import QueueEventPublisher
 
 __all__ = ("QueuePlugin",)
+
+logger = logging.getLogger(__name__)
 
 
 class QueuePlugin(InitPlugin):
@@ -117,6 +120,7 @@ class QueuePlugin(InitPlugin):
                 queues=self._config.worker_queues,
             )
             self._worker_task = asyncio.create_task(self._worker.start())
+            self._worker_task.add_done_callback(self._log_worker_task_result)
             await asyncio.sleep(0)
             app.state[self._config.queue_worker_state_key] = self._worker
 
@@ -124,10 +128,20 @@ class QueuePlugin(InitPlugin):
         if self._worker is not None:
             await self._worker.stop()
         if self._worker_task is not None:
-            with contextlib.suppress(asyncio.CancelledError):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._worker_task
             self._worker_task = None
         if self._service is not None:
             set_default_service(None)
             await self._service.close()
             self._service = None
+
+    def _log_worker_task_result(self, task: "asyncio.Task[None]") -> "None":
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is None:
+            return
+        logger.error(
+            "In-app queue worker stopped unexpectedly", exc_info=(type(exception), exception, exception.__traceback__)
+        )

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -10,7 +10,8 @@ from litestar_queues.config import execution_backend_name
 from litestar_queues.events.context import TaskExecutionContext, _bind_task_context, _reset_task_context
 from litestar_queues.events.models import QueueEvent
 from litestar_queues.exceptions import NonRetryableError
-from litestar_queues.task import ScheduleConfig, Task, TaskResult, get_scheduled_tasks, get_task_registry
+from litestar_queues.execution import get_execution_backend
+from litestar_queues.task import ScheduleConfig, Task, TaskResult, _ensure_utc, get_scheduled_tasks, get_task_registry
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -149,6 +150,8 @@ class QueueService:
         effective_scheduled_at = scheduled_at
         if effective_scheduled_at is None and effective_run_after is not None:
             effective_scheduled_at = datetime.now(timezone.utc) + effective_run_after
+        if effective_scheduled_at is not None:
+            effective_scheduled_at = _ensure_utc(effective_scheduled_at)
         effective_execution_backend = (
             execution_backend or task_obj.execution_backend or execution_backend_name(self._config.execution_backend)
         )
@@ -180,10 +183,17 @@ class QueueService:
         result = TaskResult(record.id, task_obj.name, service=self, record=record)
 
         if record.execution_backend == "immediate" and record.status == "pending":
-            claimed = await self.get_queue_backend().claim_task(record.id)
-            if claimed is not None:
-                await self.get_execution_backend().execute(self, claimed)
+            execution_backend_impl = self._execution_backend_for_name(record.execution_backend)
+            if not execution_backend_impl.is_external:
+                claimed = await self.get_queue_backend().claim_task(record.id)
+                if claimed is not None:
+                    await execution_backend_impl.execute(self, claimed)
         return result
+
+    def _execution_backend_for_name(self, name: "str") -> "BaseExecutionBackend":
+        if name == execution_backend_name(self._config.execution_backend):
+            return self.get_execution_backend()
+        return get_execution_backend(name, config=self._config)
 
     def resolve_task(self, task: "str | Task[Any, Any]") -> "Task[Any, Any]":
         """Resolve a task name or wrapper to a registered task.

--- a/src/litestar_queues/worker.py
+++ b/src/litestar_queues/worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from litestar_queues.service import QueueService
 
 __all__ = ("Worker",)
+
+logger = logging.getLogger(__name__)
 
 
 class Worker:
@@ -90,21 +93,32 @@ class Worker:
         self._stop_event.clear()
         try:
             while not self._stop_event.is_set():
-                await self._maybe_requeue_stale()
-                await self._maybe_reconcile_external()
-                processed = await self.run_once()
+                try:
+                    await self._maybe_requeue_stale()
+                    await self._maybe_reconcile_external()
+                    processed = await self.run_once()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
+                    await self._backoff_after_loop_error()
+                    continue
                 if processed == 0:
                     await self._wait_for_work()
         finally:
             self._is_running = False
 
-    async def stop(self, *, force: "bool" = False) -> "None":
-        """Stop the worker loop and drain or cancel in-flight work."""
+    async def stop(self, *, force: "bool" = False) -> "bool":
+        """Stop the worker loop and drain or cancel in-flight work.
+
+        Returns:
+            True when graceful drain escalated to cancellation.
+        """
         self._stop_event.set()
         if force:
             await self._cancel_running()
-        else:
-            await self._drain_running()
+            return False
+        return await self._drain_running()
 
     async def run_once(self) -> "int":
         """Process one batch of due tasks.
@@ -112,27 +126,47 @@ class Worker:
         Returns:
             Number of claimed task records.
         """
-        queue_backend = self._service.get_queue_backend()
         execution_backend = self._service.get_execution_backend()
         available = min(self._batch_size, max(0, self._max_concurrency - len(self._running_tasks)))
         if available <= 0:
             return 0
-        records = await self._list_pending(limit=available)
         if execution_backend.is_external:
+            records = await self._list_pending(limit=available)
             return await self._dispatch_external(records)
 
-        claimed_records: 'list["QueuedTaskRecord"]' = []
-        for record in records:
-            claimed = await queue_backend.claim_task(record.id)
-            if claimed is None:
-                continue
-            claimed_records.append(claimed)
+        claimed_records = await self._claim_available(limit=available)
         if not claimed_records:
             return 0
 
-        tasks = [self._track_execution(record) for record in claimed_records]
-        await asyncio.gather(*tasks, return_exceptions=True)
+        for record in claimed_records:
+            self._track_execution(record)
         return len(claimed_records)
+
+    async def _claim_available(self, *, limit: "int") -> "list[QueuedTaskRecord]":
+        queue_backend = self._service.get_queue_backend()
+        execution_backend_name_ = execution_backend_name(self._service.config.execution_backend)
+        records: 'list["QueuedTaskRecord"]' = []
+        if not self._queues:
+            for _ in range(limit):
+                claimed = await queue_backend.claim_next(execution_backend=execution_backend_name_)
+                if claimed is None:
+                    break
+                records.append(claimed)
+            return records
+
+        while len(records) < limit:
+            claimed_this_pass = False
+            for queue in self._queues:
+                if len(records) >= limit:
+                    break
+                claimed = await queue_backend.claim_next(queue=queue, execution_backend=execution_backend_name_)
+                if claimed is None:
+                    continue
+                records.append(claimed)
+                claimed_this_pass = True
+            if not claimed_this_pass:
+                break
+        return records
 
     async def _list_pending(self, *, limit: "int") -> "list[QueuedTaskRecord]":
         queue_backend = self._service.get_queue_backend()
@@ -176,11 +210,18 @@ class Worker:
         for record in records:
             if record.execution_ref is None:
                 continue
-            execution_backend = (
-                current_backend
-                if record.execution_backend == execution_backend_name(self._service.config.execution_backend)
-                else get_execution_backend(record.execution_backend, config=self._service.config)
-            )
+            try:
+                execution_backend = (
+                    current_backend
+                    if record.execution_backend == execution_backend_name(self._service.config.execution_backend)
+                    else get_execution_backend(record.execution_backend, config=self._service.config)
+                )
+            except ValueError:
+                logger.warning(
+                    "Skipping external queue record with unknown execution backend",
+                    extra={"task_id": str(record.id), "execution_backend": record.execution_backend},
+                )
+                continue
             updated = await execution_backend.reconcile(self._service, record)
             if updated is not None and updated.is_terminal:
                 reconciled += 1
@@ -232,9 +273,9 @@ class Worker:
             await asyncio.sleep(self._heartbeat_interval)
             await self._service.get_queue_backend().touch_heartbeat(task_id, expected_retry_count=expected_retry_count)
 
-    async def _drain_running(self) -> "None":
+    async def _drain_running(self) -> "bool":
         if not self._running_tasks:
-            return
+            return False
         try:
             await asyncio.wait_for(
                 asyncio.gather(*tuple(self._running_tasks), return_exceptions=True),
@@ -242,6 +283,8 @@ class Worker:
             )
         except asyncio.TimeoutError:
             await self._cancel_running()
+            return True
+        return False
 
     async def _cancel_running(self) -> "None":
         tasks = tuple(self._running_tasks)
@@ -264,3 +307,8 @@ class Worker:
         for task in done:
             with contextlib.suppress(asyncio.TimeoutError):
                 task.result()
+
+    async def _backoff_after_loop_error(self) -> "None":
+        timeout = min(max(self._poll_interval, 0.01), 1.0)
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._stop_event.wait(), timeout=timeout)

--- a/src/tests/unit/backends/test_bulk_enqueue.py
+++ b/src/tests/unit/backends/test_bulk_enqueue.py
@@ -50,6 +50,16 @@ async def test_enqueue_many_honors_scheduled_status() -> "None":
     assert record.status == "scheduled"
 
 
+async def test_enqueue_many_normalizes_naive_scheduled_at_to_utc() -> "None":
+    backend = InMemoryQueueBackend()
+    naive_later = (datetime.now(timezone.utc) + timedelta(minutes=5)).replace(tzinfo=None)
+
+    (record,) = await backend.enqueue_many([EnqueueSpec(task_name="tasks.later", scheduled_at=naive_later)])
+
+    assert record.status == "scheduled"
+    assert record.scheduled_at == naive_later.replace(tzinfo=timezone.utc)
+
+
 async def test_enqueue_many_deduplicates_active_keys() -> "None":
     backend = InMemoryQueueBackend()
     first = await backend.enqueue("tasks.sync", key="sync:1", kwargs={"v": 1})

--- a/src/tests/unit/test_cli_run.py
+++ b/src/tests/unit/test_cli_run.py
@@ -7,6 +7,7 @@ within the drain window.
 Skipped on Windows because SIGTERM is not meaningfully delivered there.
 """
 
+import asyncio
 import os
 import select
 import signal
@@ -23,26 +24,55 @@ pytestmark = [
 ]
 
 
-def _wait_for_worker_started(proc: "subprocess.Popen[bytes]", *, timeout: "float" = 8.0) -> "None":
-    """Wait until the worker command has installed signal handlers.
+async def test_run_worker_returns_2_when_single_signal_drain_timeout_cancels(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    from litestar_queues import QueueConfig, QueuePlugin, task
+    from litestar_queues._cli import _run_worker
+    from litestar_queues.backends import InMemoryQueueBackend
 
-    Returns:
-        None.
-    """
-    assert proc.stderr is not None
-    deadline = time.monotonic() + timeout
-    stderr = []
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            break
-        ready, _, _ = select.select([proc.stderr], [], [], 0.1)
-        if not ready:
-            continue
-        line = proc.stderr.readline().decode()
-        stderr.append(line)
-        if "litestar queues worker started" in line:
-            return
-    pytest.fail(f"worker did not report startup before SIGTERM; stderr={''.join(stderr)[-500:]!r}")
+    started = asyncio.Event()
+
+    @task("cli.stuck")
+    async def stuck() -> "None":
+        started.set()
+        await asyncio.Event().wait()
+
+    backend = InMemoryQueueBackend()
+    await backend.enqueue("cli.stuck")
+    plugin = QueuePlugin(
+        QueueConfig(
+            execution_backend="local", in_app_worker=False, worker_poll_interval=0.01, worker_final_cancel_timeout=0.1
+        )
+    )
+    plugin._queue_backend = backend
+    handlers: "dict[signal.Signals, object]" = {}
+
+    def add_signal_handler(sig: "signal.Signals", callback: "object") -> "None":
+        handlers[sig] = callback
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "add_signal_handler", add_signal_handler)
+    run_task = asyncio.create_task(_run_worker(plugin, 1, 0.01, ()))
+
+    await asyncio.wait_for(started.wait(), timeout=1)
+    handler = handlers[signal.SIGTERM]
+    assert callable(handler)
+    handler()
+
+    assert await asyncio.wait_for(run_task, timeout=2) == 2
+
+
+async def test_run_worker_returns_1_when_worker_loop_crashes(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    from litestar_queues import QueueConfig, QueuePlugin
+    from litestar_queues import _cli as cli_module
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "add_signal_handler", lambda *_args: None)
+    monkeypatch.setattr(cli_module, "Worker", _FailingStartWorker)
+    plugin = QueuePlugin(QueueConfig(execution_backend="local", in_app_worker=False))
+
+    assert await cli_module._run_worker(plugin, 1, 0.01, ()) == 1
 
 
 def test_run_subcommand_drains_on_sigterm() -> "None":
@@ -75,3 +105,39 @@ def test_run_subcommand_drains_on_sigterm() -> "None":
         f"expected clean drain (exit 0), got {proc.returncode}; "
         f"stderr={proc.stderr.read().decode()[-500:] if proc.stderr else ''!r}"
     )
+
+
+def _wait_for_worker_started(proc: "subprocess.Popen[bytes]", *, timeout: "float" = 8.0) -> "None":
+    """Wait until the worker command has installed signal handlers.
+
+    Returns:
+        None.
+    """
+    assert proc.stderr is not None
+    deadline = time.monotonic() + timeout
+    stderr = []
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            break
+        ready, _, _ = select.select([proc.stderr], [], [], 0.1)
+        if not ready:
+            continue
+        line = proc.stderr.readline().decode()
+        stderr.append(line)
+        if "litestar queues worker started" in line:
+            return
+    pytest.fail(f"worker did not report startup before SIGTERM; stderr={''.join(stderr)[-500:]!r}")
+
+
+class _FailingStartWorker:
+    __slots__ = ()
+
+    def __init__(self, *_args: "object", **_kwargs: "object") -> "None":
+        pass
+
+    async def start(self) -> "None":
+        msg = "worker crashed"
+        raise RuntimeError(msg)
+
+    async def stop(self, *, force: "bool" = False) -> "bool":
+        return False

--- a/src/tests/unit/test_public_api.py
+++ b/src/tests/unit/test_public_api.py
@@ -128,6 +128,20 @@ def test_optional_backends_resolve_lazily_via_factory() -> "None":
     assert get_queue_backend_class("valkey") is ValkeyQueueBackend
 
 
+def test_queued_task_record_normalizes_naive_scheduled_at() -> "None":
+    """Queued records normalize naive scheduled datetimes before due checks."""
+    from datetime import datetime, timedelta, timezone
+
+    from litestar_queues import QueuedTaskRecord
+
+    naive_scheduled_at = (datetime.now(timezone.utc) - timedelta(minutes=1)).replace(tzinfo=None)
+
+    record = QueuedTaskRecord(task_name="example", scheduled_at=naive_scheduled_at)
+
+    assert record.scheduled_at == naive_scheduled_at.replace(tzinfo=timezone.utc)
+    assert record.is_due is True
+
+
 def test_optional_backend_configs_live_on_submodules() -> "None":
     """Backend-specific config dataclasses are not top-level exports."""
     from litestar_queues.backends.redis import RedisBackendConfig

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -6,6 +6,7 @@ import pytest
 from litestar_queues import InMemoryQueueEventSink, QueueConfig, QueueEventConfig, QueueService
 from litestar_queues.backends import InMemoryQueueBackend
 from litestar_queues.events import QueueEventPublisher
+from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
 
 if TYPE_CHECKING:
     from litestar_queues.models import QueuedTaskRecord
@@ -59,6 +60,43 @@ async def test_enqueue_can_override_requeue_on_stale_metadata() -> "None":
 
     assert result.record is not None
     assert result.record.metadata["requeue_on_stale"] is False
+
+
+async def test_enqueue_immediate_override_executes_inline_when_configured_backend_is_external() -> "None":
+    from litestar_queues import task
+
+    @task("external.inline")
+    async def inline() -> "str":
+        return "ok"
+
+    config = QueueConfig(
+        execution_backend=CloudRunExecutionConfig(project_id="test-project", region="us-central1", job_name="worker")
+    )
+
+    async with QueueService(config) as service:
+        result = await service.enqueue(inline.using(execution_backend="immediate"))
+
+    assert result.status == "completed"
+    assert result.result == "ok"
+    assert result.record is not None
+    assert result.record.execution_backend == "immediate"
+
+
+async def test_enqueue_normalizes_naive_scheduled_at_to_utc() -> "None":
+    from litestar_queues import task
+
+    @task("scheduled.naive")
+    async def naive_schedule() -> "str":
+        return "ok"
+
+    naive_scheduled_at = (datetime.now(timezone.utc) + timedelta(minutes=5)).replace(tzinfo=None)
+
+    async with QueueService(QueueConfig(execution_backend="local")) as service:
+        result = await service.enqueue(naive_schedule, scheduled_at=naive_scheduled_at)
+
+    assert result.status == "scheduled"
+    assert result.record is not None
+    assert result.record.scheduled_at == naive_scheduled_at.replace(tzinfo=timezone.utc)
 
 
 async def test_execute_record_invokes_task_dependency_resolver_and_merges_kwargs() -> "None":

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import threading
 from contextlib import suppress
@@ -20,17 +21,14 @@ from litestar_queues import (
 )
 from litestar_queues.backends import InMemoryQueueBackend
 from litestar_queues.events import InMemoryQueueEventSink, QueueEventConfig
-from litestar_queues.task import clear_task_registry
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from litestar_queues.models import QueuedTaskRecord, StaleTaskRecoveryResult
+    from litestar_queues.task import TaskResult
 
 pytestmark = pytest.mark.anyio
-
-
-@pytest.fixture(autouse=True)
-def clean_task_registry() -> "None":
-    clear_task_registry()
 
 
 async def test_worker_run_once_processes_pending_local_task() -> "None":
@@ -43,7 +41,7 @@ async def test_worker_run_once_processes_pending_local_task() -> "None":
         worker = Worker(service)
 
         assert await worker.run_once() == 1
-        await result.refresh()
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert result.status == "completed"
     assert result.result == 42
@@ -66,12 +64,10 @@ async def test_worker_retries_failed_task_until_success() -> "None":
         worker = Worker(service)
 
         assert await worker.run_once() == 1
-        await result.refresh()
-        pending_status = result.status
-        assert pending_status == "pending"
+        await _wait_for_record_status(result, "pending")
 
         assert await worker.run_once() == 1
-        await result.refresh()
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert attempts == 2
     completed_status = result.status
@@ -93,7 +89,7 @@ async def test_worker_non_retryable_failure_skips_retries_and_injects_job_id() -
         worker = Worker(service)
 
         assert await worker.run_once() == 1
-        await result.refresh()
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert captured_job_id == str(result.id)
     assert result.status == "failed"
@@ -123,32 +119,21 @@ async def test_worker_processes_batch_with_configured_concurrency() -> "None":
 
         run_once = asyncio.create_task(worker.run_once())
         await asyncio.wait_for(both_started.wait(), timeout=1)
-        release.set()
-
+        if not run_once.done():
+            release.set()
+            await asyncio.wait_for(run_once, timeout=1)
+            pytest.fail("run_once should return after scheduling claimed records")
         assert await run_once == 2
-        await first.refresh()
-        await second.refresh()
+        release.set()
+        await first.wait(timeout=1, poll_interval=0.01)
+        await second.wait(timeout=1, poll_interval=0.01)
 
     assert first.status == "completed"
     assert second.status == "completed"
 
 
-class _LimitRecordingInMemoryQueueBackend(InMemoryQueueBackend):
-    __slots__ = ("list_limits",)
-
-    def __init__(self) -> "None":
-        super().__init__()
-        self.list_limits: "list[int]" = []
-
-    async def list_pending(
-        self, *, limit: "int" = 1, queue: "str | None" = None, execution_backend: "str | None" = None
-    ) -> 'list["QueuedTaskRecord"]':
-        self.list_limits.append(limit)
-        return await super().list_pending(limit=limit, queue=queue, execution_backend=execution_backend)
-
-
-async def test_worker_does_not_over_claim_beyond_available_concurrency() -> "None":
-    backend = _LimitRecordingInMemoryQueueBackend()
+async def test_worker_claims_local_records_through_claim_next() -> "None":
+    backend = _ClaimNextRecordingInMemoryQueueBackend()
 
     @task("tasks.capacity")
     async def capacity(value: "int") -> "int":
@@ -161,7 +146,9 @@ async def test_worker_does_not_over_claim_beyond_available_concurrency() -> "Non
 
         assert await worker.run_once() == 2
 
-    assert backend.list_limits[0] == 2
+    assert backend.claim_next_calls == [(None, "local"), (None, "local")]
+    assert backend.list_pending_calls == []
+    assert backend.claim_task_calls == []
 
 
 async def test_worker_queue_filter_restricts_claimed_records() -> "None":
@@ -175,11 +162,74 @@ async def test_worker_queue_filter_restricts_claimed_records() -> "None":
         worker = Worker(service, queues=("priority",))
 
         assert await worker.run_once() == 1
+        await priority_result.wait(timeout=1, poll_interval=0.01)
         await default_result.refresh()
         await priority_result.refresh()
 
     assert default_result.status == "pending"
     assert priority_result.status == "completed"
+
+
+async def test_worker_start_refills_open_slots_without_waiting_for_slow_batch_member() -> "None":
+    slow_started = asyncio.Event()
+    release_slow = asyncio.Event()
+    fast_values: "list[int]" = []
+    fast_tasks_finished = asyncio.Event()
+
+    @task("tasks.refill")
+    async def refill(value: "int") -> "int":
+        if value == 0:
+            slow_started.set()
+            await release_slow.wait()
+            return value
+        fast_values.append(value)
+        if sorted(fast_values) == [1, 2]:
+            fast_tasks_finished.set()
+        return value
+
+    async with QueueService(QueueConfig(execution_backend="local")) as service:
+        slow = await service.enqueue(refill, 0)
+        first_fast = await service.enqueue(refill, 1)
+        second_fast = await service.enqueue(refill, 2)
+        worker = Worker(service, batch_size=2, max_concurrency=2, poll_interval=0.01)
+        worker_task = asyncio.create_task(worker.start())
+        refilled = False
+
+        try:
+            await asyncio.wait_for(slow_started.wait(), timeout=1)
+            await asyncio.wait_for(fast_tasks_finished.wait(), timeout=0.5)
+            assert release_slow.is_set() is False
+            refilled = True
+        finally:
+            release_slow.set()
+            if not refilled:
+                await worker.stop(force=True)
+                with suppress(asyncio.CancelledError):
+                    await asyncio.wait_for(worker_task, timeout=1)
+
+        await slow.wait(timeout=1, poll_interval=0.01)
+        await first_fast.wait(timeout=1, poll_interval=0.01)
+        await second_fast.wait(timeout=1, poll_interval=0.01)
+        await worker.stop()
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait_for(worker_task, timeout=1)
+
+    assert slow.status == "completed"
+    assert first_fast.status == "completed"
+    assert second_fast.status == "completed"
+
+
+async def test_worker_start_logs_and_continues_after_transient_loop_error(caplog: "pytest.LogCaptureFixture") -> "None":
+    recovered = asyncio.Event()
+    async with QueueService(QueueConfig(execution_backend="local")) as service:
+        worker = _TransientRunOnceWorker(service, recovered=recovered, poll_interval=0.01)
+
+        with caplog.at_level(logging.ERROR, logger="litestar_queues.worker"):
+            await worker.start()
+
+    assert worker.run_once_calls == 2
+    assert recovered.is_set()
+    assert "Queue worker loop iteration failed" in caplog.text
 
 
 async def test_worker_start_wakes_from_backend_notifications() -> "None":
@@ -201,18 +251,6 @@ async def test_worker_start_wakes_from_backend_notifications() -> "None":
 
     assert result.status == "completed"
     assert result.result == 42
-
-
-class _CountingInMemoryQueueBackend(InMemoryQueueBackend):
-    __slots__ = ("requeue_calls",)
-
-    def __init__(self) -> "None":
-        super().__init__()
-        self.requeue_calls: "list[timedelta]" = []
-
-    async def requeue_stale_running(self, *, stale_after: "timedelta") -> "StaleTaskRecoveryResult":
-        self.requeue_calls.append(stale_after)
-        return await super().requeue_stale_running(stale_after=stale_after)
 
 
 async def test_worker_periodic_requeue_calls_backend_on_cadence() -> "None":
@@ -254,6 +292,33 @@ async def test_worker_periodic_requeue_respects_cadence_window() -> "None":
     assert len(backend.requeue_calls) == 1
 
 
+async def test_worker_periodic_reconcile_skips_calls_inside_cadence_window() -> "None":
+    backend = _CountingInMemoryQueueBackend()
+    async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
+        worker = Worker(service, reconcile_interval=3600.0)
+
+        await worker._maybe_reconcile_external()
+        await worker._maybe_reconcile_external()
+        await worker._maybe_reconcile_external()
+
+    assert backend.list_running_external_calls == 1
+
+
+async def test_worker_reconcile_external_skips_unknown_backend_names(caplog: "pytest.LogCaptureFixture") -> "None":
+    backend = InMemoryQueueBackend()
+    async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
+        record = await backend.enqueue("tasks.remote", execution_backend="missing-backend")
+        claimed = await backend.claim_task(record.id)
+        assert claimed is not None
+        await backend.set_execution_ref(claimed.id, "missing-backend", "jobs/missing")
+        worker = Worker(service)
+
+        with caplog.at_level(logging.WARNING, logger="litestar_queues.worker"):
+            assert await worker.reconcile_external() == 0
+
+    assert "Skipping external queue record with unknown execution backend" in caplog.text
+
+
 async def test_worker_default_worker_id_uses_pid() -> "None":
     async with QueueService(QueueConfig()) as service:
         worker = Worker(service)
@@ -278,10 +343,11 @@ async def test_worker_id_propagates_into_published_events() -> "None":
     async with QueueService(
         QueueConfig(execution_backend="local", event_config=QueueEventConfig(enabled=True, sink=sink))
     ) as service:
-        await service.enqueue(worker_id_task)
+        result = await service.enqueue(worker_id_task)
         worker = Worker(service, worker_id="worker-test")
 
         assert await worker.run_once() == 1
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert sink.events, "Expected lifecycle events to be published"
     lifecycle_types = {"task.started", "task.completed", "task.failed"}
@@ -345,6 +411,30 @@ async def test_plugin_shutdown_waits_for_in_flight_worker_task() -> "None":
     assert result.status == "completed"
 
 
+async def test_plugin_logs_when_in_app_worker_task_dies(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    from litestar_queues import plugin as plugin_module
+
+    messages: "list[tuple[str, dict[str, object]]]" = []
+
+    def log_error(message: "str", **kwargs: "object") -> "None":
+        messages.append((message, kwargs))
+
+    monkeypatch.setattr(plugin_module, "Worker", _FailingWorker)
+    monkeypatch.setattr(plugin_module.logger, "error", log_error)
+    plugin = QueuePlugin(QueueConfig(in_app_worker=True, execution_backend="local"))
+    app = Litestar(plugins=[plugin])
+
+    await plugin._on_startup(app)
+    await asyncio.sleep(0)
+
+    if plugin._service is not None:
+        await plugin._service.close()
+
+    assert messages
+    assert messages[0][0] == "In-app queue worker stopped unexpectedly"
+    assert "exc_info" in messages[0][1]
+
+
 async def test_sync_task_uses_configured_executor_and_preserves_task_context() -> "None":
     @task("tasks.sync_context")
     def sync_context(*, _job_id: "str") -> "dict[str, str | None]":
@@ -360,3 +450,93 @@ async def test_sync_task_uses_configured_executor_and_preserves_task_context() -
     assert isinstance(result.result, dict)
     assert result.result["job_id"] == result.result["context_task_id"]
     assert str(result.result["thread_name"]).startswith("lq")
+
+
+async def _wait_for_record_status(result: "TaskResult", expected_status: "str", *, timeout: "float" = 1.0) -> "None":
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        await result.refresh()
+        if result.status == expected_status:
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"record {result.id} did not reach {expected_status!r}; status={result.status!r}")
+
+
+class _ClaimNextRecordingInMemoryQueueBackend(InMemoryQueueBackend):
+    __slots__ = ("claim_next_calls", "claim_task_calls", "list_pending_calls")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.claim_next_calls: "list[tuple[str | None, str | None]]" = []
+        self.claim_task_calls: "list[object]" = []
+        self.list_pending_calls: "list[tuple[int, str | None, str | None]]" = []
+
+    async def claim_next(
+        self, *, queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "QueuedTaskRecord | None":
+        self.claim_next_calls.append((queue, execution_backend))
+        records = await InMemoryQueueBackend.list_pending(
+            self, limit=1, queue=queue, execution_backend=execution_backend
+        )
+        if not records:
+            return None
+        return await InMemoryQueueBackend.claim_task(self, records[0].id)
+
+    async def claim_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
+        self.claim_task_calls.append(task_id)
+        return await super().claim_task(task_id)
+
+    async def list_pending(
+        self, *, limit: "int" = 1, queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> 'list["QueuedTaskRecord"]':
+        self.list_pending_calls.append((limit, queue, execution_backend))
+        return await super().list_pending(limit=limit, queue=queue, execution_backend=execution_backend)
+
+
+class _CountingInMemoryQueueBackend(InMemoryQueueBackend):
+    __slots__ = ("list_running_external_calls", "requeue_calls")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.requeue_calls: "list[timedelta]" = []
+        self.list_running_external_calls = 0
+
+    async def list_running_external(self, *, limit: "int | None" = None) -> 'list["QueuedTaskRecord"]':
+        self.list_running_external_calls += 1
+        return await super().list_running_external(limit=limit)
+
+    async def requeue_stale_running(self, *, stale_after: "timedelta") -> "StaleTaskRecoveryResult":
+        self.requeue_calls.append(stale_after)
+        return await super().requeue_stale_running(stale_after=stale_after)
+
+
+class _FailingWorker:
+    __slots__ = ()
+
+    def __init__(self, *_args: "object", **_kwargs: "object") -> "None":
+        pass
+
+    async def start(self) -> "None":
+        msg = "worker boom"
+        raise RuntimeError(msg)
+
+    async def stop(self, *, force: "bool" = False) -> "bool":
+        return False
+
+
+class _TransientRunOnceWorker(Worker):
+    __slots__ = ("recovered", "run_once_calls")
+
+    def __init__(self, service: "QueueService", *, recovered: "asyncio.Event", poll_interval: "float") -> "None":
+        super().__init__(service, poll_interval=poll_interval)
+        self.recovered = recovered
+        self.run_once_calls = 0
+
+    async def run_once(self) -> "int":
+        self.run_once_calls += 1
+        if self.run_once_calls == 1:
+            msg = "transient backend failure"
+            raise RuntimeError(msg)
+        self.recovered.set()
+        await self.stop()
+        return 0

--- a/src/tests/unit/test_worker_events.py
+++ b/src/tests/unit/test_worker_events.py
@@ -22,12 +22,6 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.anyio
 
 
-class FailingSink:
-    async def publish(self, event: "QueueEvent", *, channels: "Sequence[str]") -> "None":
-        msg = "event sink unavailable"
-        raise RuntimeError(msg)
-
-
 async def test_worker_emits_started_progress_and_terminal_events_in_order() -> "None":
     sink = InMemoryQueueEventSink()
 
@@ -43,7 +37,7 @@ async def test_worker_emits_started_progress_and_terminal_events_in_order() -> "
         worker = Worker(service)
 
         assert await worker.run_once() == 1
-        await result.refresh()
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert result.status == "completed"
     assert [event.type for event in sink.events] == ["task.started", "task.progress", "task.completed"]
@@ -66,7 +60,7 @@ async def test_worker_emits_failed_terminal_event_for_failed_attempt() -> "None"
         worker = Worker(service)
 
         assert await worker.run_once() == 1
-        await result.refresh()
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert result.status == "failed"
     assert [event.type for event in sink.events] == ["task.started", "task.failed"]
@@ -184,9 +178,9 @@ async def test_quiet_success_suppresses_success_python_log_but_keeps_lifecycle_e
             quiet_result = await service.enqueue(worker_quiet_success)
             worker = Worker(service)
             assert await worker.run_once() == 1
+            await visible_result.wait(timeout=1, poll_interval=0.01)
             assert await worker.run_once() == 1
-            await visible_result.refresh()
-            await quiet_result.refresh()
+            await quiet_result.wait(timeout=1, poll_interval=0.01)
 
     assert visible_result.status == "completed"
     assert quiet_result.status == "completed"
@@ -213,13 +207,19 @@ async def test_event_publish_failure_does_not_fail_successful_task_by_default() 
         return "ok"
 
     async with QueueService(
-        QueueConfig(execution_backend="local", event_config=QueueEventConfig(enabled=True, sink=FailingSink()))
+        QueueConfig(execution_backend="local", event_config=QueueEventConfig(enabled=True, sink=_FailingSink()))
     ) as service:
         result = await service.enqueue(event_sink_failure)
         worker = Worker(service)
 
         assert await worker.run_once() == 1
-        await result.refresh()
+        await result.wait(timeout=1, poll_interval=0.01)
 
     assert result.status == "completed"
     assert result.result == "ok"
+
+
+class _FailingSink:
+    async def publish(self, event: "QueueEvent", *, channels: "Sequence[str]") -> "None":
+        msg = "event sink unavailable"
+        raise RuntimeError(msg)


### PR DESCRIPTION
## Summary

Fixes #40

- keep the worker loop alive across transient iteration failures and log in-app worker task crashes
- route local worker claims through `claim_next` while preserving external dispatch behavior
- schedule claimed local work without blocking the whole batch so free concurrency slots can refill
- return exit code 2 when graceful drain escalates to cancellation after a single stop signal
- resolve record-level immediate execution overrides correctly when the service default backend is external
- normalize naive `scheduled_at` values for enqueue, bulk enqueue specs, and queued records