### PR TITLE
fix: lazy-load redis and valkey clients

### DIFF
--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -14,8 +14,6 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 from uuid import UUID, uuid4
 
-from redis import asyncio as redis_asyncio
-
 from litestar_queues.backends.base import BaseQueueBackend
 from litestar_queues.backends.redis.config import RedisBackendConfig as _RedisBackendConfig
 from litestar_queues.exceptions import QueueError
@@ -485,6 +483,8 @@ class RedisQueueBackend(BaseQueueBackend):
             await _close_pubsub(pubsub, self._notification_channel)
 
     def _create_client(self, url: "str") -> "Any":
+        from redis import asyncio as redis_asyncio
+
         return redis_asyncio.from_url(url, decode_responses=True)
 
     async def _get_client(self) -> "Any":

--- a/src/litestar_queues/backends/valkey/backend.py
+++ b/src/litestar_queues/backends/valkey/backend.py
@@ -9,8 +9,6 @@ and the ``valkey-pubsub`` notification capability label.
 
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from valkey import asyncio as valkey_asyncio
-
 from litestar_queues.backends.redis.backend import RedisQueueBackend
 from litestar_queues.backends.valkey.config import ValkeyBackendConfig
 
@@ -32,5 +30,7 @@ class ValkeyQueueBackend(RedisQueueBackend):
         super().__init__(config=config, backend_config=cast("Any", backend_config))
 
     def _create_client(self, url: "str") -> "Any":
+        from valkey import asyncio as valkey_asyncio
+
         from_url = cast("Any", valkey_asyncio.from_url)
         return from_url(url, decode_responses=True)

--- a/src/tests/unit/backends/test_valkey_import_boundary.py
+++ b/src/tests/unit/backends/test_valkey_import_boundary.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+
+
+def test_valkey_backend_import_does_not_require_redis() -> "None":
+    """Importing ``ValkeyQueueBackend`` must not require the redis client package."""
+    code = """
+import builtins
+import sys
+import types
+
+valkey = types.ModuleType("valkey")
+valkey.__path__ = []
+valkey_asyncio = types.ModuleType("valkey.asyncio")
+
+def from_url(url, decode_responses=True):
+    return object()
+
+valkey_asyncio.from_url = from_url
+valkey.asyncio = valkey_asyncio
+sys.modules["valkey"] = valkey
+sys.modules["valkey.asyncio"] = valkey_asyncio
+
+original_import = builtins.__import__
+
+def blocked_import(name, *args, **kwargs):
+    if name == "redis" or name.startswith("redis."):
+        raise ModuleNotFoundError(name)
+    return original_import(name, *args, **kwargs)
+
+builtins.__import__ = blocked_import
+
+from litestar_queues.backends.valkey import ValkeyBackendConfig, ValkeyQueueBackend
+
+assert "redis" not in sys.modules
+assert ValkeyBackendConfig(url="redis://example").url == "redis://example"
+assert ValkeyQueueBackend.__name__ == "ValkeyQueueBackend"
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, check=False, text=True)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- lazy-load Redis and Valkey client imports when a backend client is created
- keep the Valkey backend importable without the Redis package installed
- add a subprocess import-boundary regression test for the standalone Valkey path

Closes #44.

## Validation
- `uv run pytest src/tests/unit/backends/test_valkey_import_boundary.py -q`
- `make lint`