### PR TITLE
fix: validate SQLSpec Spanner queue backend

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -260,6 +260,11 @@ ODBC targets still raise ``QueueConfigurationError``. Applications should
 install the SQLSpec adapter driver they configure; Litestar Queues does not
 install every SQLSpec driver as a package dependency.
 
+BigQuery is intentionally unsupported as a queue backend. Its SQLSpec adapter is
+useful for analytical workloads, but BigQuery does not provide the transactional
+and uniqueness behavior expected from Litestar Queues keyed enqueue and claim
+operations.
+
 SQLSpec Capability Matrix
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -371,9 +376,9 @@ advertises, then fall back to the portable path when a capability is absent.
      - ``JSON`` columns with native decoded JSON values.
      - Arrow ``load_from_records`` path.
      - Polling.
-     - Spanner sessions are write-capable by default; the queue store uses
-       ``STRING``/``INT64`` DDL and a ``UNIQUE NULL_FILTERED`` index for
-       ``task_key``.
+     - Spanner sessions are write-capable by default; schema bootstrap uses
+       Spanner's DDL operation API, ``result_json`` is nullable for pending
+       tasks, and ``task_key`` uses a ``UNIQUE NULL_FILTERED`` index.
 
 Additional SQLSpec adapters can be added by implementing a queue store and
 registering it with the SQLSpec store factory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ tests = [
   "pytest-sugar",
   "pytest-xdist",
   # Real-service fixtures for the integration tier
-  "pytest-databases[postgres,mysql,mssql,oracle,redis,valkey,cockroachdb]>=0.19.0",
+  "pytest-databases[postgres,mysql,mssql,oracle,redis,valkey,cockroachdb,spanner]>=0.19.0",
   # Redis + Valkey clients used directly by integration tests
   "redis>=5.0.0",
   "valkey>=6.0.0",

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -178,8 +178,19 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         )
 
     async def create_schema(self) -> "None":
-        """Create the SQLSpec queue table and indexes."""
+        """Create the SQLSpec queue table and indexes.
+
+        Returns:
+            None.
+        """
         if self._manage_schema:
+            store = self._get_store()
+            create_for_config = getattr(store, "create_schema_for_config", None)
+            if callable(create_for_config):
+                result = create_for_config(self._get_sqlspec_config())
+                if isawaitable(result):
+                    await result
+                return
             async with self._session() as driver:
                 for statement in await _create_schema_statements(self._get_store(), driver):
                     await driver.execute_script(statement)
@@ -1042,8 +1053,12 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             msg = "SQLSpecQueueBackend.open() must be called before using the backend."
             raise RuntimeError(msg)
         sqlspec_config = self._get_sqlspec_config()
+        store = self._get_store()
         async with _bridge_session(
-            self._get_or_create_sqlspec(), sqlspec_config, skip_explicit_begin=self._get_store().skip_explicit_begin
+            self._get_or_create_sqlspec(),
+            sqlspec_config,
+            skip_explicit_begin=store.skip_explicit_begin,
+            skip_cleanup_rollback=store.skip_cleanup_rollback,
         ) as driver:
             yield driver
 
@@ -1064,7 +1079,11 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             msg = "SQLSpecQueueBackend.open() must be called before using the backend."
             raise RuntimeError(msg)
         if self._heartbeat_pool_enabled and self._heartbeat_pool_registered and self._heartbeat_pool_config is not None:
-            async with _bridge_session(self._sqlspec, self._heartbeat_pool_config) as driver:
+            async with _bridge_session(
+                self._sqlspec,
+                self._heartbeat_pool_config,
+                skip_cleanup_rollback=self._get_store().skip_cleanup_rollback,
+            ) as driver:
                 yield driver
         else:
             async with self._session() as driver:
