### PR TITLE
fix: quote SQLSpec schema-qualified queue tables

### DIFF
--- a/src/litestar_queues/backends/sqlspec/stores/_families.py
+++ b/src/litestar_queues/backends/sqlspec/stores/_families.py
@@ -147,7 +147,7 @@ class PostgresQueueStore(SQLSpecQueueStore):
         """Return statements that create Postgres-family queue artifacts."""
         if not self._manage_schema:
             return []
-        create_table = self._to_sql(self._create_table_statement())
+        create_table = self._create_table_sql()
         if type(self).table_storage_parameters:
             create_table = f"{create_table} WITH (fillfactor = 80)"
         statements = [create_table, *self._create_index_statements()]

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -133,7 +133,7 @@ class SQLSpecQueueStore:
         """Return statements that create the queue table and indexes."""
         if not self._manage_schema:
             return []
-        return [self._to_sql(self._create_table_statement()), *self._create_index_statements()]
+        return [self._create_table_sql(), *self._create_index_statements()]
 
     def drop_statements(self) -> "list[str]":
         """Return statements that drop queue artifacts."""
@@ -572,6 +572,14 @@ class SQLSpecQueueStore:
             .column(self._col("metadata_json"), self._metadata_json_type("metadata_json"), not_null=True)
         )
 
+    def _create_table_sql(self) -> "str":
+        rendered = self._to_sql(self._create_table_statement())
+        unsplit_target = self._quote_unsplit_identifier(self.table_name)
+        split_target = self._quoted_table_name()
+        if unsplit_target != split_target:
+            rendered = rendered.replace(unsplit_target, split_target, 1)
+        return rendered
+
     def _create_index_statements(self) -> "list[str]":
         return [
             self._to_sql(
@@ -680,6 +688,12 @@ class SQLSpecQueueStore:
 
     def _quoted_col(self, canonical: "str") -> "str":
         return self._quote_identifier(self._col(canonical))
+
+    def _quote_unsplit_identifier(self, identifier: "str") -> "str":
+        if type(self).identifier_quote_style == "none":
+            return identifier
+        quote = quote_backtick_identifier if type(self).identifier_quote_style == "backtick" else quote_identifier
+        return quote(identifier)
 
     def _quote_identifier(self, identifier: "str") -> "str":
         if type(self).identifier_quote_style == "none":

--- a/src/tests/integration/backends/sqlspec/test_schema_quoting.py
+++ b/src/tests/integration/backends/sqlspec/test_schema_quoting.py
@@ -1,0 +1,39 @@
+"""SQLSpec schema-qualified table quoting regression test."""
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+pytest.importorskip("sqlspec")
+
+from litestar_queues.backends.sqlspec.stores import create_queue_store
+
+
+class FakeSQLSpecConfig(SimpleNamespace):
+    """Structural SQLSpec config used by the quoting regression test."""
+
+    extension_config: "dict[str, object]"
+    statement_config: "SimpleNamespace"
+    connection_config: "dict[str, object]"
+
+
+def test_sqlspec_queue_store_create_statements_split_schema_qualified_table_name() -> "None":
+    """CREATE TABLE must quote schema and table as separate identifiers."""
+    store = create_queue_store(_fake_postgres_config(), table_name="app.litestar_queue_task")
+
+    ddl = "\n".join(store.create_statements())
+
+    assert 'CREATE TABLE IF NOT EXISTS "app"."litestar_queue_task"' in ddl
+
+
+def _fake_postgres_config() -> "FakeSQLSpecConfig":
+    config_type = cast(
+        "type[FakeSQLSpecConfig]",
+        type("FakeAsyncpgConfig", (FakeSQLSpecConfig,), {"__module__": "sqlspec.adapters.asyncpg.config"}),
+    )
+    config = config_type()
+    config.extension_config = {}
+    config.statement_config = SimpleNamespace(dialect="postgres")
+    config.connection_config = {}
+    return config


### PR DESCRIPTION
Summary: Render SQLSpec schema-qualified queue table names as separate quoted identifiers during CREATE TABLE, including Postgres-family store overrides. Validation: uv run pytest src/tests/integration/backends/sqlspec/test_schema_quoting.py -q; make lint. Closes #47.