### PR TITLE
feat: add cooperative queue cancellation

### DIFF
--- a/docs/usage/tasks.rst
+++ b/docs/usage/tasks.rst
@@ -106,6 +106,18 @@ Unhandled exceptions retry until ``max_retries`` is exhausted. Raise
 ``NonRetryableError`` or use the ``non_retryable`` helper when a failure should
 move directly to the terminal ``failed`` state.
 
+Cancellation
+============
+
+Use ``job_cancelled("message")`` from inside a task when the task detects a
+domain cancellation and should stop without retrying. The worker marks the
+record ``cancelled`` and emits ``task.cancelled``.
+
+Backends also expose ``cancel_tasks(...)`` for exact top-level predicate
+cancellation across pending and scheduled records. Pass ``include_running=True``
+when the caller is intentionally cancelling running records that cooperate with
+``job_cancelled``.
+
 Background Tasks
 ================
 

--- a/src/litestar_queues/__init__.py
+++ b/src/litestar_queues/__init__.py
@@ -41,10 +41,12 @@ if TYPE_CHECKING:
         require_current_task_context,
     )
     from litestar_queues.exceptions import (
+        JobCancelledError,
         MissingDependencyError,
         NonRetryableError,
         QueueConfigurationError,
         QueueError,
+        job_cancelled,
         non_retryable,
     )
     from litestar_queues.execution import (
@@ -95,6 +97,7 @@ _EXPORTS = {
     "InMemoryQueueEventSink": "litestar_queues.events",
     "LocalExecutionBackend": "litestar_queues.execution",
     "MissingDependencyError": "litestar_queues.exceptions",
+    "JobCancelledError": "litestar_queues.exceptions",
     "NonRetryableError": "litestar_queues.exceptions",
     "NoopQueueEventSink": "litestar_queues.events",
     "QueueBackendCapabilities": "litestar_queues.models",
@@ -134,6 +137,7 @@ _EXPORTS = {
     "list_execution_backends": "litestar_queues.execution",
     "list_queue_backends": "litestar_queues.backends",
     "load_task_modules": "litestar_queues.task",
+    "job_cancelled": "litestar_queues.exceptions",
     "non_retryable": "litestar_queues.exceptions",
     "publish_task_event": "litestar_queues.events",
     "publish_task_log": "litestar_queues.events",
@@ -156,6 +160,7 @@ __all__ = (
     "ImmediateExecutionBackend",
     "InMemoryQueueBackend",
     "InMemoryQueueEventSink",
+    "JobCancelledError",
     "LocalExecutionBackend",
     "MissingDependencyError",
     "NonRetryableError",
@@ -194,6 +199,7 @@ __all__ = (
     "get_queue_backend_class",
     "get_scheduled_tasks",
     "get_task_registry",
+    "job_cancelled",
     "list_execution_backends",
     "list_queue_backends",
     "load_task_modules",

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -13,7 +13,7 @@ from litestar_queues.backends.base import BaseQueueBackend
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping
     from datetime import datetime, timedelta
     from uuid import UUID
 
@@ -158,9 +158,23 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         async with self._operation() as service:
             return await service.fail_task(task_id, error, retry=retry, expected_retry_count=expected_retry_count)
 
-    async def cancel_task(self, task_id: "UUID") -> "bool":
+    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         async with self._operation() as service:
-            return await service.cancel_task(task_id)
+            return await service.cancel_task(task_id, include_running=include_running)
+
+    async def cancel_tasks(
+        self,
+        *,
+        task_name: "str | None" = None,
+        queue: "str | None" = None,
+        kwargs: "Mapping[str, Any] | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
+        include_running: "bool" = False,
+    ) -> "int":
+        async with self._operation() as service:
+            return await service.cancel_tasks(
+                task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata, include_running=include_running
+            )
 
     async def touch_heartbeat(self, task_id: "UUID", *, expected_retry_count: "int | None" = None) -> "bool":
         async with self._heartbeat_operation() as service:

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -13,9 +13,12 @@ from sqlalchemy import inspect as sqlalchemy_inspect
 from sqlalchemy.orm.exc import UnmappedColumnError
 
 from litestar_queues.backends.advanced_alchemy.repository import QueueTaskRepository
+from litestar_queues.backends.base import record_matches_filters
 from litestar_queues.models import QueuedTaskRecord, QueueStatistics, StaleTaskRecoveryResult, TaskStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
 
 __all__ = ("QueueTaskService",)
@@ -244,15 +247,44 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         updated = await self._select_task(task_id)
         return self.record_from_model(updated) if updated is not None else None
 
-    async def cancel_task(self, task_id: "UUID") -> "bool":
+    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         model_type = self.model_type
         now = _utc_now()
+        cancellable_statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
         result = await self.repository.session.execute(
             update(model_type)
-            .where(model_type.id == task_id, model_type.status.in_(_DUE_STATUSES))
-            .values(_update_values(model_type, {"status": "cancelled", "completed_at": now}, now=now))
+            .where(model_type.id == task_id, model_type.status.in_(cancellable_statuses))
+            .values(
+                _update_values(model_type, {"status": "cancelled", "completed_at": now, "heartbeat_at": None}, now=now)
+            )
         )
         return int(result.rowcount or 0) == 1
+
+    async def cancel_tasks(
+        self,
+        *,
+        task_name: "str | None" = None,
+        queue: "str | None" = None,
+        kwargs: "Mapping[str, Any] | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
+        include_running: "bool" = False,
+    ) -> "int":
+        model_type = self.model_type
+        cancellable_statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
+        criteria = [model_type.status.in_(cancellable_statuses)]
+        if task_name is not None:
+            criteria.append(model_type.task_name == task_name)
+        if queue is not None:
+            criteria.append(model_type.queue == queue)
+        models = (await self.repository.session.execute(select(model_type).where(*criteria))).scalars().all()
+        cancelled = 0
+        for model in models:
+            record = self.record_from_model(model)
+            if not record_matches_filters(record, task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata):
+                continue
+            if await self.cancel_task(record.id, include_running=include_running):
+                cancelled += 1
+        return cancelled
 
     async def touch_heartbeat(self, task_id: "UUID", *, expected_retry_count: "int | None" = None) -> "bool":
         model_type = self.model_type

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -6,7 +6,7 @@ from typing_extensions import Self
 from litestar_queues.models import QueueBackendCapabilities, QueueStatistics, StaleTaskRecoveryResult
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
     from datetime import datetime, timedelta
     from types import TracebackType
     from uuid import UUID
@@ -146,8 +146,39 @@ class BaseQueueBackend:
         """
         raise NotImplementedError
 
-    async def cancel_task(self, task_id: "UUID") -> "bool":
-        """Cancel a task if it has not started."""
+    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+        """Cancel a task.
+
+        Args:
+            task_id: Queue record identifier.
+            include_running: When true, cancel a running task as part of a
+                cooperative cancellation path. Default behavior only cancels
+                pending or scheduled records.
+        """
+        raise NotImplementedError
+
+    async def cancel_tasks(
+        self,
+        *,
+        task_name: "str | None" = None,
+        queue: "str | None" = None,
+        kwargs: "Mapping[str, Any] | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
+        include_running: "bool" = False,
+    ) -> "int":
+        """Cancel tasks matching a domain predicate.
+
+        Args:
+            task_name: Optional task name exact match.
+            queue: Optional queue exact match.
+            kwargs: Optional top-level kwargs exact-match subset.
+            metadata: Optional top-level metadata exact-match subset.
+            include_running: When true, running records are included for
+                cooperative cancellation.
+
+        Returns:
+            Number of records cancelled.
+        """
         raise NotImplementedError
 
     async def touch_heartbeat(self, task_id: "UUID", *, expected_retry_count: "int | None" = None) -> "bool":
@@ -253,3 +284,24 @@ class BaseQueueBackend:
         exc_tb: "TracebackType | None",  # noqa: PYI036
     ) -> "None":
         await self.close()
+
+
+def record_matches_filters(
+    record: "QueuedTaskRecord",
+    *,
+    task_name: "str | None" = None,
+    queue: "str | None" = None,
+    kwargs: "Mapping[str, Any] | None" = None,
+    metadata: "Mapping[str, Any] | None" = None,
+) -> "bool":
+    if task_name is not None and record.task_name != task_name:
+        return False
+    if queue is not None and record.queue != queue:
+        return False
+    if kwargs is not None and not _contains_items(record.kwargs, kwargs):
+        return False
+    return metadata is None or _contains_items(record.metadata, metadata)
+
+
+def _contains_items(source: "Mapping[str, Any]", expected: "Mapping[str, Any]") -> "bool":
+    return all(source.get(key) == value for key, value in expected.items())

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -2,10 +2,11 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
-from litestar_queues.backends.base import BaseQueueBackend
+from litestar_queues.backends.base import BaseQueueBackend, record_matches_filters
 from litestar_queues.models import QueueBackendCapabilities, QueuedTaskRecord, QueueStatistics, StaleTaskRecoveryResult
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from uuid import UUID
 
     from litestar_queues.config import QueueConfig
@@ -154,14 +155,41 @@ class InMemoryQueueBackend(BaseQueueBackend):
             record.heartbeat_at = now
             return record
 
-    async def cancel_task(self, task_id: "UUID") -> "bool":
+    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         async with self._lock:
             record = self._records.get(task_id)
-            if record is None or record.status not in {"pending", "scheduled"}:
+            cancellable_statuses = {"pending", "scheduled", "running"} if include_running else {"pending", "scheduled"}
+            if record is None or record.status not in cancellable_statuses:
                 return False
             record.status = "cancelled"
             record.completed_at = _utc_now()
+            record.heartbeat_at = None
             return True
+
+    async def cancel_tasks(
+        self,
+        *,
+        task_name: "str | None" = None,
+        queue: "str | None" = None,
+        kwargs: "Mapping[str, Any] | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
+        include_running: "bool" = False,
+    ) -> "int":
+        cancellable_statuses = {"pending", "scheduled", "running"} if include_running else {"pending", "scheduled"}
+        cancelled = 0
+        async with self._lock:
+            for record in self._records.values():
+                if record.status not in cancellable_statuses:
+                    continue
+                if not record_matches_filters(
+                    record, task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata
+                ):
+                    continue
+                record.status = "cancelled"
+                record.completed_at = _utc_now()
+                record.heartbeat_at = None
+                cancelled += 1
+        return cancelled
 
     async def touch_heartbeat(self, task_id: "UUID", *, expected_retry_count: "int | None" = None) -> "bool":
         record = self._records.get(task_id)

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 from uuid import UUID, uuid4
 
-from litestar_queues.backends.base import BaseQueueBackend
+from litestar_queues.backends.base import BaseQueueBackend, record_matches_filters
 from litestar_queues.backends.redis.config import RedisBackendConfig as _RedisBackendConfig
 from litestar_queues.exceptions import QueueError
 from litestar_queues.models import (
@@ -26,7 +26,7 @@ from litestar_queues.models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterable
+    from collections.abc import AsyncIterator, Iterable, Mapping
 
     from litestar_queues.backends.redis._typing import RedisClientLike, RedisPipelineLike, RedisPubSubLike
     from litestar_queues.config import QueueConfig
@@ -276,20 +276,58 @@ class RedisQueueBackend(BaseQueueBackend):
             await self._save_record(record)
             return record
 
-    async def cancel_task(self, task_id: "UUID") -> "bool":
-        """Cancel a task if it has not started.
+    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+        """Cancel a task.
 
         Returns:
             True when the task was cancelled.
         """
         async with self._lock(f"task:{task_id}", wait=True):
             record = await self.get_task(task_id)
-            if record is None or record.status not in _DUE_STATUSES:
+            cancellable_statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
+            if record is None or record.status not in cancellable_statuses:
                 return False
             record.status = "cancelled"
             record.completed_at = _utc_now()
+            record.heartbeat_at = None
             await self._save_record(record)
             return True
+
+    async def cancel_tasks(
+        self,
+        *,
+        task_name: "str | None" = None,
+        queue: "str | None" = None,
+        kwargs: "Mapping[str, Any] | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
+        include_running: "bool" = False,
+    ) -> "int":
+        """Cancel tasks matching a domain predicate.
+
+        Returns:
+            Number of records cancelled.
+        """
+        statuses = tuple(sorted((*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES))
+        cancelled = 0
+        for record in await self._list_records_by_statuses(statuses):
+            if not record_matches_filters(record, task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata):
+                continue
+            async with self._lock(f"task:{record.id}", wait=True):
+                latest = await self.get_task(record.id)
+                if latest is None:
+                    continue
+                if latest.status not in statuses:
+                    continue
+                if not record_matches_filters(
+                    latest, task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata
+                ):
+                    continue
+                latest.status = "cancelled"
+                latest.completed_at = _utc_now()
+                latest.heartbeat_at = None
+                await self._save_record(latest)
+                cancelled += 1
+        return cancelled
 
     async def touch_heartbeat(self, task_id: "UUID", *, expected_retry_count: "int | None" = None) -> "bool":
         """Update the heartbeat timestamp for a running task.

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -14,7 +14,7 @@ from sqlspec import SQLSpec
 from sqlspec.extensions.events import normalize_event_channel_name, resolve_adapter_name
 from sqlspec.utils.sync_tools import async_
 
-from litestar_queues.backends.base import BaseQueueBackend
+from litestar_queues.backends.base import BaseQueueBackend, record_matches_filters
 from litestar_queues.backends.sqlspec.config import DEFAULT_NOTIFICATION_CHANNEL, SQLSpecBackendConfig
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME, configure_queue_migration_extension
 from litestar_queues.backends.sqlspec.schema import (
@@ -35,7 +35,7 @@ from litestar_queues.models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator, Sequence
+    from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 
     from litestar_queues.backends.sqlspec._typing import (
         SQLSpecConfig,
@@ -550,21 +550,52 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             self._increment_queue_metric("claim_lost")
         return updated_record
 
-    async def cancel_task(self, task_id: "UUID") -> "bool":
+    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         async with self._session() as driver:
             await driver.begin()
             try:
                 result = await driver.execute(
                     self._get_store().cancel_task(
-                        task_id=str(task_id), completed_at=self._serialize_datetime(_utc_now())
+                        task_id=str(task_id),
+                        completed_at=self._serialize_datetime(_utc_now()),
+                        include_running=include_running,
                     )
                 )
+                rows_affected = _rows_affected(result)
+                if rows_affected < 0:
+                    updated_row = await self._select_task(driver, task_id)
+                    cancelled = updated_row is not None and self._record_from_row(updated_row).status == "cancelled"
+                else:
+                    cancelled = rows_affected == 1
                 await driver.commit()
             except Exception:
                 with suppress(Exception):
                     await driver.rollback()
                 raise
-        return int(result.rows_affected) == 1
+        return cancelled
+
+    async def cancel_tasks(
+        self,
+        *,
+        task_name: "str | None" = None,
+        queue: "str | None" = None,
+        kwargs: "Mapping[str, Any] | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
+        include_running: "bool" = False,
+    ) -> "int":
+        store = self._get_store()
+        async with self._session() as driver:
+            rows = await driver.select(
+                store.list_cancellable(include_running=include_running, task_name=task_name, queue=queue)
+            )
+        cancelled = 0
+        for row in cast("list[dict[str, Any]]", rows):
+            record = self._record_from_row(row)
+            if not record_matches_filters(record, task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata):
+                continue
+            if await self.cancel_task(record.id, include_running=include_running):
+                cancelled += 1
+        return cancelled
 
     async def touch_heartbeat(self, task_id: "UUID", *, expected_retry_count: "int | None" = None) -> "bool":
         async with self._heartbeat_session() as driver:

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -346,15 +346,30 @@ class SQLSpecQueueStore:
             )
         return statement
 
-    def cancel_task(self, *, task_id: "str", completed_at: "DatetimeParam") -> "Update":
-        """Return an UPDATE statement that cancels a due task."""
+    def cancel_task(
+        self, *, task_id: "str", completed_at: "DatetimeParam", include_running: "bool" = False
+    ) -> "Update":
+        """Return an UPDATE statement that cancels a due or running task."""
+        statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
         return (
             sql
             .update(self.table_name)
-            .set(**self._mapped_values({"status": "cancelled", "completed_at": completed_at}))
+            .set(**self._mapped_values({"status": "cancelled", "completed_at": completed_at, "heartbeat_at": None}))
             .where_eq(self._col("id"), task_id)
-            .where_in(self._col("status"), _DUE_STATUSES)
+            .where_in(self._col("status"), statuses)
         )
+
+    def list_cancellable(
+        self, *, include_running: "bool" = False, task_name: "str | None" = None, queue: "str | None" = None
+    ) -> "Select":
+        """Return a SELECT statement for task records eligible for cancellation."""
+        statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
+        statement = self._select_all().where_in(self._col("status"), statuses)
+        if task_name is not None:
+            statement = statement.where_eq(self._col("task_name"), task_name)
+        if queue is not None:
+            statement = statement.where_eq(self._col("queue"), queue)
+        return statement
 
     def touch_heartbeat(self, *, task_id: "str", heartbeat_at: "DatetimeParam") -> "Update":
         """Return an UPDATE statement that touches a running task heartbeat."""

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -176,7 +176,7 @@ class QueueConfig:
             QueueEventPublisher,
             TaskExecutionContext,
         )
-        from litestar_queues.exceptions import NonRetryableError, non_retryable
+        from litestar_queues.exceptions import JobCancelledError, NonRetryableError, job_cancelled, non_retryable
         from litestar_queues.execution import (
             BaseExecutionBackend,
             CloudRunExecutionBackend,
@@ -205,6 +205,7 @@ class QueueConfig:
             "InMemoryQueueBackend": InMemoryQueueBackend,
             "LocalExecutionBackend": LocalExecutionBackend,
             "NamedDependency": NamedDependency,
+            "JobCancelledError": JobCancelledError,
             "NonRetryableError": NonRetryableError,
             "NoopQueueEventSink": NoopQueueEventSink,
             "InMemoryQueueEventSink": InMemoryQueueEventSink,
@@ -230,6 +231,7 @@ class QueueConfig:
             "TaskExecutionContext": TaskExecutionContext,
             "TaskResult": TaskResult,
             "Worker": Worker,
+            "job_cancelled": job_cancelled,
             "non_retryable": non_retryable,
         }
         with suppress(ImportError):

--- a/src/litestar_queues/exceptions.py
+++ b/src/litestar_queues/exceptions.py
@@ -1,4 +1,12 @@
-__all__ = ("MissingDependencyError", "NonRetryableError", "QueueConfigurationError", "QueueError", "non_retryable")
+__all__ = (
+    "JobCancelledError",
+    "MissingDependencyError",
+    "NonRetryableError",
+    "QueueConfigurationError",
+    "QueueError",
+    "job_cancelled",
+    "non_retryable",
+)
 
 
 class QueueError(Exception):
@@ -13,6 +21,10 @@ class NonRetryableError(QueueError):
     """Raised by a task to mark the current failure as permanent."""
 
 
+class JobCancelledError(QueueError):
+    """Raised by a task to cooperatively mark itself cancelled."""
+
+
 def non_retryable(message: "str") -> "None":
     """Raise a non-retryable task failure.
 
@@ -20,6 +32,15 @@ def non_retryable(message: "str") -> "None":
         NonRetryableError: Always raised with the provided message.
     """
     raise NonRetryableError(message)
+
+
+def job_cancelled(message: "str" = "Task cancelled") -> "None":
+    """Raise a cooperative task cancellation.
+
+    Raises:
+        JobCancelledError: Always raised with the provided message.
+    """
+    raise JobCancelledError(message)
 
 
 class MissingDependencyError(QueueError, ImportError):

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 from litestar_queues.config import execution_backend_name
 from litestar_queues.events.context import TaskExecutionContext, _bind_task_context, _reset_task_context
 from litestar_queues.events.models import QueueEvent
-from litestar_queues.exceptions import NonRetryableError
+from litestar_queues.exceptions import JobCancelledError, NonRetryableError
 from litestar_queues.execution import get_execution_backend
 from litestar_queues.task import ScheduleConfig, Task, TaskResult, _ensure_utc, get_scheduled_tasks, get_task_registry
 
@@ -267,24 +267,33 @@ class QueueService:
             await task_context.lifecycle("task.cancelled")
             self._log_task_event("Queue task cancelled", record, level=logging.WARNING)
             raise
+        except JobCancelledError as exc:
+            cancelled = await self.get_queue_backend().cancel_task(record.id, include_running=True)
+            if not cancelled:
+                return await self.publish_claim_lost(record, phase="cancel", task_context=task_context)
+            cancelled_record = await self._current_or_claimed(record)
+            payload = {"status": cancelled_record.status, "retry_count": cancelled_record.retry_count}
+            await task_context.lifecycle("task.cancelled", message=str(exc), payload=payload)
+            self._log_task_event("Queue task cancelled", cancelled_record, level=logging.INFO, payload=payload)
+            return cancelled_record
         except NonRetryableError as exc:
-            updated = await self.get_queue_backend().fail_task(
+            failed_record = await self.get_queue_backend().fail_task(
                 record.id, str(exc), retry=False, expected_retry_count=record.retry_count
             )
-            if updated is None:
+            if failed_record is None:
                 return await self.publish_claim_lost(record, phase="fail", task_context=task_context)
-            failed = updated
+            failed = failed_record
             payload = {"status": failed.status, "retry_count": failed.retry_count, "will_retry": False}
             await task_context.lifecycle("task.failed", message=str(exc), payload=payload)
             self._log_task_event("Queue task failed", failed, level=logging.ERROR, payload=payload)
-            return updated
+            return failed_record
         except Exception as exc:
-            updated = await self.get_queue_backend().fail_task(
+            failed_record = await self.get_queue_backend().fail_task(
                 record.id, str(exc), expected_retry_count=record.retry_count
             )
-            if updated is None:
+            if failed_record is None:
                 return await self.publish_claim_lost(record, phase="fail", task_context=task_context)
-            failed = updated
+            failed = failed_record
             payload = {
                 "status": failed.status,
                 "retry_count": failed.retry_count,
@@ -303,12 +312,12 @@ class QueueService:
         finally:
             _reset_task_context(context_token)
 
-        updated = await self.get_queue_backend().complete_task(
+        completed_record = await self.get_queue_backend().complete_task(
             record.id, result=result, expected_retry_count=record.retry_count
         )
-        if updated is None:
+        if completed_record is None:
             return await self.publish_claim_lost(record, phase="complete", task_context=task_context)
-        completed = updated
+        completed = completed_record
         await task_context.lifecycle(
             "task.completed", payload={"status": completed.status, "retry_count": completed.retry_count}
         )

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -52,6 +52,56 @@ async def test_backend_contract_persists_execution_metadata_and_filters_claims(
     assert stored_local.status == "pending"
 
 
+async def test_backend_contract_bulk_cancels_matching_domain_predicate(queue_backend: "BaseQueueBackend") -> "None":
+    first = await queue_backend.enqueue(
+        "tasks.bulk.cancel",
+        kwargs={"workspace_id": "workspace-1", "collection_id": "collection-1"},
+        metadata={"kind": "refresh"},
+    )
+    running = await queue_backend.enqueue(
+        "tasks.bulk.cancel", kwargs={"workspace_id": "workspace-1"}, metadata={"kind": "refresh"}
+    )
+    wrong_workspace = await queue_backend.enqueue(
+        "tasks.bulk.cancel", kwargs={"workspace_id": "workspace-2"}, metadata={"kind": "refresh"}
+    )
+    wrong_metadata = await queue_backend.enqueue(
+        "tasks.bulk.cancel", kwargs={"workspace_id": "workspace-1"}, metadata={"kind": "other"}
+    )
+    wrong_task = await queue_backend.enqueue(
+        "tasks.bulk.keep", kwargs={"workspace_id": "workspace-1"}, metadata={"kind": "refresh"}
+    )
+    claimed = await queue_backend.claim_task(running.id)
+    assert claimed is not None
+
+    without_running = await queue_backend.cancel_tasks(
+        task_name="tasks.bulk.cancel", kwargs={"workspace_id": "workspace-1"}, metadata={"kind": "refresh"}
+    )
+    with_running = await queue_backend.cancel_tasks(
+        task_name="tasks.bulk.cancel",
+        kwargs={"workspace_id": "workspace-1"},
+        metadata={"kind": "refresh"},
+        include_running=True,
+    )
+    stored_first = await queue_backend.get_task(first.id)
+    stored_running = await queue_backend.get_task(running.id)
+    stored_wrong_workspace = await queue_backend.get_task(wrong_workspace.id)
+    stored_wrong_metadata = await queue_backend.get_task(wrong_metadata.id)
+    stored_wrong_task = await queue_backend.get_task(wrong_task.id)
+
+    assert without_running == 1
+    assert with_running == 1
+    assert stored_first is not None
+    assert stored_running is not None
+    assert stored_wrong_workspace is not None
+    assert stored_wrong_metadata is not None
+    assert stored_wrong_task is not None
+    assert stored_first.status == "cancelled"
+    assert stored_running.status == "cancelled"
+    assert stored_wrong_workspace.status == "pending"
+    assert stored_wrong_metadata.status == "pending"
+    assert stored_wrong_task.status == "pending"
+
+
 async def test_backend_contract_exposes_operational_queries_and_cleanup(queue_backend: "BaseQueueBackend") -> "None":
     completed = await queue_backend.enqueue("tasks.report")
     claimed_completed = await queue_backend.claim_task(completed.id)

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -68,6 +68,53 @@ async def test_memory_backend_fail_task_retries_then_fails_permanently() -> "Non
     assert failed.completed_at is not None
 
 
+async def test_memory_backend_only_cancels_running_tasks_when_explicitly_allowed() -> "None":
+    backend = InMemoryQueueBackend()
+    record = await backend.enqueue("tasks.running_cancel")
+    claimed = await backend.claim_task(record.id)
+    assert claimed is not None
+
+    assert await backend.cancel_task(record.id) is False
+    assert await backend.cancel_task(record.id, include_running=True) is True
+
+    stored = await backend.get_task(record.id)
+    assert stored is record
+    assert stored.status == "cancelled"
+    assert stored.completed_at is not None
+    assert stored.heartbeat_at is None
+
+
+async def test_memory_backend_bulk_cancels_matching_domain_predicate() -> "None":
+    backend = InMemoryQueueBackend()
+    first = await backend.enqueue(
+        "tasks.bulk_cancel", kwargs={"workspace_id": "workspace-1", "other": "kept"}, metadata={"kind": "refresh"}
+    )
+    running = await backend.enqueue("tasks.bulk_cancel", kwargs={"workspace_id": "workspace-1"})
+    wrong_workspace = await backend.enqueue("tasks.bulk_cancel", kwargs={"workspace_id": "workspace-2"})
+    wrong_task = await backend.enqueue("tasks.other", kwargs={"workspace_id": "workspace-1"})
+    claimed = await backend.claim_task(running.id)
+    assert claimed is not None
+
+    cancelled = await backend.cancel_tasks(
+        task_name="tasks.bulk_cancel", kwargs={"workspace_id": "workspace-1"}, include_running=True
+    )
+
+    assert cancelled == 2
+    stored_first = await backend.get_task(first.id)
+    stored_running = await backend.get_task(running.id)
+    stored_wrong_workspace = await backend.get_task(wrong_workspace.id)
+    stored_wrong_task = await backend.get_task(wrong_task.id)
+
+    assert stored_first is not None
+    assert stored_running is not None
+    assert stored_wrong_workspace is not None
+    assert stored_wrong_task is not None
+    assert stored_first.status == "cancelled"
+    assert stored_running.status == "cancelled"
+    assert stored_wrong_workspace.status == "pending"
+    assert stored_wrong_task.status == "pending"
+
+
 async def test_memory_backend_requeues_stale_running_task_when_policy_allows() -> "None":
     backend = InMemoryQueueBackend()
     record = await backend.enqueue("tasks.stale", max_retries=1, metadata={"requeue_on_stale": True})

--- a/src/tests/unit/test_public_api.py
+++ b/src/tests/unit/test_public_api.py
@@ -171,3 +171,19 @@ def test_task_dependency_resolver_config_surface() -> "None":
     instance = QueueConfig()
     assert instance.task_dependency_resolver is None
     assert instance.signature_namespace["TaskDependencyResolver"] is TaskDependencyResolver
+
+
+def test_job_cancelled_helper_is_public_and_in_signature_namespace() -> "None":
+    """Cooperative cancellation is available from the package root and Litestar signature namespace."""
+    import litestar_queues
+    from litestar_queues import JobCancelledError, job_cancelled
+    from litestar_queues.config import QueueConfig
+    from litestar_queues.exceptions import JobCancelledError as ExceptionsJobCancelledError
+
+    instance = QueueConfig()
+
+    assert JobCancelledError is ExceptionsJobCancelledError
+    assert "JobCancelledError" in litestar_queues.__all__
+    assert "job_cancelled" in litestar_queues.__all__
+    assert instance.signature_namespace["JobCancelledError"] is JobCancelledError
+    assert instance.signature_namespace["job_cancelled"] is job_cancelled

--- a/src/tests/unit/test_worker_events.py
+++ b/src/tests/unit/test_worker_events.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from litestar_queues import QueueConfig, QueueService, Worker, task
+from litestar_queues import QueueConfig, QueueService, Worker, job_cancelled, task
 from litestar_queues.backends import InMemoryQueueBackend
 from litestar_queues.events import (
     InMemoryQueueEventSink,
@@ -92,6 +92,31 @@ async def test_worker_emits_cancelled_event_for_cancelled_attempt() -> "None":
             await runner
 
     assert [event.type for event in sink.events] == ["task.started", "task.cancelled"]
+
+
+async def test_worker_marks_job_cancelled_error_terminal_without_retry() -> "None":
+    sink = InMemoryQueueEventSink()
+
+    @task("tasks.worker_job_cancelled", retries=3)
+    async def worker_job_cancelled() -> "None":
+        job_cancelled("domain cancellation")
+
+    async with QueueService(
+        QueueConfig(execution_backend="local", event_config=QueueEventConfig(enabled=True, sink=sink))
+    ) as service:
+        result = await service.enqueue(worker_job_cancelled)
+        worker = Worker(service)
+
+        assert await worker.run_once() == 1
+        await result.wait(timeout=1, poll_interval=0.01)
+
+    assert result.status == "cancelled"
+    assert result.record is not None
+    assert result.record.retry_count == 0
+    assert result.record.error is None
+    assert [event.type for event in sink.events] == ["task.started", "task.cancelled"]
+    assert sink.events[-1].message == "domain cancellation"
+    assert sink.events[-1].payload == {"status": "cancelled", "retry_count": 0}
 
 
 async def test_worker_emits_claim_lost_event_when_terminal_fence_rejects_stale_attempt() -> "None":


### PR DESCRIPTION
## Summary

- Add a public cooperative cancellation signal with `JobCancelledError` and `job_cancelled()`.
- Mark running tasks as terminal `cancelled` when a worker raises the cancellation signal, without retrying the job.
- Add backend support for cancelling running work explicitly and bulk-cancelling queued/running tasks by domain filters across memory, Redis, SQLSpec, and Advanced Alchemy backends.
- Document task cancellation and cover the behavior with focused unit and backend contract tests.