@@ -1378,7 +1397,11 @@ class _ManagedAsyncDriver:
 
 @asynccontextmanager
 async def _bridge_session(
-    sqlspec_manager: "Any", sqlspec_config: "Any", *, skip_explicit_begin: "bool" = False
+    sqlspec_manager: "Any",
+    sqlspec_config: "Any",
+    *,
+    skip_explicit_begin: "bool" = False,
+    skip_cleanup_rollback: "bool" = False,
 ) -> "AsyncIterator[Any]":
     """Yield a SQLSpec driver regardless of sync/async config.
 
@@ -1402,12 +1425,12 @@ async def _bridge_session(
         try:
             yield managed_driver
         except BaseException as exc:
-            if not managed_driver.transaction_finalized:
+            if not managed_driver.transaction_finalized and not skip_cleanup_rollback:
                 await _rollback_sync_session(driver, executor=executor)
             if not await async_(session_cm.__exit__, executor=executor)(type(exc), exc, exc.__traceback__):
                 raise
         else:
-            if not managed_driver.transaction_finalized:
+            if not managed_driver.transaction_finalized and not skip_cleanup_rollback:
                 await _rollback_sync_session(driver, executor=executor)
             await async_(session_cm.__exit__, executor=executor)(None, None, None)
         finally:

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -59,6 +59,7 @@ class SQLSpecQueueStore:
     identifier_quote_style: 'ClassVar[Literal["double", "backtick", "none"]]' = "double"
     claim_select_stream_chunk_size: "ClassVar[int | None]" = None
     skip_explicit_begin: "ClassVar[bool]" = False
+    skip_cleanup_rollback: "ClassVar[bool]" = False
     # Per-store opt-in: canonical JSON columns whose driver round-trips
     # native Python values rather than JSON-encoded strings. Subclasses
     # whose drivers register a JSON codec (asyncpg JSONB, psycopg JSONB,

--- a/src/litestar_queues/backends/sqlspec/stores/spanner/store.py
+++ b/src/litestar_queues/backends/sqlspec/stores/spanner/store.py
@@ -2,8 +2,6 @@
 
 from typing import Any, ClassVar, Literal
 
-from sqlspec import sql
-
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore
 
 __all__ = ("SpannerQueueStore",)
@@ -16,6 +14,7 @@ class SpannerQueueStore(SQLSpecQueueStore):
 
     data_dictionary_dialect: "ClassVar[str | None]" = "spanner"
     identifier_quote_style: 'ClassVar[Literal["double", "backtick", "none"]]' = "backtick"
+    skip_cleanup_rollback: "ClassVar[bool]" = True
     auto_native_json_columns: "ClassVar[frozenset[str]]" = frozenset({
         "args_json",
         "kwargs_json",
@@ -23,50 +22,119 @@ class SpannerQueueStore(SQLSpecQueueStore):
         "result_json",
     })
 
+    def create_statements(self) -> "list[str]":
+        """Return statements that create the Spanner queue table and indexes."""
+        if not self._manage_schema:
+            return []
+        return [self._build_create_table_sql(), *self._create_index_statements()]
+
     def drop_statements(self) -> "list[str]":
         """Return statements that drop Spanner queue artifacts."""
         if not self._manage_schema:
             return []
-        return [self._to_sql(sql.drop_index(self._index_name("task_key")).if_exists()), *super().drop_statements()]
+        return [
+            f"DROP INDEX {self._quoted_index_name('task_key')}",
+            f"DROP INDEX {self._quoted_index_name('heartbeat')}",
+            f"DROP INDEX {self._quoted_index_name('pending')}",
+            f"DROP TABLE {self._quoted_table_name()}",
+        ]
 
-    def _create_table_statement(self) -> "Any":
-        return (
-            sql
-            .create_table(self.table_name)
-            .if_not_exists()
-            .column(self._col("id"), self._id_type(), primary_key=True)
-            .column(self._col("task_name"), self._indexed_text_type(), not_null=True)
-            .column(self._col("args_json"), self._payload_json_type("args_json"), not_null=True)
-            .column(self._col("kwargs_json"), self._payload_json_type("kwargs_json"), not_null=True)
-            .column(self._col("queue"), self._indexed_text_type(), not_null=True)
-            .column(self._col("execution_backend"), self._indexed_text_type(), not_null=True)
-            .column(self._col("execution_profile"), self._indexed_text_type())
-            .column(self._col("execution_ref"), self._indexed_text_type())
-            .column(self._col("status"), self._indexed_text_type(), not_null=True)
-            .column(self._col("priority"), self._integer_type(), not_null=True)
-            .column(self._col("max_retries"), self._integer_type(), not_null=True)
-            .column(self._col("retry_count"), self._integer_type(), not_null=True)
-            .column(self._col("scheduled_at"), self._timestamp_type())
-            .column(self._col("created_at"), self._timestamp_type(), not_null=True)
-            .column(self._col("started_at"), self._timestamp_type())
-            .column(self._col("completed_at"), self._timestamp_type())
-            .column(self._col("heartbeat_at"), self._timestamp_type())
-            .column(self._col("result_json"), self._result_json_type("result_json"), not_null=True)
-            .column(self._col("error"), self._error_type())
-            .column(self._col("task_key"), self._indexed_text_type())
-            .column(self._col("metadata_json"), self._metadata_json_type("metadata_json"), not_null=True)
+    def create_schema_for_config(self, config: "Any") -> "None":
+        """Create Spanner schema objects through the native DDL operation API.
+
+        Returns:
+            None.
+        """
+        if not self._manage_schema:
+            return
+        get_database = getattr(config, "get_database", None)
+        if not callable(get_database):
+            msg = "Spanner queue schema creation requires a SQLSpec SpannerSyncConfig."
+            raise TypeError(msg)
+        database = get_database()
+        for statement in self.create_statements():
+            _execute_spanner_ddl(database, statement)
+
+    def serialize_json(self, canonical: "str", value: "Any") -> "Any":
+        """Serialize JSON values as native Spanner JSON parameters.
+
+        Returns:
+            A Spanner JSON parameter value for JSON columns, otherwise a
+            serialized JSON value.
+        """
+        if canonical in self._native_json_columns:
+            from sqlspec.adapters.spanner import spanner_json
+
+            return spanner_json(value)
+        return super().serialize_json(canonical, value)
+
+    def _build_create_table_sql(self) -> "str":
+        columns = (
+            f"{self._quoted_col('id')} {self._id_type()} NOT NULL",
+            f"{self._quoted_col('task_name')} {self._indexed_text_type()} NOT NULL",
+            f"{self._quoted_col('args_json')} {self._payload_json_type('args_json')} NOT NULL",
+            f"{self._quoted_col('kwargs_json')} {self._payload_json_type('kwargs_json')} NOT NULL",
+            f"{self._quoted_col('queue')} {self._indexed_text_type()} NOT NULL",
+            f"{self._quoted_col('execution_backend')} {self._indexed_text_type()} NOT NULL",
+            f"{self._quoted_col('execution_profile')} {self._indexed_text_type()}",
+            f"{self._quoted_col('execution_ref')} {self._indexed_text_type()}",
+            f"{self._quoted_col('status')} {self._indexed_text_type()} NOT NULL",
+            f"{self._quoted_col('priority')} {self._integer_type()} NOT NULL",
+            f"{self._quoted_col('max_retries')} {self._integer_type()} NOT NULL",
+            f"{self._quoted_col('retry_count')} {self._integer_type()} NOT NULL",
+            f"{self._quoted_col('scheduled_at')} {self._timestamp_type()}",
+            f"{self._quoted_col('created_at')} {self._timestamp_type()} NOT NULL",
+            f"{self._quoted_col('started_at')} {self._timestamp_type()}",
+            f"{self._quoted_col('completed_at')} {self._timestamp_type()}",
+            f"{self._quoted_col('heartbeat_at')} {self._timestamp_type()}",
+            f"{self._quoted_col('result_json')} {self._result_json_type('result_json')}",
+            f"{self._quoted_col('error')} {self._error_type()}",
+            f"{self._quoted_col('task_key')} {self._indexed_text_type()}",
+            f"{self._quoted_col('metadata_json')} {self._metadata_json_type('metadata_json')} NOT NULL",
         )
+        column_sql = ",\n  ".join(columns)
+        return f"CREATE TABLE {self._quoted_table_name()} (\n  {column_sql}\n) PRIMARY KEY ({self._quoted_col('id')})"
 
     def _create_index_statements(self) -> "list[str]":
-        statements = super()._create_index_statements()
-        statements.append(
-            f"CREATE UNIQUE NULL_FILTERED INDEX IF NOT EXISTS {self._quoted_index_name('task_key')} "
-            f"ON {self._quoted_table_name()} ({self._quoted_col('task_key')})"
-        )
-        return statements
+        return [
+            (
+                f"CREATE INDEX {self._quoted_index_name('pending')} ON {self._quoted_table_name()} "
+                f"({self._quoted_col('status')}, {self._quoted_col('queue')}, "
+                f"{self._quoted_col('execution_backend')}, {self._quoted_col('scheduled_at')}, "
+                f"{self._quoted_col('priority')}, {self._quoted_col('created_at')})"
+            ),
+            (
+                f"CREATE INDEX {self._quoted_index_name('heartbeat')} ON {self._quoted_table_name()} "
+                f"({self._quoted_col('status')}, {self._quoted_col('heartbeat_at')})"
+            ),
+            (
+                f"CREATE UNIQUE NULL_FILTERED INDEX {self._quoted_index_name('task_key')} "
+                f"ON {self._quoted_table_name()} ({self._quoted_col('task_key')})"
+            ),
+        ]
 
     def _string_type(self, length: "int | None" = None) -> "str":
         return "STRING(MAX)" if length is None else f"STRING({length})"
 
     def _integer_type(self) -> "str":
         return "INT64"
+
+    def _timestamp_type(self) -> "str":
+        return "TIMESTAMP"
+
+
+def _is_spanner_already_exists_error(exc: "Exception") -> "bool":
+    try:
+        from google.api_core.exceptions import AlreadyExists
+    except ImportError:
+        return "already exists" in str(exc).lower()
+    return isinstance(exc, AlreadyExists) or "already exists" in str(exc).lower()
+
+
+def _execute_spanner_ddl(database: "Any", statement: "str") -> "None":
+    try:
+        database.update_ddl([statement]).result()
+    except Exception as exc:
+        if _is_spanner_already_exists_error(exc):
+            return
+        raise

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -17,6 +17,7 @@ pytest_plugins = [
     "pytest_databases.docker.mssql",
     "pytest_databases.docker.oracle",
     "pytest_databases.docker.mssql",
+    "pytest_databases.docker.spanner",
     "pytest_databases.docker.redis",
     "pytest_databases.docker.valkey",
 ]

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -685,8 +685,46 @@ def test_sqlspec_spanner_store_uses_spanner_ddl_and_native_json_columns() -> "No
     assert isinstance(store, SpannerQueueStore)
     assert "STRING(64)" in ddl
     assert "INT64" in ddl
+    assert "TIMESTAMP" in ddl
+    assert "IF NOT EXISTS" not in ddl
+    assert "PRIMARY KEY (`id`)" in ddl
+    assert "`result_json` JSON NOT NULL" not in ddl
+    assert "`metadata_json` JSON NOT NULL" in ddl
     assert "CREATE UNIQUE NULL_FILTERED INDEX" in ddl
     assert store._native_json_columns == frozenset({"args_json", "kwargs_json", "metadata_json", "result_json"})
+    assert type(store.serialize_json("result_json", None)).__name__ == "JsonObject"
+    assert type(store.serialize_json("metadata_json", {"source": "spanner"})).__name__ == "JsonObject"
+
+
+async def test_sqlspec_backend_uses_spanner_update_ddl_for_schema_bootstrap() -> "None":
+    class FakeOperation:
+        def result(self) -> "None":
+            return None
+
+    class FakeDatabase:
+        def __init__(self) -> "None":
+            self.statement_batches: "list[tuple[str, ...]]" = []
+
+        def update_ddl(self, ddl_statements: "list[str]") -> "FakeOperation":
+            self.statement_batches.append(tuple(ddl_statements))
+            return FakeOperation()
+
+    database = FakeDatabase()
+    config = _fake_adapter_config("spanner", dialect="spanner", config_type_name="SpannerSyncConfig")
+    config.get_database = lambda: database
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(config=config, table_name="queue_tasks", notifications=False)
+    )
+
+    await backend.open()
+    await backend.close()
+
+    assert database.statement_batches
+    assert all(len(batch) == 1 for batch in database.statement_batches)
+    statements = [statement for batch in database.statement_batches for statement in batch]
+    assert statements == create_queue_store(config, table_name="queue_tasks").create_statements()
+    assert "PRIMARY KEY (`id`)" in statements[0]
+    assert all("IF NOT EXISTS" not in statement for statement in statements)
 
 
 @pytest.mark.parametrize(
@@ -784,6 +822,17 @@ async def test_sqlspec_sync_bridge_can_skip_explicit_begin_for_driver_managed_tr
     assert manager.driver.begin_count == 0
     assert manager.driver.commit_count == 1
     assert manager.driver.rollback_count == 0
+
+
+async def test_sqlspec_sync_bridge_can_skip_cleanup_rollback_for_driver_owned_sessions() -> "None":
+    """Some sync drivers own cleanup in their session context manager."""
+    manager = _FakeSyncSQLSpec()
+
+    async with _bridge_session(manager, _FakeSyncConfig(), skip_cleanup_rollback=True) as driver:
+        assert await driver.select("SELECT 1") == []
+
+    assert manager.driver.rollback_count == 0
+    assert manager.session.exit_count == 1
 
 
 @pytest.mark.parametrize(

--- a/src/tests/integration/backends/sqlspec/test_spanner_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_spanner_contract.py
@@ -1,6 +1,8 @@
 """Optional live contract coverage for the SQLSpec Spanner backend."""
 
 import os
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -9,37 +11,46 @@ pytest.importorskip("google.cloud.spanner_v1")
 
 from google.api_core.exceptions import GoogleAPICallError
 from google.auth.exceptions import DefaultCredentialsError
+from google.cloud import spanner
 from sqlspec.adapters.spanner import SpannerSyncConfig
 
 from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueBackend
+from tests.integration._names import table_name_for_test
+
+if TYPE_CHECKING:
+    from pytest_databases.docker.spanner import SpannerService
 
 pytestmark = pytest.mark.anyio
 
 _SPANNER_ENV_VARS = ("SPANNER_PROJECT", "SPANNER_INSTANCE", "SPANNER_DATABASE")
 
 
-def _spanner_connection_config() -> "dict[str, object]":
-    missing = [name for name in _SPANNER_ENV_VARS if not os.getenv(name)]
-    if missing:
-        joined = ", ".join(missing)
-        pytest.skip(f"Spanner live test requires {joined} to be set")
-    return {
-        "project": os.environ["SPANNER_PROJECT"],
-        "instance_id": os.environ["SPANNER_INSTANCE"],
-        "database_id": os.environ["SPANNER_DATABASE"],
-    }
-
-
 async def test_sqlspec_spanner_backend_live_contract_round_trip() -> "None":
+    try:
+        await _run_spanner_contract(
+            _spanner_env_connection_config(), table_name=table_name_for_test("litestar_queue_spanner", "live", __name__)
+        )
+    except (DefaultCredentialsError, GoogleAPICallError, OSError) as exc:
+        pytest.skip(f"Spanner live test unavailable: {exc}")
+
+
+async def test_sqlspec_spanner_backend_emulator_contract_round_trip(spanner_service: "SpannerService") -> "None":
+    _ensure_spanner_emulator_database(spanner_service)
+    await _run_spanner_contract(
+        _spanner_emulator_connection_config(spanner_service),
+        table_name=table_name_for_test("litestar_queue_spanner", "emulator", __name__),
+    )
+
+
+async def _run_spanner_contract(connection_config: "dict[str, object]", *, table_name: "str") -> "None":
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(config=SpannerSyncConfig(connection_config=_spanner_connection_config()))
+        backend_config=SQLSpecBackendConfig(
+            config=SpannerSyncConfig(connection_config=connection_config, driver_features={"timeout": 30.0}),
+            table_name=table_name,
+        )
     )
     try:
-        try:
-            await backend.open()
-        except (DefaultCredentialsError, GoogleAPICallError, OSError) as exc:
-            pytest.skip(f"Spanner live test unavailable: {exc}")
-
+        await backend.open()
         record = await backend.enqueue("tasks.spanner.live", kwargs={"ok": True}, metadata={"source": "live"})
         claimed = await backend.claim_task(record.id)
         assert claimed is not None
@@ -54,3 +65,56 @@ async def test_sqlspec_spanner_backend_live_contract_round_trip() -> "None":
         assert stored.result == {"done": True}
     finally:
         await backend.close()
+
+
+def _spanner_env_connection_config() -> "dict[str, object]":
+    missing = [name for name in _SPANNER_ENV_VARS if not os.getenv(name)]
+    if missing:
+        joined = ", ".join(missing)
+        pytest.skip(f"Spanner live test requires {joined} to be set")
+    return {
+        "project": os.environ["SPANNER_PROJECT"],
+        "instance_id": os.environ["SPANNER_INSTANCE"],
+        "database_id": os.environ["SPANNER_DATABASE"],
+        "disable_builtin_metrics": True,
+    }
+
+
+def _spanner_emulator_connection_config(spanner_service: "SpannerService") -> "dict[str, object]":
+    return {
+        "project": spanner_service.project,
+        "instance_id": spanner_service.instance_name,
+        "database_id": spanner_service.database_name,
+        "credentials": spanner_service.credentials,
+        "client_options": spanner_service.client_options,
+        "disable_builtin_metrics": True,
+    }
+
+
+def _ensure_spanner_emulator_database(spanner_service: "SpannerService") -> "None":
+    from google.api_core.exceptions import AlreadyExists
+
+    client = cast(
+        "Any",
+        spanner.Client(
+            project=spanner_service.project,
+            credentials=spanner_service.credentials,
+            client_options=spanner_service.client_options,
+            disable_builtin_metrics=True,
+        ),
+    )
+    try:
+        instance = client.instance(
+            spanner_service.instance_name,
+            configuration_name="emulator-config",
+            display_name=spanner_service.instance_name,
+            node_count=1,
+        )
+        with suppress(AlreadyExists):
+            instance.create().result()
+
+        database = instance.database(spanner_service.database_name)
+        with suppress(AlreadyExists):
+            database.create().result()
+    finally:
+        client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1621,7 +1621,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extra = ["cockroachdb", "oracle", "postgres", "redis", "valkey"] },
+    { name = "pytest-databases", extra = ["cockroachdb", "oracle", "postgres", "redis", "spanner", "valkey"] },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -1670,7 +1670,7 @@ tests = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extra = ["cockroachdb", "oracle", "postgres", "redis", "valkey"] },
+    { name = "pytest-databases", extra = ["cockroachdb", "oracle", "postgres", "redis", "spanner", "valkey"] },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -1709,7 +1709,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extras = ["postgres", "mysql", "mssql", "oracle", "redis", "valkey", "cockroachdb"], specifier = ">=0.19.0" },
+    { name = "pytest-databases", extras = ["postgres", "mysql", "mssql", "oracle", "redis", "valkey", "cockroachdb", "spanner"], specifier = ">=0.19.0" },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -1748,7 +1748,7 @@ tests = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extras = ["postgres", "mysql", "mssql", "oracle", "redis", "valkey", "cockroachdb"], specifier = ">=0.19.0" },
+    { name = "pytest-databases", extras = ["postgres", "mysql", "mssql", "oracle", "redis", "valkey", "cockroachdb", "spanner"], specifier = ">=0.19.0" },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -3351,6 +3351,9 @@ postgres = [
 ]
 redis = [
     { name = "redis" },
+]
+spanner = [
+    { name = "google-cloud-spanner" },
 ]
 valkey = [
     { name = "valkey" },


### PR DESCRIPTION
Summary:
- route Spanner queue schema bootstrap through Spanner native DDL operations
- bind queue JSON columns with Spanner native JSON parameters and allow pending result_json to be null
- add emulator-backed Spanner contract coverage while keeping env-backed live coverage
- document that BigQuery is intentionally unsupported for queue workloads

Closes #16.

Validation:
- make lint
- uv run pytest src/tests/integration/backends/sqlspec/test_contract.py -k "spanner or sync_bridge" -q
- uv run pytest src/tests/integration/backends/sqlspec/test_spanner_contract.py -q