### PR TITLE
feat: add realtime example browser E2E coverage

### DIFF
--- a/.github/workflows/e2e-examples.yml
+++ b/.github/workflows/e2e-examples.yml
@@ -13,8 +13,25 @@ on:
 
 jobs:
   browser:
+    name: ${{ matrix.suite }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: example-server
+            pytest_args: src/tests/e2e/test_example_server.py
+          - suite: sse-contract
+            pytest_args: src/tests/e2e/test_realtime_browser.py -k test_sse_browser_contract
+          - suite: websocket-contract
+            pytest_args: src/tests/e2e/test_realtime_browser.py -k test_websocket_browser_contract
+          - suite: sse-reconnect
+            pytest_args: src/tests/e2e/test_realtime_browser.py -k "test_replacing_stream_mount_reconnects_cleanly and sse"
+          - suite: websocket-reconnect
+            pytest_args: src/tests/e2e/test_realtime_browser.py -k "test_replacing_stream_mount_reconnects_cleanly and websocket"
+          - suite: topology
+            pytest_args: src/tests/e2e/test_realtime_topology.py
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -39,7 +56,7 @@ jobs:
       - name: Run realtime browser E2E tests
         env:
           LITESTAR_QUEUES_E2E_TIMEOUT: "90"
-        run: uv run pytest src/tests/e2e -m e2e
+        run: uv run pytest ${{ matrix.pytest_args }} -m e2e
 
       - name: Stop topology services
         if: ${{ always() }}

--- a/.github/workflows/e2e-examples.yml
+++ b/.github/workflows/e2e-examples.yml
@@ -1,0 +1,46 @@
+name: Realtime example E2E
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/e2e-examples.yml"
+      - "examples/htmx_realtime_*/**"
+      - "src/tests/e2e/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "Makefile"
+  workflow_dispatch:
+
+jobs:
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install E2E dependencies
+        env:
+          UV_PYTHON: "3.12"
+        run: make install-e2e
+
+      - name: Install Chromium and system dependencies
+        run: uv run playwright install --with-deps chromium
+
+      - name: Start Redis and Valkey topology services
+        run: make start-infra
+
+      - name: Run realtime browser E2E tests
+        env:
+          LITESTAR_QUEUES_E2E_TIMEOUT: "90"
+        run: uv run pytest src/tests/e2e -m e2e
+
+      - name: Stop topology services
+        if: ${{ always() }}
+        run: make stop-infra

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,13 +48,13 @@ jobs:
         if: ${{ !inputs.coverage }}
         env:
           UV_PYTHON: ${{ inputs.python-version }}
-        run: uv run pytest src/tests -n 2
+        run: uv run pytest src/tests/unit src/tests/integration -n 2
 
       - name: Test with coverage
         if: ${{ inputs.coverage }}
         env:
           UV_PYTHON: ${{ inputs.python-version }}
-        run: uv run pytest src/tests --cov=litestar_queues --cov-report=xml -n 2
+        run: uv run pytest src/tests/unit src/tests/integration --cov=litestar_queues --cov-report=xml -n 2
 
       - uses: actions/upload-artifact@v7
         if: ${{ inputs.coverage }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.20"
+    rev: "v0.15.21"
     hooks:
       - id: ruff-check
         args: ["--fix"]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SHELL := /bin/bash
 MAKEFLAGS += --no-print-directory
 UV_SYNC_ARGS ?= --all-extras --dev
 INFRA_ARGS ?=
+EXAMPLE_APPS := $(wildcard examples/htmx_realtime_*/)
+EXAMPLE_APP_MODULES := $(addsuffix .app:app, $(subst /,.,$(patsubst %/,%,$(EXAMPLE_APPS))))
 
 # -----------------------------------------------------------------------------
 # Display Formatting and Colors
@@ -47,13 +49,42 @@ install-uv:                                         ## Install latest version of
 install: clean                                      ## Install the project and dependencies for local development
 	@echo "${INFO} Starting fresh installation..."
 	@uv sync $(UV_SYNC_ARGS)
+	@$(MAKE) install-examples-assets
 	@echo "${OK} Installation complete"
+
+.PHONY: install-examples-assets
+install-examples-assets:                              ## Install frontend assets for bundled example apps
+	@if [ -n "$(EXAMPLE_APP_MODULES)" ]; then \
+		for app in $(EXAMPLE_APP_MODULES); do \
+			echo "${INFO} Installing frontend assets for $$app..."; \
+			LITESTAR_APP=$$app uv run litestar assets install; \
+		done; \
+	else \
+		echo "${WARN} No example apps matched examples/htmx_realtime_*"; \
+	fi
+
+.PHONY: build-examples-assets
+build-examples-assets:                               ## Build frontend assets for bundled example apps
+	@if [ -n "$(EXAMPLE_APP_MODULES)" ]; then \
+		for app in $(EXAMPLE_APP_MODULES); do \
+			echo "${INFO} Building frontend assets for $$app..."; \
+			LITESTAR_APP=$$app uv run litestar assets build; \
+		done; \
+	else \
+		echo "${WARN} No example apps matched examples/htmx_realtime_*"; \
+	fi
 
 .PHONY: install-test-adapters
 install-test-adapters:                              ## Install test dependencies for the full integration matrix
 	@echo "${INFO} Installing test dependencies..."
 	@uv sync --group tests $(UV_SYNC_ARGS)
 	@echo "${OK} Test dependencies installed"
+
+.PHONY: install-e2e
+install-e2e:                                       ## Install browser E2E dependencies (Chromium is separate)
+	@echo "${INFO} Installing browser E2E dependencies..."
+	@uv sync $(UV_SYNC_ARGS) --group e2e
+	@echo "${OK} Browser E2E dependencies installed"
 
 .PHONY: destroy
 destroy:                                            ## Destroy the virtual environment
@@ -145,7 +176,7 @@ clean:                                              ## Cleanup temporary build a
 .PHONY: test
 test:                                               ## Run the tests
 	@echo "${INFO} Running test cases..."
-	@uv run pytest src/tests
+	@uv run pytest src/tests/unit src/tests/integration
 	@echo "${OK} Tests complete"
 
 .PHONY: test-all
@@ -166,10 +197,18 @@ test-integration:                                   ## Run integration tests onl
 .PHONY: coverage
 coverage:                                           ## Run tests with coverage report
 	@echo "${INFO} Running tests with coverage..."
-	@uv run pytest src/tests --cov -n auto
+	@uv run pytest src/tests/unit src/tests/integration --cov -n auto
 	@uv run coverage html >/dev/null 2>&1
 	@uv run coverage xml >/dev/null 2>&1
 	@echo "${OK} Coverage report generated"
+
+.PHONY: test-examples-e2e
+test-examples-e2e: install-e2e                       ## Install Chromium and run real-browser example tests
+	@echo "${INFO} Installing Chromium for browser E2E tests..."
+	@uv run playwright install chromium
+	@echo "${INFO} Running browser E2E tests..."
+	@uv run pytest src/tests/e2e -m e2e
+	@echo "${OK} Browser E2E tests complete"
 
 # -----------------------------------------------------------------------------
 # Local Infrastructure

--- a/README.md
+++ b/README.md
@@ -352,13 +352,16 @@ Every command loads the application the same way the Litestar CLI does: via
 <summary>Development</summary>
 
 ```bash
-# Install local development dependencies.
+# Install local development dependencies and provision assets for all shipped examples.
 make install
+
+# Optionally pre-build bundled example frontend bundles.
+make build-examples-assets
 
 # Run unit tests only.
 make test-unit
 
-# Run integration tests. Docker-backed services autoskip when unavailable.
+# Run integration tests. Docker-backed services auto-skip when unavailable.
 make test-integration
 
 # Build documentation.

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -22,12 +22,38 @@ behavior:
 
    uv run pytest src/tests/unit
 
+Install project dependencies for local development before running tests:
+
+.. code-block:: bash
+
+   make install
+
+This installs package/test dependencies and provisions frontend assets for the shipped
+example apps.
+
 Install test dependencies before running the full integration matrix:
 
 .. code-block:: bash
 
    make install-test-adapters
    uv run pytest src/tests/integration
+
+Browser E2E tests are intentionally separate from the unit and integration
+tiers. Install their Python dependencies and Chromium, then run:
+
+.. code-block:: bash
+
+   make test-examples-e2e
+
+The E2E target starts the real Litestar/Vite example processes through
+``litestar run`` and drives them with Chromium. It is not included in
+``make test`` or the ordinary integration workflow.
+
+If you want to prebuild all example frontend assets in one step:
+
+.. code-block:: bash
+
+   make build-examples-assets
 
 The integration tier intentionally relies on pytest-databases autoskip
 behavior. A test should request a service fixture such as ``postgres_service``,

--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -25,6 +25,28 @@ Install optional extras only when an application needs them:
 The core package import does not require optional queue or execution client
 libraries.
 
+Choosing a Live Channels Backend
+--------------------------------
+
+Queue persistence and live browser delivery are independent. ``RedisBackendConfig``
+and ``ValkeyBackendConfig`` persist and wake workers; they do not make the
+application's SSE or WebSocket Channels stream cross-process. Use
+``MemoryChannelsBackend`` only for one-process apps, or explicitly configure a
+shared Channels backend as well.
+
+For the Redis/Valkey realtime examples, the shared branch uses
+``RedisChannelsStreamBackend`` because ``EventStreamConfig(history=25)`` needs
+stream history. ``RedisChannelsPubSubBackend`` is a valid low-overhead choice
+only when history is intentionally zero. The Valkey example passes a Valkey
+client into the Litestar Redis-protocol Channels backend; it does not import or
+construct a Redis client in that path.
+
+For PostgreSQL-only deployments, prefer ``AsyncPgChannelsBackend`` or
+``PsycoPgChannelsBackend`` when ephemeral LISTEN/NOTIFY fan-out is sufficient.
+SQLSpec and Advanced Alchemy SQLite queue persistence do not create that
+cross-process fan-out automatically. Oracle AQ and TxEventQ are queue-worker
+wakeup transports, not browser event transports.
+
 SQLSpec
 -------
 

--- a/docs/usage/deployment/cloud-run.rst
+++ b/docs/usage/deployment/cloud-run.rst
@@ -34,6 +34,24 @@ The important rule is simple:
 If no dispatcher process is running, records routed to ``cloudrun`` stay
 pending forever.
 
+Realtime fan-out is a separate concern
+--------------------------------------
+
+If the web service and dispatcher are separate Cloud Run processes, do not use
+``MemoryChannelsBackend`` for browser events. It is process-local even when the
+queue records are stored in a shared database. Configure a shared Redis
+Channels Streams backend (or a PostgreSQL Channels backend when that is the
+existing stack) in both processes, with the same channel key prefix and event
+contract. Redis/Valkey queue notifications only wake the dispatcher; they do
+not carry SSE or WebSocket event payloads.
+
+Keep browser authentication and proxy behavior explicit: same-origin relative
+stream URLs are the simplest deployment, while a separate frontend origin
+needs the corresponding CORS, cookie, WebSocket upgrade, and proxy timeout
+configuration. A 403 on an enqueue POST is an auth/CSRF problem, not a
+Channels delivery failure. A stream error after a successful enqueue is a
+Channels, origin, or proxy problem.
+
 Recommended topology
 ====================
 

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -177,7 +177,6 @@ Configure buffering on ``EventConfig``:
                buffer_size=50,
                flush_interval=0.25,
                max_pending=5000,
-               overflow="drop_oldest",
            ),
        ),
    )
@@ -254,6 +253,53 @@ single transport (disabling both while ``enabled=True`` raises
 Subscribers receive at-most-once delivery per ``eventKey`` (or per ``id`` when
 no key is set) within a single connection. Set ``QueueEvent(..., event_key=...)``
 at publish time when worker-level retries should not double-emit downstream.
+
+Queue Storage, Worker Wakeups, and Browser Fan-Out
+==================================================
+
+These are three separate decisions. Queue storage holds task records. A queue
+backend's notification mechanism is a worker wakeup hint. The Channels backend
+is the live event fan-out path consumed by SSE or WebSocket clients. Choosing a
+Redis or Valkey queue backend does not configure shared browser Channels.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Topology
+     - Queue storage
+     - Worker wakeup
+     - Browser event fan-out
+   * - Local example
+     - Memory
+     - In-process
+     - ``MemoryChannelsBackend``
+   * - Shared Redis
+     - ``RedisBackendConfig``
+     - Redis queue pub/sub (hint)
+     - ``RedisChannelsStreamBackend``
+   * - Shared Valkey
+     - ``ValkeyBackendConfig``
+     - Valkey queue pub/sub (hint)
+     - Redis Channels Streams with the Valkey client
+   * - SQLSpec / Advanced Alchemy SQLite
+     - SQLite database
+     - Polling or in-process
+     - ``MemoryChannelsBackend`` unless a separate Channels backend is configured
+   * - Oracle AQ / TxEventQ
+     - Oracle queue backend
+     - AQ or TxEventQ worker wakeup
+     - Not a browser Channels transport
+
+The shipped Redis and Valkey realtime copies keep ``MemoryChannelsBackend`` by
+default. Set their shared-Channels environment switch and run a separate
+``litestar queues run --queue demo --drain-timeout 30`` process when the web
+service and worker are split. Because the examples request event history, the
+shared branch uses Redis Streams rather than Redis Pub/Sub; Pub/Sub has no
+history for a subscriber that connects later.
+
+The queue record remains the source of truth if a wakeup is dropped or
+coalesced. Conversely, a successful worker wakeup does not prove that a
+browser subscriber received an event. Test these planes independently.
 
 Consuming Stream Events
 =======================
@@ -410,7 +456,7 @@ state updates:
    reversed, so a misordered app fails fast instead of flushing in-flight task
    events into a closed sink.
 
-   When ``EventConfig(enabled=True)`` is configured without an explicit
+   When ``EventConfig()`` is configured without an explicit
    ``channels_backend`` (and no custom ``sink``), ``QueuePlugin`` auto-resolves
    the app's registered ``ChannelsPlugin`` as the live sink, so no manual
    wiring is needed.
@@ -490,7 +536,7 @@ the queue table:
 
    config = QueueConfig(
        queue_backend=SQLSpecBackendConfig(config=sqlspec_config),
-       event_log=EventLogConfig(enabled=True),
+       event_log=EventLogConfig(),
    )
 
 By default SQLSpec stores history in ``<queue_table>_event_log``. For example,

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,9 +32,26 @@ Each transport has the same backend variants:
 - `htmx_realtime_websocket_valkey/` and `htmx_realtime_sse_valkey/`:
   `ValkeyBackendConfig`.
 
+The backend name describes queue persistence, not browser event fan-out. Every
+shipped copy currently uses `MemoryChannelsBackend` for live Channels delivery,
+so the web app and worker must stay in one process. Redis or Valkey queue
+notifications can wake a worker, but they do not make the browser stream
+shared. A separate worker topology requires an explicit broker-backed Channels
+configuration; do not infer it from selecting a Redis or Valkey queue backend.
+
+All demos inherit `QueueConfig`'s in-process worker default. The Redis and
+Valkey copies accept `LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0` only for their
+documented shared web/worker topology.
+
 Start with the README in the directory you want to run. Every example uses the
 optional `litestar-queues[examples]` Python extra and local frontend
 dependencies from its own `package.json`.
+
+You can provision frontend assets for all shipped examples at once with:
+
+```bash
+make install
+```
 
 ## Conventions
 

--- a/examples/htmx_realtime_common.py
+++ b/examples/htmx_realtime_common.py
@@ -1,0 +1,10 @@
+"""Small shared helpers for the copyable realtime examples."""
+
+import os
+
+
+def standalone_worker_options() -> dict[str, bool]:
+    """Return only the explicit override for a separately run queue worker."""
+    if os.getenv("LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER") == "0":
+        return {"in_app_worker": False}
+    return {}

--- a/examples/htmx_realtime_common.py
+++ b/examples/htmx_realtime_common.py
@@ -2,6 +2,8 @@
 
 import os
 
+__all__ = ("standalone_worker_options",)
+
 
 def standalone_worker_options() -> dict[str, bool]:
     """Return only the explicit override for a separately run queue worker."""

--- a/examples/htmx_realtime_sse/app.py
+++ b/examples/htmx_realtime_sse/app.py
@@ -120,11 +120,7 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other

--- a/examples/htmx_realtime_sse_advanced_alchemy/README.md
+++ b/examples/htmx_realtime_sse_advanced_alchemy/README.md
@@ -11,6 +11,9 @@ the code. Queue persistence runs through Advanced Alchemy with
 `sqlite+aiosqlite`, and delivery uses memory Channels in the same process, so
 no external service is needed.
 
+This is a one-process topology: the SQLite queue database is persistence only;
+it does not make live Channels delivery available to a separate worker process.
+
 The queue database defaults to `queue-advanced-alchemy.db` under the example
 directory. The demo enables `create_all=True` and `create_schema=True` so the
 local schema is auto-created for a copyable app.

--- a/examples/htmx_realtime_sse_advanced_alchemy/app.py
+++ b/examples/htmx_realtime_sse_advanced_alchemy/app.py
@@ -131,11 +131,7 @@ queue_config = QueueConfig(
         ),
         create_schema=True,
     ),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other

--- a/examples/htmx_realtime_sse_redis/README.md
+++ b/examples/htmx_realtime_sse_redis/README.md
@@ -10,9 +10,41 @@ This copy is SSE-only. It uses the plugin-owned
 the code. Queue persistence runs through Redis, and delivery uses memory
 Channels in the same process, so only Redis is needed as an external service.
 
+The default remains one process: Redis stores queue records and can provide
+worker wakeups, but it does not make the live Channels stream shared. A
+separate `litestar queues run` worker needs an explicit broker-backed Channels
+configuration; selecting `RedisBackendConfig` alone is not enough.
+
 Set `LITESTAR_QUEUES_EXAMPLE_REDIS_URL` when Redis is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
 spinning up a Redis container.
+
+## Shared Web and Worker Mode
+
+The opt-in shared topology uses Redis Streams for live Channels delivery. It
+keeps the configured event history (`history=25`) and is intentionally separate
+from Redis queue wakeup pub/sub:
+
+```bash
+export LITESTAR_QUEUES_EXAMPLE_REDIS_URL=redis://127.0.0.1:16379/0
+export LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS=1
+export LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0
+export LITESTAR_QUEUES_EXAMPLE_REDIS_KEY_PREFIX=litestar_queues:demo:redis:queue
+export LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX=litestar_queues:demo:redis:channels
+
+LITESTAR_APP=examples.htmx_realtime_sse_redis.app:app uv run litestar run
+```
+
+In a second terminal, run the worker with the same environment and app:
+
+```bash
+LITESTAR_APP=examples.htmx_realtime_sse_redis.app:app \
+uv run litestar queues run --queue demo --drain-timeout 30
+```
+
+Do not switch this branch to `RedisChannelsPubSubBackend`: it has no history
+support. The queue backend's notifications wake workers; Redis Channels
+Streams carry the browser events.
 
 ## Run It (dev server, hot reload)
 

--- a/examples/htmx_realtime_sse_redis/app.py
+++ b/examples/htmx_realtime_sse_redis/app.py
@@ -6,13 +6,16 @@ from uuid import uuid4
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.memory import MemoryChannelsBackend
+from litestar.channels.backends.redis import RedisChannelsStreamBackend
 from litestar.di import NamedDependency
 from litestar.plugins.htmx import HTMXPlugin, HTMXTemplate
 from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 from litestar_vite import PathConfig, ViteConfig, VitePlugin
+from redis import asyncio as redis_asyncio
 
+from examples.htmx_realtime_common import standalone_worker_options
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
 from litestar_queues.backends.redis import RedisBackendConfig
 from litestar_queues.events import (
@@ -32,6 +35,13 @@ DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
 DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
 VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
 REDIS_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_REDIS_URL", "redis://localhost:6379/0")
+REDIS_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_REDIS_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_sse_redis"
+)
+CHANNELS_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX", "litestar_queues:channels:htmx_realtime_sse_redis"
+)
+SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
     "You clicked restart, so the app queued a background job.",
@@ -112,8 +122,14 @@ async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template
 
 
 # -- docs-app-config-start --
+channels_client = None
+channels_backend = MemoryChannelsBackend(history=200)
+if SHARED_CHANNELS:
+    channels_client = redis_asyncio.from_url(REDIS_URL, decode_responses=False)
+    channels_backend = RedisChannelsStreamBackend(history=200, redis=channels_client, key_prefix=CHANNELS_KEY_PREFIX)
+
 channels = ChannelsPlugin(
-    backend=MemoryChannelsBackend(history=200),
+    backend=channels_backend,
     arbitrary_channels_allowed=True,
     subscriber_max_backlog=1000,
     subscriber_backlog_strategy="dropleft",
@@ -122,12 +138,8 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=RedisBackendConfig(url=REDIS_URL, key_prefix="litestar_queues:examples:htmx_realtime_sse_redis"),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    queue_backend=RedisBackendConfig(url=REDIS_URL, key_prefix=REDIS_KEY_PREFIX),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other
@@ -135,16 +147,25 @@ queue_config = QueueConfig(
     event_stream=EventStreamConfig(
         scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
     ),
+    **standalone_worker_options(),
 )
 
 vite_config = ViteConfig(
     mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
 )
 
+
+async def close_shared_channels() -> None:
+    """Close the separately owned Redis Channels client on app shutdown."""
+    if channels_client is not None:
+        await channels_client.aclose()
+
+
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
+    on_shutdown=[close_shared_channels],
     plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_sse_sqlspec/README.md
+++ b/examples/htmx_realtime_sse_sqlspec/README.md
@@ -11,6 +11,9 @@ the code. Queue persistence runs through SQLSpec with the Aiosqlite driver,
 and delivery uses memory Channels in the same process, so no external service
 is needed.
 
+This is a one-process topology: the SQLite queue database is persistence only;
+it does not make live Channels delivery available to a separate worker process.
+
 The queue database defaults to `queue-sqlspec.db` under the example directory.
 `SQLSpecBackendConfig` sets `create_schema=False` and `run_migrations=True`, so
 startup calls the SQLSpec migration path for the local queue schema.

--- a/examples/htmx_realtime_sse_sqlspec/app.py
+++ b/examples/htmx_realtime_sse_sqlspec/app.py
@@ -125,11 +125,7 @@ queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
     queue_backend=SQLSpecBackendConfig(config=sqlspec_config, create_schema=False, run_migrations=True),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other

--- a/examples/htmx_realtime_sse_valkey/README.md
+++ b/examples/htmx_realtime_sse_valkey/README.md
@@ -10,9 +10,42 @@ This copy is SSE-only. It uses the plugin-owned
 the code. Queue persistence runs through Valkey, and delivery uses memory
 Channels in the same process, so only Valkey is needed as an external service.
 
+The default remains one process: Valkey stores queue records and can provide
+worker wakeups, but it does not make the live Channels stream shared. A
+separate `litestar queues run` worker needs an explicit broker-backed Channels
+configuration; selecting `ValkeyBackendConfig` alone is not enough.
+
 Set `LITESTAR_QUEUES_EXAMPLE_VALKEY_URL` when Valkey is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
 spinning up a Valkey container.
+
+## Shared Web and Worker Mode
+
+The opt-in shared topology uses Litestar's Redis Channels Streams backend with
+the Valkey client. It keeps the configured event history (`history=25`) and is
+intentionally separate from Valkey queue wakeup pub/sub:
+
+```bash
+export LITESTAR_QUEUES_EXAMPLE_VALKEY_URL=redis://127.0.0.1:16380/0
+export LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS=1
+export LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0
+export LITESTAR_QUEUES_EXAMPLE_VALKEY_KEY_PREFIX=litestar_queues:demo:valkey:queue
+export LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX=litestar_queues:demo:valkey:channels
+
+LITESTAR_APP=examples.htmx_realtime_sse_valkey.app:app uv run litestar run
+```
+
+In a second terminal, run the worker with the same environment and app:
+
+```bash
+LITESTAR_APP=examples.htmx_realtime_sse_valkey.app:app \
+uv run litestar queues run --queue demo --drain-timeout 30
+```
+
+Do not switch this branch to `RedisChannelsPubSubBackend`: it has no history
+support. The Valkey queue backend's notifications wake workers; Redis Channels
+Streams carry the browser events. The Valkey branch never creates a Redis
+client directly.
 
 ## Run It (dev server, hot reload)
 

--- a/examples/htmx_realtime_sse_valkey/app.py
+++ b/examples/htmx_realtime_sse_valkey/app.py
@@ -6,13 +6,16 @@ from uuid import uuid4
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.memory import MemoryChannelsBackend
+from litestar.channels.backends.redis import RedisChannelsStreamBackend
 from litestar.di import NamedDependency
 from litestar.plugins.htmx import HTMXPlugin, HTMXTemplate
 from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 from litestar_vite import PathConfig, ViteConfig, VitePlugin
+from valkey import asyncio as valkey_asyncio
 
+from examples.htmx_realtime_common import standalone_worker_options
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
 from litestar_queues.backends.valkey import ValkeyBackendConfig
 from litestar_queues.events import (
@@ -32,6 +35,13 @@ DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
 DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
 VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
 VALKEY_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_VALKEY_URL", "redis://localhost:6379/0")
+VALKEY_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_VALKEY_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_sse_valkey"
+)
+CHANNELS_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX", "litestar_queues:channels:htmx_realtime_sse_valkey"
+)
+SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
     "You clicked restart, so the app queued a background job.",
@@ -112,8 +122,14 @@ async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template
 
 
 # -- docs-app-config-start --
+channels_client = None
+channels_backend = MemoryChannelsBackend(history=200)
+if SHARED_CHANNELS:
+    channels_client = valkey_asyncio.from_url(VALKEY_URL, decode_responses=False)
+    channels_backend = RedisChannelsStreamBackend(history=200, redis=channels_client, key_prefix=CHANNELS_KEY_PREFIX)
+
 channels = ChannelsPlugin(
-    backend=MemoryChannelsBackend(history=200),
+    backend=channels_backend,
     arbitrary_channels_allowed=True,
     subscriber_max_backlog=1000,
     subscriber_backlog_strategy="dropleft",
@@ -122,12 +138,8 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=ValkeyBackendConfig(url=VALKEY_URL, key_prefix="litestar_queues:examples:htmx_realtime_sse_valkey"),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    queue_backend=ValkeyBackendConfig(url=VALKEY_URL, key_prefix=VALKEY_KEY_PREFIX),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other
@@ -135,16 +147,25 @@ queue_config = QueueConfig(
     event_stream=EventStreamConfig(
         scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
     ),
+    **standalone_worker_options(),
 )
 
 vite_config = ViteConfig(
     mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
 )
 
+
+async def close_shared_channels() -> None:
+    """Close the separately owned Valkey Channels client on app shutdown."""
+    if channels_client is not None:
+        await channels_client.aclose()
+
+
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
+    on_shutdown=[close_shared_channels],
     plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_websocket/app.py
+++ b/examples/htmx_realtime_websocket/app.py
@@ -120,11 +120,7 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other

--- a/examples/htmx_realtime_websocket_advanced_alchemy/README.md
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/README.md
@@ -11,6 +11,9 @@ code. Queue persistence runs through Advanced Alchemy with `sqlite+aiosqlite`,
 and delivery uses memory Channels in the same process, so no external service
 is needed.
 
+This is a one-process topology: the SQLite queue database is persistence only;
+it does not make live Channels delivery available to a separate worker process.
+
 The queue database defaults to `queue-advanced-alchemy.db` under the example
 directory. The demo enables `create_all=True` and `create_schema=True` so the
 local schema is auto-created for a copyable app.

--- a/examples/htmx_realtime_websocket_advanced_alchemy/app.py
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/app.py
@@ -131,11 +131,7 @@ queue_config = QueueConfig(
         ),
         create_schema=True,
     ),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other

--- a/examples/htmx_realtime_websocket_redis/README.md
+++ b/examples/htmx_realtime_websocket_redis/README.md
@@ -10,9 +10,41 @@ This copy is WebSocket-only. It uses the plugin-owned
 code. Queue persistence runs through Redis, and delivery uses memory Channels
 in the same process, so only Redis is needed as an external service.
 
+The default remains one process: Redis stores queue records and can provide
+worker wakeups, but it does not make the live Channels stream shared. A
+separate `litestar queues run` worker needs an explicit broker-backed Channels
+configuration; selecting `RedisBackendConfig` alone is not enough.
+
 Set `LITESTAR_QUEUES_EXAMPLE_REDIS_URL` when Redis is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
 spinning up a Redis container.
+
+## Shared Web and Worker Mode
+
+The opt-in shared topology uses Redis Streams for live Channels delivery. It
+keeps the configured event history (`history=25`) and is intentionally separate
+from Redis queue wakeup pub/sub:
+
+```bash
+export LITESTAR_QUEUES_EXAMPLE_REDIS_URL=redis://127.0.0.1:16379/0
+export LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS=1
+export LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0
+export LITESTAR_QUEUES_EXAMPLE_REDIS_KEY_PREFIX=litestar_queues:demo:redis:queue
+export LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX=litestar_queues:demo:redis:channels
+
+LITESTAR_APP=examples.htmx_realtime_websocket_redis.app:app uv run litestar run
+```
+
+In a second terminal, run the worker with the same environment and app:
+
+```bash
+LITESTAR_APP=examples.htmx_realtime_websocket_redis.app:app \
+uv run litestar queues run --queue demo --drain-timeout 30
+```
+
+Do not switch this branch to `RedisChannelsPubSubBackend`: it has no history
+support. The queue backend's notifications wake workers; Redis Channels
+Streams carry the browser events.
 
 ## Run It (dev server, hot reload)
 

--- a/examples/htmx_realtime_websocket_redis/app.py
+++ b/examples/htmx_realtime_websocket_redis/app.py
@@ -6,13 +6,16 @@ from uuid import uuid4
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.memory import MemoryChannelsBackend
+from litestar.channels.backends.redis import RedisChannelsStreamBackend
 from litestar.di import NamedDependency
 from litestar.plugins.htmx import HTMXPlugin, HTMXTemplate
 from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 from litestar_vite import PathConfig, ViteConfig, VitePlugin
+from redis import asyncio as redis_asyncio
 
+from examples.htmx_realtime_common import standalone_worker_options
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
 from litestar_queues.backends.redis import RedisBackendConfig
 from litestar_queues.events import (
@@ -32,6 +35,13 @@ DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
 DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
 VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
 REDIS_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_REDIS_URL", "redis://localhost:6379/0")
+REDIS_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_REDIS_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_websocket_redis"
+)
+CHANNELS_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX", "litestar_queues:channels:htmx_realtime_websocket_redis"
+)
+SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
     "You clicked restart, so the app queued a background job.",
@@ -112,8 +122,14 @@ async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template
 
 
 # -- docs-app-config-start --
+channels_client = None
+channels_backend = MemoryChannelsBackend(history=200)
+if SHARED_CHANNELS:
+    channels_client = redis_asyncio.from_url(REDIS_URL, decode_responses=False)
+    channels_backend = RedisChannelsStreamBackend(history=200, redis=channels_client, key_prefix=CHANNELS_KEY_PREFIX)
+
 channels = ChannelsPlugin(
-    backend=MemoryChannelsBackend(history=200),
+    backend=channels_backend,
     arbitrary_channels_allowed=True,
     subscriber_max_backlog=1000,
     subscriber_backlog_strategy="dropleft",
@@ -122,14 +138,8 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=RedisBackendConfig(
-        url=REDIS_URL, key_prefix="litestar_queues:examples:htmx_realtime_websocket_redis"
-    ),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    queue_backend=RedisBackendConfig(url=REDIS_URL, key_prefix=REDIS_KEY_PREFIX),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other
@@ -137,16 +147,25 @@ queue_config = QueueConfig(
     event_stream=EventStreamConfig(
         scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
     ),
+    **standalone_worker_options(),
 )
 
 vite_config = ViteConfig(
     mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
 )
 
+
+async def close_shared_channels() -> None:
+    """Close the separately owned Redis Channels client on app shutdown."""
+    if channels_client is not None:
+        await channels_client.aclose()
+
+
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
+    on_shutdown=[close_shared_channels],
     plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_websocket_sqlspec/README.md
+++ b/examples/htmx_realtime_websocket_sqlspec/README.md
@@ -11,6 +11,9 @@ code. Queue persistence runs through SQLSpec with the Aiosqlite driver, and
 delivery uses memory Channels in the same process, so no external service is
 needed.
 
+This is a one-process topology: the SQLite queue database is persistence only;
+it does not make live Channels delivery available to a separate worker process.
+
 The queue database defaults to `queue-sqlspec.db` under the example directory.
 `SQLSpecBackendConfig` sets `create_schema=False` and `run_migrations=True`, so
 startup calls the SQLSpec migration path for the local queue schema.

--- a/examples/htmx_realtime_websocket_sqlspec/app.py
+++ b/examples/htmx_realtime_websocket_sqlspec/app.py
@@ -125,11 +125,7 @@ queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
     queue_backend=SQLSpecBackendConfig(config=sqlspec_config, create_schema=False, run_migrations=True),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other

--- a/examples/htmx_realtime_websocket_valkey/README.md
+++ b/examples/htmx_realtime_websocket_valkey/README.md
@@ -10,9 +10,42 @@ This copy is WebSocket-only. It uses the plugin-owned
 code. Queue persistence runs through Valkey, and delivery uses memory Channels
 in the same process, so only Valkey is needed as an external service.
 
+The default remains one process: Valkey stores queue records and can provide
+worker wakeups, but it does not make the live Channels stream shared. A
+separate `litestar queues run` worker needs an explicit broker-backed Channels
+configuration; selecting `ValkeyBackendConfig` alone is not enough.
+
 Set `LITESTAR_QUEUES_EXAMPLE_VALKEY_URL` when Valkey is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
 spinning up a Valkey container.
+
+## Shared Web and Worker Mode
+
+The opt-in shared topology uses Litestar's Redis Channels Streams backend with
+the Valkey client. It keeps the configured event history (`history=25`) and is
+intentionally separate from Valkey queue wakeup pub/sub:
+
+```bash
+export LITESTAR_QUEUES_EXAMPLE_VALKEY_URL=redis://127.0.0.1:16380/0
+export LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS=1
+export LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0
+export LITESTAR_QUEUES_EXAMPLE_VALKEY_KEY_PREFIX=litestar_queues:demo:valkey:queue
+export LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX=litestar_queues:demo:valkey:channels
+
+LITESTAR_APP=examples.htmx_realtime_websocket_valkey.app:app uv run litestar run
+```
+
+In a second terminal, run the worker with the same environment and app:
+
+```bash
+LITESTAR_APP=examples.htmx_realtime_websocket_valkey.app:app \
+uv run litestar queues run --queue demo --drain-timeout 30
+```
+
+Do not switch this branch to `RedisChannelsPubSubBackend`: it has no history
+support. The Valkey queue backend's notifications wake workers; Redis Channels
+Streams carry the browser events. The Valkey branch never creates a Redis
+client directly.
 
 ## Run It (dev server, hot reload)
 

--- a/examples/htmx_realtime_websocket_valkey/app.py
+++ b/examples/htmx_realtime_websocket_valkey/app.py
@@ -6,13 +6,16 @@ from uuid import uuid4
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.memory import MemoryChannelsBackend
+from litestar.channels.backends.redis import RedisChannelsStreamBackend
 from litestar.di import NamedDependency
 from litestar.plugins.htmx import HTMXPlugin, HTMXTemplate
 from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 from litestar_vite import PathConfig, ViteConfig, VitePlugin
+from valkey import asyncio as valkey_asyncio
 
+from examples.htmx_realtime_common import standalone_worker_options
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
 from litestar_queues.backends.valkey import ValkeyBackendConfig
 from litestar_queues.events import (
@@ -32,6 +35,13 @@ DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
 DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
 VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
 VALKEY_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_VALKEY_URL", "redis://localhost:6379/0")
+VALKEY_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_VALKEY_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_websocket_valkey"
+)
+CHANNELS_KEY_PREFIX = os.getenv(
+    "LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX", "litestar_queues:channels:htmx_realtime_websocket_valkey"
+)
+SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
     "You clicked restart, so the app queued a background job.",
@@ -112,8 +122,14 @@ async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template
 
 
 # -- docs-app-config-start --
+channels_client = None
+channels_backend = MemoryChannelsBackend(history=200)
+if SHARED_CHANNELS:
+    channels_client = valkey_asyncio.from_url(VALKEY_URL, decode_responses=False)
+    channels_backend = RedisChannelsStreamBackend(history=200, redis=channels_client, key_prefix=CHANNELS_KEY_PREFIX)
+
 channels = ChannelsPlugin(
-    backend=MemoryChannelsBackend(history=200),
+    backend=channels_backend,
     arbitrary_channels_allowed=True,
     subscriber_max_backlog=1000,
     subscriber_backlog_strategy="dropleft",
@@ -122,14 +138,8 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=ValkeyBackendConfig(
-        url=VALKEY_URL, key_prefix="litestar_queues:examples:htmx_realtime_websocket_valkey"
-    ),
-    event=EventConfig(
-        enabled=True,
-        channels_backend=channels,
-        buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest"),
-    ),
+    queue_backend=ValkeyBackendConfig(url=VALKEY_URL, key_prefix=VALKEY_KEY_PREFIX),
+    event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
     # A demo-only allow-all authorizer: it suppresses the missing-auth warning
     # for this local single-process example. Real deployments must authorize.
     # Each demo registers only its own transport so a stale tab from the other
@@ -137,16 +147,25 @@ queue_config = QueueConfig(
     event_stream=EventStreamConfig(
         scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
     ),
+    **standalone_worker_options(),
 )
 
 vite_config = ViteConfig(
     mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
 )
 
+
+async def close_shared_channels() -> None:
+    """Close the separately owned Valkey Channels client on app shutdown."""
+    if channels_client is not None:
+        await channels_client.aclose()
+
+
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
+    on_shutdown=[close_shared_channels],
     plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
 )
 # -- docs-app-config-end --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = { text = "MIT" }
 name = "litestar-queues"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.2.0"
+version = "0.3.0"
 
 [project.urls]
 Changelog = "https://github.com/cofin/litestar-queues/releases/"
@@ -84,7 +84,7 @@ allow-direct-references = true
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.2.0"
+current_version = "0.3.0"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"
@@ -181,6 +181,10 @@ tests = [
   # SQLSpec adapters covered by the default integration matrix
   "sqlspec[adbc,aiosqlite,oracledb,aiomysql,psycopg,asyncpg,duckdb,psqlpy,asyncmy,arrow-odbc,cockroachdb,pymysql,spanner,litestar,mysql-connector,mssql-python,pymssql]>=0.52.0",
 ]
+e2e = [
+  "playwright>=1.50.0",
+  "pytest-playwright>=0.7.0",
+]
 
 #####################
 # Testing           #
@@ -199,6 +203,10 @@ filterwarnings = [
   "ignore:the \\(type, exc, tb\\) signature of throw\\(\\) is deprecated, use the single-arg signature instead\\.:DeprecationWarning:asyncio\\.locks",
 ]
 testpaths = ["src/tests"]
+markers = [
+  "e2e: end-to-end tests that start real example processes and Chromium",
+  "topology: cross-process queue and Channels topology tests",
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/src/tests/e2e/__init__.py
+++ b/src/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests for the shipped Litestar Queues examples."""

--- a/src/tests/e2e/assertions.py
+++ b/src/tests/e2e/assertions.py
@@ -1,7 +1,5 @@
 """Assertions shared by browser and process-level example tests."""
 
-from __future__ import annotations
-
 import re
 from urllib.parse import urljoin, urlsplit
 

--- a/src/tests/e2e/assertions.py
+++ b/src/tests/e2e/assertions.py
@@ -1,0 +1,25 @@
+"""Assertions shared by browser and process-level example tests."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urljoin, urlsplit
+
+
+def assert_asset_urls_on_origin(html: str, origin: str) -> None:
+    """Reject asset URLs that escape the Litestar origin."""
+    refs = re.findall(r"<(?:script\b[^>]*\bsrc|link\b[^>]*\bhref)=[\"']([^\"']+)[\"']", html, flags=re.IGNORECASE)
+
+    assert refs, "page rendered no script or stylesheet references"
+    expected = urlsplit(origin)
+    for ref in refs:
+        resolved = urlsplit(urljoin(f"{origin}/", ref))
+        if resolved.scheme in {"http", "https"}:
+            assert (resolved.scheme, resolved.netloc) == (expected.scheme, expected.netloc), (
+                f"asset reference escapes the Litestar origin: {ref}"
+            )
+
+
+def assert_production_assets(html: str) -> None:
+    """Ensure built pages do not retain the Vite development client."""
+    assert "@vite/client" not in html, "production page still references the Vite development client"

--- a/src/tests/e2e/conftest.py
+++ b/src/tests/e2e/conftest.py
@@ -1,0 +1,105 @@
+"""Fixtures for queue example browser tests."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from .server_manager import ExampleMode, ExampleServer
+
+E2E_TEST_TIMEOUT = float(os.getenv("LITESTAR_QUEUES_E2E_TIMEOUT", "90"))
+
+
+@dataclass
+class BrowserDiagnostics:
+    """Browser failures collected for a failure message."""
+
+    console_errors: list[str] = field(default_factory=list)
+    page_errors: list[str] = field(default_factory=list)
+    request_failures: list[str] = field(default_factory=list)
+    failed_responses: list[str] = field(default_factory=list)
+
+
+@pytest.fixture(scope="session", params=["sse", "websocket"])
+def example_name(request: pytest.FixtureRequest) -> str:
+    """Select a canonical browser example alias.
+
+    Returns:
+        The example alias selected by the parametrized fixture.
+    """
+    return str(request.param)
+
+
+@pytest.fixture(scope="session", params=["dev", "production"])
+def server_mode(request: pytest.FixtureRequest) -> ExampleMode:
+    """Select the asset mode under test.
+
+    Returns:
+        The selected Litestar/Vite asset mode.
+    """
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def example_server(example_name: str, server_mode: ExampleMode) -> ExampleServer:
+    """Start one example per example/mode pair and clean it up at session end.
+
+    Yields:
+        The ready example process manager.
+    """
+    server = ExampleServer(example_name, mode=server_mode)
+    server.start()
+    try:
+        server.wait_until_ready(timeout=E2E_TEST_TIMEOUT)
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def e2e_timeout() -> float:
+    """Return the configurable browser timeout in seconds."""
+    return E2E_TEST_TIMEOUT
+
+
+@pytest.fixture
+def browser_diagnostics() -> BrowserDiagnostics:
+    """Collect browser console, page, request, and response failures.
+
+    Returns:
+        A mutable diagnostics collection for the current browser test.
+    """
+    return BrowserDiagnostics()
+
+
+@pytest.fixture
+def browser_page(page: Any, browser_diagnostics: BrowserDiagnostics, e2e_timeout: float) -> Any:
+    """Return a fresh Playwright page with actionable diagnostics attached.
+
+    Yields:
+        A fresh Playwright page configured with the E2E timeout.
+    """
+    page.set_default_timeout(e2e_timeout * 1000)
+    page.on(
+        "console",
+        lambda message: browser_diagnostics.console_errors.append(message.text) if message.type == "error" else None,
+    )
+    page.on("pageerror", lambda error: browser_diagnostics.page_errors.append(str(error)))
+    page.on(
+        "requestfailed",
+        lambda request: browser_diagnostics.request_failures.append(
+            f"{request.method} {request.url}: {request.failure}"
+        ),
+    )
+    page.on(
+        "response",
+        lambda response: (
+            browser_diagnostics.failed_responses.append(f"{response.status} {response.request.method} {response.url}")
+            if response.status >= 400
+            else None
+        ),
+    )
+    yield page

--- a/src/tests/e2e/conftest.py
+++ b/src/tests/e2e/conftest.py
@@ -1,10 +1,9 @@
 """Fixtures for queue example browser tests."""
 
-from __future__ import annotations
-
 import os
+from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -40,11 +39,11 @@ def server_mode(request: pytest.FixtureRequest) -> ExampleMode:
     Returns:
         The selected Litestar/Vite asset mode.
     """
-    return request.param
+    return cast("ExampleMode", request.param)
 
 
 @pytest.fixture(scope="session")
-def example_server(example_name: str, server_mode: ExampleMode) -> ExampleServer:
+def example_server(example_name: str, server_mode: ExampleMode) -> Iterator[ExampleServer]:
     """Start one example per example/mode pair and clean it up at session end.
 
     Yields:

--- a/src/tests/e2e/health_check.py
+++ b/src/tests/e2e/health_check.py
@@ -1,0 +1,52 @@
+"""HTTP readiness checks for example-process E2E tests."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def wait_for_paths(base_url: str, paths: Iterable[str], *, timeout: float) -> dict[str, httpx.Response]:
+    """Wait until every path returns HTTP 200 on the Litestar origin.
+
+    Returns:
+        The successful responses keyed by request path.
+    """
+    paths = tuple(paths)
+    deadline = time.monotonic() + timeout
+    last_status: dict[str, int | None] = dict.fromkeys(paths)
+    last_error: dict[str, str] = {}
+
+    with httpx.Client(base_url=base_url, follow_redirects=True) as client:
+        while time.monotonic() < deadline:
+            responses: dict[str, httpx.Response] = {}
+            ready = True
+            for path in paths:
+                try:
+                    response = client.get(path, timeout=5.0)
+                except httpx.HTTPError as exc:
+                    last_error[path] = str(exc)
+                    ready = False
+                    continue
+
+                responses[path] = response
+                last_status[path] = response.status_code
+                if response.status_code != 200:
+                    ready = False
+
+            if ready:
+                return responses
+            time.sleep(0.25)
+
+    details = []
+    for path in paths:
+        status = last_status[path]
+        error = last_error.get(path)
+        details.append(f"{path}: status={status!r} error={error!r}")
+    message = f"Example did not become ready at {base_url}: {'; '.join(details)}"
+    raise TimeoutError(message)

--- a/src/tests/e2e/health_check.py
+++ b/src/tests/e2e/health_check.py
@@ -1,14 +1,9 @@
 """HTTP readiness checks for example-process E2E tests."""
 
-from __future__ import annotations
-
 import time
-from typing import TYPE_CHECKING
+from collections.abc import Iterable
 
 import httpx
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 def wait_for_paths(base_url: str, paths: Iterable[str], *, timeout: float) -> dict[str, httpx.Response]:

--- a/src/tests/e2e/server_manager.py
+++ b/src/tests/e2e/server_manager.py
@@ -1,24 +1,20 @@
 """Process lifecycle for the shipped HTMX realtime examples."""
 
-from __future__ import annotations
-
 import os
 import signal
 import socket
 import subprocess
 import time
 from collections import deque
+from collections.abc import Mapping
 from pathlib import Path
 from threading import Lock, Thread
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import httpx
 
 from .assertions import assert_asset_urls_on_origin, assert_production_assets
 from .health_check import wait_for_paths
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ExampleMode = Literal["dev", "production"]

--- a/src/tests/e2e/server_manager.py
+++ b/src/tests/e2e/server_manager.py
@@ -1,0 +1,288 @@
+"""Process lifecycle for the shipped HTMX realtime examples."""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import time
+from collections import deque
+from pathlib import Path
+from threading import Lock, Thread
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+
+from .assertions import assert_asset_urls_on_origin, assert_production_assets
+from .health_check import wait_for_paths
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ExampleMode = Literal["dev", "production"]
+
+EXAMPLE_APPS: dict[str, str] = {
+    "sse": "examples.htmx_realtime_sse.app:app",
+    "websocket": "examples.htmx_realtime_websocket.app:app",
+    "sse_redis": "examples.htmx_realtime_sse_redis.app:app",
+    "websocket_redis": "examples.htmx_realtime_websocket_redis.app:app",
+    "sse_valkey": "examples.htmx_realtime_sse_valkey.app:app",
+    "websocket_valkey": "examples.htmx_realtime_websocket_valkey.app:app",
+}
+
+
+def find_free_port() -> int:
+    """Ask the operating system for an available local TCP port.
+
+    Returns:
+        An available local TCP port.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class ExampleServer:
+    """Start one realtime example through the Litestar CLI."""
+
+    def __init__(self, example_name: str, *, mode: ExampleMode, environment: Mapping[str, str] | None = None) -> None:
+        if example_name not in EXAMPLE_APPS:
+            message = f"Unsupported browser example: {example_name!r}"
+            raise ValueError(message)
+        if mode not in {"dev", "production"}:
+            message = f"Unsupported example mode: {mode!r}"
+            raise ValueError(message)
+
+        self.example_name = example_name
+        self.mode = mode
+        self.port: int | None = None
+        self._process: subprocess.Popen[str] | None = None
+        self._log_lines: deque[str] = deque(maxlen=40)
+        self._log_lock = Lock()
+        self._capture_thread: Thread | None = None
+        self._extra_environment = dict(environment or {})
+
+    @property
+    def base_url(self) -> str:
+        """Return the Litestar origin once the server has started."""
+        if self.port is None:
+            message = "Example server has not started"
+            raise RuntimeError(message)
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self) -> None:
+        """Install/build assets as needed and start the Litestar process."""
+        if self._process is not None:
+            message = "Example server is already started"
+            raise RuntimeError(message)
+
+        env = self._environment()
+        if self.mode == "production":
+            self._run_cli(["assets", "install"], env=env)
+            self._run_cli(["assets", "build"], env=env)
+
+        self.port = find_free_port()
+        command = ["uv", "run", "litestar", "run", "--host", "127.0.0.1", "--port", str(self.port)]
+        self._process = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+        self._capture_thread = Thread(target=self._capture_output, daemon=True)
+        self._capture_thread.start()
+
+    def wait_until_ready(self, timeout: float) -> None:
+        """Wait for the app, status route, and required asset mode to respond."""
+        try:
+            self._check_process_alive()
+            wait_for_paths(self.base_url, ("/", "/demo/status"), timeout=timeout)
+
+            if self.mode == "dev":
+                wait_for_paths(self.base_url, ("/static/@vite/client",), timeout=timeout)
+
+            with httpx.Client(base_url=self.base_url, follow_redirects=True) as client:
+                page = client.get("/", timeout=5.0)
+                page.raise_for_status()
+                assert_asset_urls_on_origin(page.text, self.base_url)
+                if self.mode == "production":
+                    assert_production_assets(page.text)
+
+            self._check_process_alive()
+        except (TimeoutError, RuntimeError, httpx.HTTPError) as exc:
+            message = f"{exc}\nRecent server output:\n{self._recent_logs()}"
+            raise RuntimeError(message) from exc
+
+    def stop(self) -> None:
+        """Terminate the Litestar process and its process group."""
+        process = self._process
+        self._process = None
+        if process is None:
+            return
+
+        if process.poll() is None:
+            if os.name == "nt":
+                process.terminate()
+            else:
+                os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                if os.name == "nt":
+                    process.kill()
+                else:
+                    os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5.0)
+
+        if self._capture_thread is not None:
+            self._capture_thread.join(timeout=2.0)
+            self._capture_thread = None
+
+    def _environment(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update({
+            "LITESTAR_APP": EXAMPLE_APPS[self.example_name],
+            "LITESTAR_QUEUES_EXAMPLE_STEPS": "2",
+            "LITESTAR_QUEUES_EXAMPLE_STEP_DELAY": "0.05",
+            "LITESTAR_QUEUES_EXAMPLE_VITE_DEV": "1" if self.mode == "dev" else "0",
+            "PYTHONUNBUFFERED": "1",
+        })
+        env.update(self._extra_environment)
+        return env
+
+    def _run_cli(self, arguments: list[str], *, env: dict[str, str]) -> None:
+        result = subprocess.run(
+            ["uv", "run", "litestar", *arguments],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=180.0,
+        )
+        if result.returncode:
+            output = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
+            message = f"Litestar CLI command failed ({arguments!r}) with code {result.returncode}:\n{output}"
+            raise RuntimeError(message)
+
+    def _capture_output(self) -> None:
+        process = self._process
+        if process is None or process.stdout is None:
+            return
+        for line in process.stdout:
+            with self._log_lock:
+                self._log_lines.append(line.rstrip())
+
+    def _recent_logs(self) -> str:
+        with self._log_lock:
+            return "\n".join(self._log_lines)
+
+    def _check_process_alive(self) -> None:
+        process = self._process
+        if process is None:
+            message = "Example server has not started"
+            raise RuntimeError(message)
+        if process.poll() is None:
+            return
+        with self._log_lock:
+            output = "\n".join(self._log_lines)
+        message = f"Example server exited with code {process.returncode}:\n{output}"
+        raise RuntimeError(message)
+
+
+class QueueWorker:
+    """Run a queue worker process against an example app."""
+
+    def __init__(self, example_name: str, *, environment: Mapping[str, str]) -> None:
+        if example_name not in EXAMPLE_APPS:
+            message = f"Unsupported browser example: {example_name!r}"
+            raise ValueError(message)
+
+        self.command = ["uv", "run", "litestar", "queues", "run", "--queue", "demo", "--drain-timeout", "30"]
+        self.environment = os.environ.copy()
+        self.environment.update(environment)
+        self.environment.update({"LITESTAR_APP": EXAMPLE_APPS[example_name], "PYTHONUNBUFFERED": "1"})
+        self._process: subprocess.Popen[str] | None = None
+        self._log_lines: deque[str] = deque(maxlen=40)
+        self._log_lock = Lock()
+        self._capture_thread: Thread | None = None
+
+    def start(self) -> None:
+        """Start the standalone Litestar queue worker."""
+        if self._process is not None:
+            message = "Queue worker is already started"
+            raise RuntimeError(message)
+        self._process = subprocess.Popen(
+            self.command,
+            cwd=REPO_ROOT,
+            env=self.environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+        self._capture_thread = Thread(target=self._capture_output, daemon=True)
+        self._capture_thread.start()
+
+    def wait_until_running(self, timeout: float = 10.0) -> None:
+        """Wait until the worker process remains alive for one polling interval."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._check_process_alive()
+            time.sleep(0.1)
+            self._check_process_alive()
+            return
+        message = f"Queue worker did not remain alive within {timeout}s:\n{self._recent_logs()}"
+        raise TimeoutError(message)
+
+    def stop(self) -> None:
+        """Terminate the worker process and its process group."""
+        process = self._process
+        self._process = None
+        if process is None:
+            return
+        if process.poll() is None:
+            if os.name == "nt":
+                process.terminate()
+            else:
+                os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                if os.name == "nt":
+                    process.kill()
+                else:
+                    os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5.0)
+        if self._capture_thread is not None:
+            self._capture_thread.join(timeout=2.0)
+            self._capture_thread = None
+
+    def _capture_output(self) -> None:
+        process = self._process
+        if process is None or process.stdout is None:
+            return
+        for line in process.stdout:
+            with self._log_lock:
+                self._log_lines.append(line.rstrip())
+
+    def _recent_logs(self) -> str:
+        with self._log_lock:
+            return "\n".join(self._log_lines)
+
+    def _check_process_alive(self) -> None:
+        process = self._process
+        if process is None:
+            message = "Queue worker has not started"
+            raise RuntimeError(message)
+        if process.poll() is None:
+            return
+        message = f"Queue worker exited with code {process.returncode}:\n{self._recent_logs()}"
+        raise RuntimeError(message)

--- a/src/tests/e2e/server_manager.py
+++ b/src/tests/e2e/server_manager.py
@@ -27,6 +27,7 @@ EXAMPLE_APPS: dict[str, str] = {
     "sse_valkey": "examples.htmx_realtime_sse_valkey.app:app",
     "websocket_valkey": "examples.htmx_realtime_websocket_valkey.app:app",
 }
+INSTALLED_EXAMPLES: set[str] = set()
 
 
 def find_free_port() -> int:
@@ -75,8 +76,11 @@ class ExampleServer:
             raise RuntimeError(message)
 
         env = self._environment()
-        if self.mode == "production":
+        if self.example_name not in INSTALLED_EXAMPLES:
             self._run_cli(["assets", "install"], env=env)
+            INSTALLED_EXAMPLES.add(self.example_name)
+
+        if self.mode == "production":
             self._run_cli(["assets", "build"], env=env)
 
         self.port = find_free_port()

--- a/src/tests/e2e/server_manager.py
+++ b/src/tests/e2e/server_manager.py
@@ -151,6 +151,7 @@ class ExampleServer:
             "LITESTAR_QUEUES_EXAMPLE_STEPS": "2",
             "LITESTAR_QUEUES_EXAMPLE_STEP_DELAY": "0.05",
             "LITESTAR_QUEUES_EXAMPLE_VITE_DEV": "1" if self.mode == "dev" else "0",
+            "LITESTAR_BYPASS_ENV_CHECK": "1",
             "PYTHONUNBUFFERED": "1",
         })
         env.update(self._extra_environment)

--- a/src/tests/e2e/test_example_server.py
+++ b/src/tests/e2e/test_example_server.py
@@ -1,0 +1,19 @@
+"""Smoke tests for the queue example process harness."""
+
+import pytest
+
+from .server_manager import ExampleServer
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("example_name", ["sse", "websocket"])
+@pytest.mark.parametrize("mode", ["dev", "production"])
+def test_example_server_starts(example_name: str, mode: str) -> None:
+    """Both canonical browser examples start through the Litestar CLI."""
+    server = ExampleServer(example_name, mode=mode)  # type: ignore[arg-type]
+    server.start()
+    try:
+        server.wait_until_ready(timeout=90.0)
+        assert server.base_url.startswith("http://127.0.0.1:")
+    finally:
+        server.stop()

--- a/src/tests/e2e/test_realtime_browser.py
+++ b/src/tests/e2e/test_realtime_browser.py
@@ -1,0 +1,210 @@
+"""Browser contracts for the HTMX SSE and WebSocket examples."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from .conftest import BrowserDiagnostics
+
+pytestmark = pytest.mark.e2e
+
+_ERROR_EVENTS = {"htmx:sseError", "htmx:wsError", "htmx:responseError", "htmx:sendError"}
+
+
+def _install_event_collector(page: Any) -> None:
+    page.evaluate(
+        """
+        () => {
+          const events = [];
+          for (const name of [
+            "htmx:sseOpen", "htmx:sseError", "htmx:sseClose",
+            "htmx:wsOpen", "htmx:wsError", "htmx:wsClose",
+            "htmx:responseError", "htmx:sendError",
+            "htmx:sseBeforeMessage", "htmx:wsBeforeMessage",
+          ]) {
+            document.body.addEventListener(name, (event) => {
+              events.push(name);
+              if (name === "htmx:sseBeforeMessage") {
+                window.__queueE2EFrames.push(event.detail?.data ?? null);
+              }
+              if (name === "htmx:wsBeforeMessage") {
+                window.__queueE2EFrames.push(event.detail?.message ?? null);
+              }
+            });
+          }
+          window.__queueE2EEvents = events;
+          window.__queueE2EFrames = [];
+        }
+        """
+    )
+
+
+def _events(page: Any) -> list[str]:
+    return page.evaluate("() => window.__queueE2EEvents ?? []")
+
+
+def _frames(page: Any) -> list[str]:
+    return [frame for frame in page.evaluate("() => window.__queueE2EFrames ?? []") if isinstance(frame, str)]
+
+
+def _assert_task_event(frames: list[str]) -> None:
+    payloads = [json.loads(frame) for frame in frames]
+    assert any(payload.get("type") == "task.event" for payload in payloads), frames
+
+
+def _assert_clean_browser(
+    diagnostics: BrowserDiagnostics, *, server_mode: str, allow_stream_abort: bool = False
+) -> None:
+    allowed_console = []
+    if server_mode == "dev":
+        allowed_console = [
+            message
+            for message in diagnostics.console_errors
+            if "vite" in message.lower() and "websocket" in message.lower()
+        ]
+    unexpected_console = [message for message in diagnostics.console_errors if message not in allowed_console]
+    assert not unexpected_console, f"unexpected browser console errors: {unexpected_console}"
+    assert not diagnostics.page_errors, f"browser page errors: {diagnostics.page_errors}"
+    request_failures = diagnostics.request_failures
+    if allow_stream_abort:
+        request_failures = [
+            failure
+            for failure in request_failures
+            if "net::ERR_ABORTED" not in failure or "/queues/events/" not in failure
+        ]
+    assert not request_failures, f"failed browser requests: {request_failures}"
+    assert not diagnostics.failed_responses, f"failed browser responses: {diagnostics.failed_responses}"
+
+
+def _assert_common_page(page: Any, base_url: str) -> None:
+    assert page.url == f"{base_url}/"
+    assert page.locator("#stream-mount").count() == 1
+    assert page.locator('button[hx-post="/demo/restart"]').count() == 1
+
+
+def _start_mission(page: Any, base_url: str) -> str:
+    with page.expect_response(
+        lambda response: response.request.method == "POST" and response.url == f"{base_url}/demo/restart"
+    ) as response_info:
+        page.get_by_role("button", name="Restart the demo queue job and crawl").click()
+    response = response_info.value
+    assert response.status == 200, response.status_text
+
+    mount = page.locator("#stream-mount")
+    mount.wait_for(state="attached")
+    task_id = mount.get_attribute("data-task-id")
+    assert task_id
+    return task_id
+
+
+def _wait_for_completion(page: Any) -> None:
+    page.locator("#job-readout").filter(has_text="Mission complete").wait_for(state="visible")
+    assert "1/2 -" in page.locator("#crawl-lines").inner_text()
+
+
+@pytest.mark.parametrize("example_name", ["sse"], indirect=True)
+def test_sse_browser_contract(example_server: Any, browser_page: Any, browser_diagnostics: BrowserDiagnostics) -> None:
+    """SSE opens on the Litestar origin and renders live terminal state."""
+    page = browser_page
+    page.goto(example_server.base_url, wait_until="domcontentloaded")
+    _install_event_collector(page)
+    _assert_common_page(page, example_server.base_url)
+    _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode)
+
+    task_id = _start_mission(page, example_server.base_url)
+    mount = page.locator("#stream-mount")
+    assert mount.get_attribute("hx-ext") == "sse"
+    stream_url = mount.get_attribute("sse-connect")
+    assert stream_url == f"/queues/events/sse/tasks/{task_id}"
+
+    page.wait_for_function("() => (window.__queueE2EEvents ?? []).includes('htmx:sseOpen')")
+    _wait_for_completion(page)
+
+    events = _events(page)
+    assert "htmx:sseOpen" in events
+    assert "htmx:sseBeforeMessage" in events
+    _assert_task_event(_frames(page))
+    assert not _ERROR_EVENTS.intersection(events), events
+    _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode)
+
+
+@pytest.mark.parametrize("example_name", ["websocket"], indirect=True)
+def test_websocket_browser_contract(
+    example_server: Any, browser_page: Any, browser_diagnostics: BrowserDiagnostics
+) -> None:
+    """WebSocket opens on the Litestar origin and renders live terminal state."""
+    page = browser_page
+    page.goto(example_server.base_url, wait_until="domcontentloaded")
+    _install_event_collector(page)
+    _assert_common_page(page, example_server.base_url)
+    _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode)
+
+    task_id = _start_mission(page, example_server.base_url)
+    mount = page.locator("#stream-mount")
+    assert mount.get_attribute("hx-ext") == "ws"
+    stream_url = mount.get_attribute("ws-connect")
+    assert stream_url == f"/queues/events/tasks/{task_id}"
+
+    page.wait_for_function("() => (window.__queueE2EEvents ?? []).includes('htmx:wsOpen')")
+    _wait_for_completion(page)
+
+    events = _events(page)
+    assert "htmx:wsOpen" in events
+    assert "htmx:wsBeforeMessage" in events
+    _assert_task_event(_frames(page))
+    assert not _ERROR_EVENTS.intersection(events), events
+    _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode)
+
+
+@pytest.mark.parametrize(
+    ("transport", "example_name"), [("sse", "sse"), ("websocket", "websocket")], indirect=["example_name"]
+)
+def test_replacing_stream_mount_reconnects_cleanly(
+    example_server: Any, browser_page: Any, browser_diagnostics: BrowserDiagnostics, transport: str
+) -> None:
+    """Replacing the HTMX mount closes the old stream before the next run."""
+    page = browser_page
+    page.goto(example_server.base_url, wait_until="domcontentloaded")
+    _install_event_collector(page)
+    websocket_states: dict[str, bool] = {}
+
+    if transport == "websocket":
+
+        def record_websocket(websocket: Any) -> None:
+            websocket_states[websocket.url] = False
+            websocket.on("close", lambda: websocket_states.__setitem__(websocket.url, True))
+
+        page.on("websocket", record_websocket)
+
+    first_task_id = _start_mission(page, example_server.base_url)
+    _wait_for_completion(page)
+    first_events = _events(page)
+    event_prefix = "sse" if transport == "sse" else "ws"
+    assert f"htmx:{event_prefix}Open" in first_events
+
+    second_task_id = _start_mission(page, example_server.base_url)
+    assert second_task_id != first_task_id
+    mount = page.locator("#stream-mount")
+    assert mount.get_attribute("data-task-id") == second_task_id
+    _wait_for_completion(page)
+    _assert_task_event(_frames(page))
+
+    events = _events(page)
+    close_event = f"htmx:{event_prefix}Close"
+    open_event = f"htmx:{event_prefix}Open"
+    if transport == "sse":
+        assert close_event in events, events
+        assert events.index(close_event) < len(events) - 1
+        assert events.index(close_event) < max(index for index, event in enumerate(events) if event == open_event)
+    else:
+        first_socket = next((url for url in websocket_states if first_task_id in url), None)
+        second_socket = next((url for url in websocket_states if second_task_id in url), None)
+        assert first_socket is not None, websocket_states
+        assert second_socket is not None, websocket_states
+        assert websocket_states[first_socket], websocket_states
+    assert not _ERROR_EVENTS.intersection(events), events
+    _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode, allow_stream_abort=True)

--- a/src/tests/e2e/test_realtime_browser.py
+++ b/src/tests/e2e/test_realtime_browser.py
@@ -1,14 +1,11 @@
 """Browser contracts for the HTMX SSE and WebSocket examples."""
 
-from __future__ import annotations
-
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any, cast
 
 import pytest
 
-if TYPE_CHECKING:
-    from .conftest import BrowserDiagnostics
+from .conftest import BrowserDiagnostics
 
 pytestmark = pytest.mark.e2e
 
@@ -44,7 +41,7 @@ def _install_event_collector(page: Any) -> None:
 
 
 def _events(page: Any) -> list[str]:
-    return page.evaluate("() => window.__queueE2EEvents ?? []")
+    return cast("list[str]", page.evaluate("() => window.__queueE2EEvents ?? []"))
 
 
 def _frames(page: Any) -> list[str]:
@@ -96,7 +93,7 @@ def _start_mission(page: Any, base_url: str) -> str:
 
     mount = page.locator("#stream-mount")
     mount.wait_for(state="attached")
-    task_id = mount.get_attribute("data-task-id")
+    task_id = cast("str | None", mount.get_attribute("data-task-id"))
     assert task_id
     return task_id
 

--- a/src/tests/e2e/test_realtime_topology.py
+++ b/src/tests/e2e/test_realtime_topology.py
@@ -1,8 +1,7 @@
 """Cross-process queue and Channels topology tests."""
 
-from __future__ import annotations
-
 import os
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import pytest
@@ -17,6 +16,9 @@ from .test_realtime_browser import (
     _start_mission,
     _wait_for_completion,
 )
+
+if TYPE_CHECKING:
+    from .conftest import BrowserDiagnostics
 
 pytestmark = [pytest.mark.e2e, pytest.mark.topology]
 
@@ -40,8 +42,8 @@ def test_shared_channels_deliver_from_a_standalone_worker(
     default_url: str,
     key_env: str,
     transport: str,
-    browser_page: object,
-    browser_diagnostics: object,
+    browser_page: Any,
+    browser_diagnostics: "BrowserDiagnostics",
 ) -> None:
     """A separate queue worker publishes live events through shared Channels."""
     url = os.getenv(url_env, default_url)
@@ -99,12 +101,12 @@ def test_shared_channels_deliver_from_a_standalone_worker(
         client.close()
 
 
-def _connect_or_skip(backend: str, url: str) -> object:
+def _connect_or_skip(backend: str, url: str) -> Any:
     try:
         if backend == "redis":
             from redis import Redis
 
-            client = Redis.from_url(url, socket_connect_timeout=1, socket_timeout=1)
+            client: Any = Redis.from_url(url, socket_connect_timeout=1, socket_timeout=1)
         else:
             from valkey import Valkey
 

--- a/src/tests/e2e/test_realtime_topology.py
+++ b/src/tests/e2e/test_realtime_topology.py
@@ -1,0 +1,121 @@
+"""Cross-process queue and Channels topology tests."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from .server_manager import ExampleServer, QueueWorker
+from .test_realtime_browser import (
+    _assert_clean_browser,
+    _assert_task_event,
+    _events,
+    _frames,
+    _install_event_collector,
+    _start_mission,
+    _wait_for_completion,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.topology]
+
+
+def test_queue_worker_uses_the_litestar_queue_cli() -> None:
+    worker = QueueWorker("sse", environment={})
+    assert worker.command[-6:] == ["queues", "run", "--queue", "demo", "--drain-timeout", "30"]
+
+
+@pytest.mark.parametrize(
+    ("backend", "url_env", "default_url", "key_env"),
+    [
+        ("redis", "LITESTAR_QUEUES_EXAMPLE_REDIS_URL", "redis://127.0.0.1:16379/0", "REDIS"),
+        ("valkey", "LITESTAR_QUEUES_EXAMPLE_VALKEY_URL", "redis://127.0.0.1:16380/0", "VALKEY"),
+    ],
+)
+@pytest.mark.parametrize("transport", ["sse", "websocket"])
+def test_shared_channels_deliver_from_a_standalone_worker(
+    backend: str,
+    url_env: str,
+    default_url: str,
+    key_env: str,
+    transport: str,
+    browser_page: object,
+    browser_diagnostics: object,
+) -> None:
+    """A separate queue worker publishes live events through shared Channels."""
+    url = os.getenv(url_env, default_url)
+    client = _connect_or_skip(backend, url)
+    suffix = uuid4().hex
+    queue_prefix = f"litestar_queues:e2e:{suffix}:queue"
+    environment = {
+        url_env: url,
+        "LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS": "1",
+        "LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER": "0",
+        "LITESTAR_QUEUES_EXAMPLE_STEPS": "2",
+        "LITESTAR_QUEUES_EXAMPLE_STEP_DELAY": "0.05",
+        f"LITESTAR_QUEUES_EXAMPLE_{key_env}_KEY_PREFIX": queue_prefix,
+        "LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX": f"litestar_queues:e2e:{suffix}:channels",
+    }
+    example_name = f"{transport}_{backend}"
+    server = ExampleServer(example_name, mode="production", environment=environment)
+    worker = QueueWorker(example_name, environment=environment)
+    try:
+        server.start()
+        server.wait_until_ready(timeout=90.0)
+        worker.start()
+        worker.wait_until_running()
+
+        page = browser_page
+        page.goto(server.base_url, wait_until="domcontentloaded")
+        _install_event_collector(page)
+        task_id = _start_mission(page, server.base_url)
+        mount = page.locator("#stream-mount")
+        if transport == "sse":
+            assert mount.get_attribute("sse-connect") == f"/queues/events/sse/tasks/{task_id}"
+            page.wait_for_function("() => (window.__queueE2EEvents ?? []).includes('htmx:sseOpen')")
+        else:
+            assert mount.get_attribute("ws-connect") == f"/queues/events/tasks/{task_id}"
+            page.wait_for_function("() => (window.__queueE2EEvents ?? []).includes('htmx:wsOpen')")
+        page.set_default_timeout(15_000)
+        try:
+            _wait_for_completion(page)
+        except Exception as exc:
+            message = (
+                f"browser events: {_events(page)}\n"
+                f"worker output: {worker._recent_logs()}\n"
+                f"server output: {server._recent_logs()}\n"
+                f"queue keys: {list(client.scan_iter(match=f'{queue_prefix}*'))}"
+            )
+            raise AssertionError(message) from exc
+        _assert_task_event(_frames(page))
+        assert "htmx:sseError" not in _events(page)
+        assert "htmx:wsError" not in _events(page)
+        _assert_clean_browser(browser_diagnostics, server_mode="production")
+    finally:
+        worker.stop()
+        server.stop()
+        _delete_prefix(client, f"litestar_queues:e2e:{suffix}:")
+        client.close()
+
+
+def _connect_or_skip(backend: str, url: str) -> object:
+    try:
+        if backend == "redis":
+            from redis import Redis
+
+            client = Redis.from_url(url, socket_connect_timeout=1, socket_timeout=1)
+        else:
+            from valkey import Valkey
+
+            client = Valkey.from_url(url, socket_connect_timeout=1, socket_timeout=1)
+        client.ping()
+    except Exception as exc:  # noqa: BLE001 - vendor client errors vary by backend
+        pytest.skip(f"{backend} service unavailable at {url}: {exc}")
+    return client
+
+
+def _delete_prefix(client: object, prefix: str) -> None:
+    keys = list(client.scan_iter(match=f"{prefix}*"))  # type: ignore[attr-defined]
+    if keys:
+        client.delete(*keys)  # type: ignore[attr-defined]

--- a/src/tests/unit/examples/test_htmx_realtime_example.py
+++ b/src/tests/unit/examples/test_htmx_realtime_example.py
@@ -31,19 +31,11 @@ BACKEND_VARIANTS = {
     },
     "redis": {
         "suffix": "_redis",
-        "backend_markers": (
-            "RedisBackendConfig",
-            "LITESTAR_QUEUES_EXAMPLE_REDIS_URL",
-            'key_prefix="litestar_queues:examples:',
-        ),
+        "backend_markers": ("RedisBackendConfig", "LITESTAR_QUEUES_EXAMPLE_REDIS_URL", "REDIS_KEY_PREFIX"),
     },
     "valkey": {
         "suffix": "_valkey",
-        "backend_markers": (
-            "ValkeyBackendConfig",
-            "LITESTAR_QUEUES_EXAMPLE_VALKEY_URL",
-            'key_prefix="litestar_queues:examples:',
-        ),
+        "backend_markers": ("ValkeyBackendConfig", "LITESTAR_QUEUES_EXAMPLE_VALKEY_URL", "VALKEY_KEY_PREFIX"),
     },
 }
 
@@ -136,7 +128,7 @@ def test_htmx_realtime_examples_keep_simple_queue_and_vite_config() -> None:
         assert "execution_backend=" not in app_source
         assert "in_app_worker=" not in app_source
         assert "worker_poll_interval=" not in app_source
-        assert 'buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2, overflow="drop_oldest")' in app_source
+        assert "buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)" in app_source
         assert "EventStreamConfig(" in app_source
         assert "status_json" in app_source
         assert "HTMXTemplate(" in app_source
@@ -153,6 +145,31 @@ def test_htmx_realtime_examples_keep_simple_queue_and_vite_config() -> None:
     assert "queue_backend=" not in memory_app
     sse_memory_app = (EXAMPLES_ROOT / "htmx_realtime_sse" / "app.py").read_text()
     assert "queue_backend=" not in sse_memory_app
+
+
+def test_htmx_realtime_examples_keep_live_channels_process_local_by_default() -> None:
+    for name in EXAMPLE_VARIANTS:
+        app_source = (EXAMPLES_ROOT / name / "app.py").read_text()
+        assert "MemoryChannelsBackend" in app_source, name
+        assert "ChannelsPlugin(" in app_source, name
+
+
+def test_redis_and_valkey_examples_offer_explicit_shared_channels_mode() -> None:
+    common_source = (EXAMPLES_ROOT / "htmx_realtime_common.py").read_text()
+    assert 'os.getenv("LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER") == "0"' in common_source
+    assert 'return {"in_app_worker": False}' in common_source
+
+    for name in EXAMPLE_VARIANTS:
+        if str(EXAMPLE_VARIANTS[name]["backend_name"]) not in {"redis", "valkey"}:
+            continue
+        app_source = (EXAMPLES_ROOT / name / "app.py").read_text()
+        assert "LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS" in app_source, name
+        assert "standalone_worker_options" in app_source, name
+        assert "RedisChannelsStreamBackend" in app_source, name
+        assert "decode_responses=False" in app_source, name
+        assert "CHANNELS_KEY_PREFIX" in app_source, name
+        if str(EXAMPLE_VARIANTS[name]["backend_name"]) == "valkey":
+            assert "from redis" not in app_source, name
 
 
 def _assert_canonical_frontend(example_root: Path) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -815,16 +815,16 @@ wheels = [
 
 [[package]]
 name = "docker"
-version = "7.1.0"
+version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
 ]
 
 [[package]]
@@ -924,7 +924,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1586,7 +1586,7 @@ wheels = [
 
 [[package]]
 name = "litestar-queues"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "litestar" },
@@ -1687,6 +1687,10 @@ docs = [
     { name = "sphinx-togglebutton" },
     { name = "sphinxcontrib-mermaid" },
 ]
+e2e = [
+    { name = "playwright" },
+    { name = "pytest-playwright" },
+]
 tests = [
     { name = "adbc-driver-sqlite" },
     { name = "advanced-alchemy" },
@@ -1782,6 +1786,10 @@ docs = [
     { name = "sphinx-paramlinks", specifier = ">=0.6.0" },
     { name = "sphinx-togglebutton", specifier = ">=0.3.2" },
     { name = "sphinxcontrib-mermaid", specifier = ">=0.9.2" },
+]
+e2e = [
+    { name = "playwright", specifier = ">=1.50.0" },
+    { name = "pytest-playwright", specifier = ">=0.7.0" },
 ]
 tests = [
     { name = "adbc-driver-sqlite" },
@@ -2766,6 +2774,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2810,14 +2837,14 @@ wheels = [
 
 [[package]]
 name = "proto-plus"
-version = "1.28.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/44/767757fd2cdd4a60d7e4440d9f7b491d6131103d313638d2c03e06c268fb/proto_plus-1.28.1.tar.gz", hash = "sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168", size = 57166, upload-time = "2026-07-08T17:04:02.367Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/34/2f2b57dbfd145b995a29847a16b0903fce5ef6ad3c7aad740a609c5d3678/proto_plus-1.28.1-py3-none-any.whl", hash = "sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed", size = 50408, upload-time = "2026-07-08T17:03:34.532Z" },
 ]
 
 [[package]]
@@ -3077,11 +3104,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -3264,6 +3291,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3385,6 +3424,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3445,6 +3497,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-playwright"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/ef/172eb8e23c80491fc72f1401c72f9305663873649351306a38b18406b0c9/pytest_playwright-0.8.0.tar.gz", hash = "sha256:7888d4a2443160c82e0c506c437076679f86b36d1910427250d90fbf1843a981", size = 17132, upload-time = "2026-05-18T10:16:15.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl", hash = "sha256:856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933", size = 17143, upload-time = "2026-05-18T10:16:18.226Z" },
+]
+
+[[package]]
 name = "pytest-sugar"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3489,6 +3556,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -3667,27 +3746,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.20"
+version = "0.15.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
-    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
-    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
-    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
-    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
 ]
 
 [[package]]
@@ -4221,6 +4300,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a queue-local Litestar process harness and real Chromium coverage for the HTMX SSE/WebSocket examples in development and production asset modes.
- Validate standalone Redis/Valkey workers with shared Channels Streams, unique prefixes, owned-client shutdown, and backend-specific client boundaries.
- Make all realtime examples inherit queue/event defaults instead of repeating them; only an explicit `LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0` enables the standalone-worker override.
- Document the separation between queue persistence, worker wakeups, and browser Channels fan-out, including Redis, Valkey, SQLite, PostgreSQL, Oracle AQ, and TxEventQ boundaries.
- Add the explicit E2E workflow and dependency/Make targets.