### PR TITLE
fix: register SQLSpec queue migrations without mutating caller config

### DIFF
--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -3,6 +3,7 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable
 from logging import getLogger
@@ -200,8 +201,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         """Apply packaged SQLSpec migrations."""
         if self._manage_schema:
             sqlspec_config = self._get_sqlspec_config()
-            configure_queue_migration_extension(sqlspec_config, table_name=self._resolve_table_name())
-            await sqlspec_config.migrate_up(echo=False)
+            with _temporary_queue_migration_extension(sqlspec_config, table_name=self._resolve_table_name()):
+                await sqlspec_config.migrate_up(echo=False)
 
     async def enqueue(
         self,
@@ -1524,6 +1525,26 @@ def _queue_extension_settings(sqlspec_config: "Any | None") -> "dict[str, Any]":
         return {}
     extension_config = cast("dict[str, Any]", getattr(sqlspec_config, "extension_config", {}) or {})
     return dict(cast("dict[str, Any]", extension_config.get(QUEUE_EXTENSION_NAME, {}) or {}))
+
+
+@contextmanager
+def _temporary_queue_migration_extension(sqlspec_config: "Any", *, table_name: "str") -> "Iterator[None]":
+    original_extension_config = deepcopy(cast("dict[str, Any]", getattr(sqlspec_config, "extension_config", {}) or {}))
+    original_migration_config = deepcopy(cast("dict[str, Any]", getattr(sqlspec_config, "migration_config", {}) or {}))
+
+    extension_config = deepcopy(original_extension_config)
+    queue_settings = dict(cast("dict[str, Any]", extension_config.get(QUEUE_EXTENSION_NAME, {}) or {}))
+    queue_settings["table_name"] = validate_table_name(table_name)
+    extension_config[QUEUE_EXTENSION_NAME] = queue_settings
+
+    sqlspec_config.extension_config = extension_config
+    sqlspec_config.set_migration_config(deepcopy(original_migration_config))
+    configure_queue_migration_extension(sqlspec_config, table_name=table_name)
+    try:
+        yield
+    finally:
+        sqlspec_config.extension_config = original_extension_config
+        sqlspec_config.set_migration_config(original_migration_config)
 
 
 async def _create_schema_statements(store: "Any", driver: "Any") -> "list[str]":

--- a/src/litestar_queues/backends/sqlspec/extension.py
+++ b/src/litestar_queues/backends/sqlspec/extension.py
@@ -35,20 +35,4 @@ def _configure_extension_settings(sqlspec_config: "Any", *, table_name: "str") -
     extension_config = dict(cast("dict[str, Any]", getattr(sqlspec_config, "extension_config", {}) or {}))
     queue_settings = dict(cast("dict[str, Any]", extension_config.get(QUEUE_EXTENSION_NAME, {}) or {}))
     queue_settings["table_name"] = validate_table_name(table_name)
-    extension_config[QUEUE_EXTENSION_NAME] = queue_settings
-    sqlspec_config.extension_config = extension_config
-
-    migration_config = dict(cast("dict[str, Any]", getattr(sqlspec_config, "migration_config", {}) or {}))
-    include_extensions = migration_config.get("include_extensions")
-    if include_extensions is None:
-        include_list: "list[str]" = []
-    elif isinstance(include_extensions, tuple):
-        include_list = list(include_extensions)
-    else:
-        include_list = list(cast("list[str]", include_extensions))
-
-    if QUEUE_EXTENSION_NAME not in include_list:
-        include_list.append(QUEUE_EXTENSION_NAME)
-    migration_config["include_extensions"] = include_list
-    sqlspec_config.set_migration_config(migration_config)
     return queue_settings

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -11,8 +11,10 @@ Two flavours of tests live here:
 """
 
 import asyncio
+import logging
 import sqlite3
 import sys
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from subprocess import run
 from types import SimpleNamespace
@@ -1113,6 +1115,31 @@ async def test_sqlspec_backend_can_start_with_packaged_migrations(
         versions = [row[0] for row in connection.execute("SELECT version_num FROM ddl_migrations")]
 
     assert versions == ["ext_litestar_queues_0001"]
+
+
+async def test_sqlspec_backend_packaged_migrations_do_not_mutate_adopter_config(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory", caplog: "pytest.LogCaptureFixture"
+) -> "None":
+    db_path = tmp_path / "migrated-config.db"
+    sqlspec_config = sqlite_config_factory(db_path)
+    original_extension_config = deepcopy(sqlspec_config.extension_config)
+    original_migration_config = deepcopy(sqlspec_config.migration_config)
+
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, create_schema=False, run_migrations=True)
+    )
+
+    caplog.set_level(logging.WARNING, logger="sqlspec.migrations.base")
+    await backend.open()
+    try:
+        record = await backend.enqueue("tasks.migrated_config")
+    finally:
+        await backend.close()
+
+    assert record.task_name == "tasks.migrated_config"
+    assert not any("Extension litestar_queues not found" in entry.message for entry in caplog.records)
+    assert deepcopy(sqlspec_config.extension_config) == original_extension_config
+    assert deepcopy(sqlspec_config.migration_config) == original_migration_config
 
 
 async def test_sqlspec_backend_uses_configured_table_name(


### PR DESCRIPTION
This fixes SQLSpec queue migration startup so opening the backend with `run_migrations=True` no longer logs `Extension litestar_queues not found` and no longer mutates the caller's config.

What changed:
- stop adding `litestar_queues` to `include_extensions`
- inject the queue migration path/settings into the constructed SQLSpec commands/runner
- add a regression test for the warning and config-mutation behavior

Verification:
- `uv run pytest src/tests/integration/backends/sqlspec/test_contract.py::test_sqlspec_backend_can_start_with_packaged_migrations src/tests/integration/backends/sqlspec/test_contract.py::test_sqlspec_backend_packaged_migrations_do_not_mutate_adopter_config src/tests/integration/backends/sqlspec/test_contract.py::test_sqlspec_backend_uses_structured_extension_config_when_explicit_values_are_absent src/tests/integration/backends/sqlspec/test_contract.py::test_sqlspec_backend_explicit_config_values_override_sqlspec_extension_config -q`

Closes #43