### PR TITLE
feat: complete queue backend and realtime example overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,12 @@ docs-linkcheck:                                     ## Check documentation links
 	@uv run sphinx-build -b linkcheck docs docs/_build/linkcheck
 	@echo "${OK} Docs linkcheck complete"
 
+.PHONY: docs-audit
+docs-audit:                                         ## Audit documentation structure and terminology
+	@echo "${INFO} Auditing docs..."
+	@uv run python tools/docs_audit.py
+	@echo "${OK} Docs audit complete"
+
 .PHONY: docs-clean
 docs-clean:                                         ## Clean documentation artifacts
 	@echo "${INFO} Cleaning docs artifacts..."

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ queue and in-app worker are ideal for this first run.
 
 ## Production boundary
 
-Queue persistence and execution placement are separate choices. The default
-memory backend is process-local, so production deployments with separate web
-and worker processes need a shared backend such as SQLSpec, Advanced Alchemy,
-Redis, or Valkey. Run standalone workers when web and task capacity should
-scale independently. Cloud Run is an execution backend, not queue storage.
+Choose where tasks are stored separately from where they run. The default
+memory backend stores tasks in one Python process. If the web app and worker
+run in separate processes, use a shared backend such as SQLSpec, Advanced
+Alchemy, Redis, or Valkey. Use standalone workers when the web app and task
+workers must scale separately. Cloud Run runs tasks; it does not store them.
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -6,45 +6,20 @@
 [![CI](https://github.com/cofin/litestar-queues/actions/workflows/ci.yml/badge.svg)](https://github.com/cofin/litestar-queues/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-cofin.github.io-blue)](https://cofin.github.io/litestar-queues/)
 
-Litestar Queues adds background task queues to Litestar applications. Define a
-task with a decorator, enqueue it from a route handler or service, and let a
-worker run it now, later, after a retry, or on a schedule.
+Litestar Queues lets a Litestar application persist work, run it in a worker,
+and inspect the result. Use it for work that should outlive the request that
+started it: sending email, importing files, refreshing reports, or calling a
+slow service.
 
-Use it when a request should return quickly while work continues elsewhere:
-sending email, refreshing reports, syncing accounts, importing files, calling
-slow APIs, or running operational maintenance jobs.
+## Quickstart
 
-## What You Get
-
-- **Simple task API**: `@task(...)` registers async or sync callables with
-  defaults for queues, retries, priority, timeout, delay, logging, and metadata.
-- **Litestar plugin**: `QueuePlugin` wires a managed `QueueService` into
-  Litestar dependency injection, app state, startup, shutdown, and CLI commands.
-- **Workers included**: run an in-app worker for local/lightweight apps or a
-  standalone worker process for production deployments.
-- **Scheduling**: run recurring interval or five-field cron tasks.
-- **Result tracking**: queued records move through `pending`, `scheduled`,
-  `running`, `completed`, `failed`, and `cancelled`.
-- **Pluggable backends**: start with the in-memory backend, then move to
-  SQLSpec, Advanced Alchemy, Redis, Valkey, or Cloud Run execution when needed.
-- **Realtime events**: publish lifecycle, progress, log, and custom task events
-  to your own Litestar Channels setup.
-
-## Install
+Install the package:
 
 ```bash
 pip install litestar-queues
 ```
 
-The base install is intentionally small. It includes the task API, Litestar
-plugin, in-memory queue backend, immediate execution, and local workers.
-Persistent or remote integrations are optional extras.
-
-Litestar Queues supports Python 3.10 through 3.14.
-
-## Quick Start
-
-Create an `app.py`:
+Create `app.py`:
 
 ```python
 from litestar import Litestar, post
@@ -53,7 +28,7 @@ from litestar.di import NamedDependency
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
 
 
-@task("accounts.sync", queue="accounts", retries=3, timeout=300)
+@task("accounts.sync", queue="accounts", timeout=30)
 async def sync_account(account_id: str) -> dict[str, str]:
     return {"account_id": account_id, "status": "synced"}
 
@@ -64,7 +39,7 @@ async def create_sync_job(
     queue_service: NamedDependency[QueueService],
 ) -> dict[str, str]:
     result = await queue_service.enqueue(sync_account, account_id)
-    return {"task_id": str(result.id), "status": result.status or "queued"}
+    return {"task_id": str(result.id), "status": result.status or "pending"}
 
 
 app = Litestar(
@@ -73,316 +48,36 @@ app = Litestar(
 )
 ```
 
-Run the app:
+Run the application:
 
 ```bash
 LITESTAR_APP=app:app litestar run --reload
 ```
 
-Call the route:
+Enqueue a task:
 
 ```bash
 curl -X POST http://127.0.0.1:8000/accounts/acct-123/sync
 ```
 
-Trigger the same job in whichever form fits the caller:
-
-```python
-# 1. Pass the decorated task object.
-await queue_service.enqueue(sync_account, account_id)
-
-# 2. Pass the registered task name when the caller should not import the task.
-await queue_service.enqueue("accounts.sync", account_id)
-
-# 3. Use the task helper when the QueuePlugin has an active default service.
-await sync_account.enqueue(account_id)
-```
-
-If you enqueue by string to avoid importing the task function, make sure the
-module is loaded at startup so the decorator can register the task name:
-
-```python
-app = Litestar(
-    route_handlers=[create_sync_job],
-    plugins=[
-        QueuePlugin(
-            config=QueueConfig(task_modules=("app.accounts.tasks",)),
-        ),
-    ],
-)
-```
-
-All three forms can still override execution for one job:
-
-```python
-await queue_service.enqueue(
-    "accounts.sync",
-    account_id,
-    execution_backend="cloudrun",
-    execution_profile="heavy",
-)
-```
-
-By default, Litestar Queues uses in-memory queue storage and starts a local
-worker inside the Litestar process. That is useful for learning, tests, and
-small local apps. For production, use a persistent queue backend and usually run
-workers separately from the web process.
-
-## The Basic Model
-
-Litestar Queues keeps two decisions separate:
-
-- A **queue backend** stores task records and state.
-- An **execution backend** decides where claimed work runs.
-
-The default is `queue_backend="memory"` and `execution_backend="local"`.
-`memory` stores records inside the current Python process. `local` runs claimed
-tasks in the worker process. `immediate` is available for inline execution,
-mostly in tests.
-
-## Running Workers
-
-For local development, the in-app worker is the shortest path:
-
-```python
-config = QueueConfig(in_app_worker=True)
-```
-
-For heavier deployments, turn off the in-app worker in the web app:
-
-```python
-config = QueueConfig(in_app_worker=False)
-```
-
-Then run one or more standalone workers:
-
-```bash
-LITESTAR_APP=app:app litestar queues run --drain-timeout 30
-```
-
-Workers process every queue by default. Restrict a worker to one or more queue
-names with `--queue`:
-
-```bash
-LITESTAR_APP=app:app litestar queues run --queue accounts --queue emails
-```
-
-## Documentation
-
-- [Getting Started](https://cofin.github.io/litestar-queues/getting_started/index.html)
-- [Usage Guides](https://cofin.github.io/litestar-queues/usage/index.html)
-- [Backends](https://cofin.github.io/litestar-queues/usage/backends.html)
-- [API Reference](https://cofin.github.io/litestar-queues/reference/index.html)
-
-<details>
-<summary>Optional backend and execution choices</summary>
-
-Install only the extras your app needs:
-
-```bash
-pip install "litestar-queues[sqlspec]"
-pip install "litestar-queues[advanced-alchemy]"
-pip install "litestar-queues[redis]"
-pip install "litestar-queues[valkey]"
-pip install "litestar-queues[cloudrun]"
-```
-
-| Name | Type | Typical use |
-| --- | --- | --- |
-| `memory` | Queue backend | Tests, examples, and local in-process apps |
-| `sqlspec` | Queue backend | SQL-backed persistence through SQLSpec adapters |
-| `advanced-alchemy` | Queue backend | SQLAlchemy/Advanced Alchemy persistence |
-| `redis` | Queue backend | Redis-backed task records and worker wakeups |
-| `valkey` | Queue backend | Valkey-backed task records and worker wakeups |
-| `immediate` | Execution backend | Inline execution for tests and scripts |
-| `local` | Execution backend | In-process worker execution |
-| `cloudrun` | Execution backend | Dispatch to Google Cloud Run Jobs |
-
-SQLSpec example:
-
-```python
-from sqlspec.adapters.aiosqlite import AiosqliteConfig
-
-from litestar_queues import QueueConfig
-from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-queue_config = QueueConfig(
-    queue_backend=SQLSpecBackendConfig(
-        config=AiosqliteConfig(connection_config={"database": "queue.db"}),
-        run_migrations=True,
-    ),
-    execution_backend="local",
-)
-```
-
-Redis example:
-
-```python
-from litestar_queues import QueueConfig
-from litestar_queues.backends.redis import RedisBackendConfig
-
-queue_config = QueueConfig(
-    queue_backend=RedisBackendConfig(url="redis://localhost:6379/0"),
-    execution_backend="local",
-)
-```
-
-</details>
-
-<details>
-<summary>Task options, scheduling, events, and background responses</summary>
-
-Task defaults can live on the decorator:
-
-```python
-@task(
-    "reports.render",
-    queue="reports",
-    priority=10,
-    retries=2,
-    timeout=120,
-    run_after=30,
-)
-async def render_report(report_id: str) -> str:
-    return report_id
-```
-
-Override those defaults for one enqueue call:
-
-```python
-result = await queue_service.enqueue(
-    render_report,
-    "report-1",
-    queue="slow-reports",
-    priority=1,
-    retries=5,
-    timeout=600,
-    metadata={"requested_by": "user-123"},
-)
-await result.wait(timeout=30)
-```
-
-Successful completion logs are quiet by default. This only suppresses the
-operator log line for a successful task; lifecycle events, progress/log events,
-streams, and event history still publish. Set `QueueConfig(quiet_success=False)`
-or pass `quiet_success=False` on a task or enqueue call when successful
-completion logs should be emitted.
-
-Run recurring tasks with intervals or cron expressions:
-
-```python
-from datetime import timedelta
-
-from litestar_queues import task
-
-
-@task("reports.refresh", interval=timedelta(minutes=15), jitter=30)
-async def refresh_reports() -> None:
-    ...
-
-
-@task("billing.close-day", cron="0 0 * * *", timezone="UTC")
-async def close_billing_day() -> None:
-    ...
-```
-
-Publish progress from inside a running task:
-
-```python
-from litestar_queues.events import publish_task_log, publish_task_progress
-
-
-@task("imports.process")
-async def process_import(path: str) -> None:
-    await publish_task_log("Import started")
-    await publish_task_progress(current=5, total=10, message="Halfway done")
-```
-
-Return the HTTP response first, then enqueue the job:
-
-```python
-from litestar import Response, post
-from litestar_queues import QueuedBackgroundTask
-
-
-@post("/trigger")
-async def trigger() -> Response[dict[str, str]]:
-    return Response(
-        {"status": "queued"},
-        background=QueuedBackgroundTask(process_import, "/tmp/data.csv"),
-    )
-```
-
-`QueuedBackgroundTask` only saves the job in the queue. Your queue settings
-decide when the task runs.
-
-Use `await queue_service.enqueue(...)` inside the route when the job must be
-saved before the response is sent.
-
-</details>
-
-<details>
-<summary>CLI commands</summary>
-
-`QueuePlugin` adds a `queues` command group to the Litestar CLI:
-
-```bash
-# Start a standalone worker.
-LITESTAR_APP=app:app litestar queues run --drain-timeout 30
-
-# Process only selected queues.
-LITESTAR_APP=app:app litestar queues run --queue accounts --max-concurrency 4
-
-# Print queue status counts.
-LITESTAR_APP=app:app litestar queues status
-
-# Emit queue status as JSON.
-LITESTAR_APP=app:app litestar queues status --json
-
-# Check whether a scheduler canary task completed recently.
-LITESTAR_APP=app:app litestar queues scheduler-health --minutes 5
-```
-
-Every command loads the application the same way the Litestar CLI does: via
-`LITESTAR_APP`, `--app`, or the standard app discovery paths.
-
-</details>
-
-<details>
-<summary>Development</summary>
-
-```bash
-# Install local development dependencies and provision assets for all shipped examples.
-make install
-
-# Optionally pre-build bundled example frontend bundles.
-make build-examples-assets
-
-# Run unit tests only.
-make test-unit
-
-# Run integration tests. Docker-backed services auto-skip when unavailable.
-make test-integration
-
-# Build documentation.
-make docs
-
-# Run linting and type checks.
-make lint
-```
-
-The source lives under `src/litestar_queues`. Tests live under
-`src/tests/unit` and `src/tests/integration`.
-
-</details>
-
-## Links
-
-- Docs: <https://cofin.github.io/litestar-queues/>
-- Source: <https://github.com/cofin/litestar-queues>
-- Issues: <https://github.com/cofin/litestar-queues/issues>
-- Litestar: <https://litestar.dev/>
-
-## License
-
-MIT
+The response contains a task ID and an initial status. The default in-memory
+queue and in-app worker are ideal for this first run.
+
+## Production boundary
+
+Queue persistence and execution placement are separate choices. The default
+memory backend is process-local, so production deployments with separate web
+and worker processes need a shared backend such as SQLSpec, Advanced Alchemy,
+Redis, or Valkey. Run standalone workers when web and task capacity should
+scale independently. Cloud Run is an execution backend, not queue storage.
+
+## Next steps
+
+- [Start here](https://cofin.github.io/litestar-queues/getting_started/index.html)
+- [Understand the model](https://cofin.github.io/litestar-queues/usage/concepts.html)
+- [Follow a how-to guide](https://cofin.github.io/litestar-queues/usage/index.html)
+- [Choose backends](https://cofin.github.io/litestar-queues/usage/backends.html)
+- [Run an example](https://cofin.github.io/litestar-queues/examples/index.html)
+- [Browse the API reference](https://cofin.github.io/litestar-queues/reference/index.html)
+
+Litestar Queues supports Python 3.10 through 3.14 and is licensed under MIT.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,11 +10,12 @@ try:
 except ModuleNotFoundError:
     SAWarning = None
 else:
-    warnings.filterwarnings(
-        "ignore",
-        message="Unmanaged access of declarative attribute .* from non-mapped class QueueTaskModelMixin",
-        category=SAWarning,
-    )
+    for declarative_class in ("QueueTaskModelMixin", "QueueEventLogModelMixin", "UUIDAuditBase"):
+        warnings.filterwarnings(
+            "ignore",
+            message=f"Unmanaged access of declarative attribute .* from non-mapped class {declarative_class}",
+            category=SAWarning,
+        )
 
 current_path = Path(__file__).parent.parent.resolve()
 sys.path.append(str(current_path))
@@ -98,22 +99,27 @@ html_theme_options: "dict[str, Any]" = {
             "title": "Docs",
             "children": [
                 {
-                    "title": "Get Started",
+                    "title": "Start here",
                     "url": "getting_started/index",
-                    "summary": "Install the package and enqueue the first task.",
+                    "summary": "Install the package and enqueue your first task.",
                 },
                 {
-                    "title": "Usage",
+                    "title": "Concepts",
+                    "url": "usage/concepts",
+                    "summary": "Understand task records, workers, backends, and events.",
+                },
+                {
+                    "title": "How-to guides",
                     "url": "usage/index",
-                    "summary": "Configure tasks, workers, schedules, events, and testing.",
+                    "summary": "Complete focused task, worker, backend, and event goals.",
                 },
                 {
-                    "title": "Backends",
-                    "url": "usage/backends",
-                    "summary": "Choose queue persistence and execution integrations.",
+                    "title": "Examples",
+                    "url": "examples/index",
+                    "summary": "Run WebSocket and SSE applications with backend variants.",
                 },
                 {
-                    "title": "API Reference",
+                    "title": "Reference",
                     "url": "reference/index",
                     "summary": "Browse the public queue, backend, worker, and event APIs.",
                 },
@@ -131,6 +137,11 @@ html_theme_options: "dict[str, Any]" = {
                     "title": "Testing",
                     "url": "contributing/testing",
                     "summary": "Run unit, integration, backend, and docs checks.",
+                },
+                {
+                    "title": "Documentation",
+                    "url": "contributing/documentation",
+                    "summary": "Write and audit focused, source-backed documentation.",
                 },
             ],
         },

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -2,8 +2,8 @@
 Writing documentation
 =========================
 
-Write for the reader's next goal. Keep the beginner path short, put the
-default before alternatives, and move backend internals or matrices into a
+Write for the reader's next goal. Keep the beginner path short. Explain the
+default before alternatives, and move backend internals or matrices to a
 focused guide or reference page.
 
 Authoring workflow
@@ -30,17 +30,17 @@ Authoring workflow
 Page templates
 ==============
 
-**Concept:** define the boundary, show one compact flow, contrast commonly
-confused terms, then link to goal-oriented guides.
+**Concept:** define the topic and its limits, show one compact flow, contrast
+terms readers may confuse, then link to goal-oriented guides.
 
 **How-to:** state the outcome, show a complete minimal example, explain only
 the decisions in that example, then link to alternatives and operations.
 
-**Reference:** enumerate the public contract, defaults, fields, return values,
-and errors. Do not turn generated API output into a tutorial.
+**Reference:** list the public API, defaults, fields, return values, and errors.
+Do not turn generated API output into a tutorial.
 
-**Gallery:** identify the canonical runnable example, describe variants as
-deltas, state topology requirements, and link to browser acceptance coverage.
+**Gallery:** identify the main runnable example, explain how each variant
+differs, state its process layout, and link to browser test coverage.
 
 Review rubric
 =============

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -1,0 +1,65 @@
+=========================
+Writing documentation
+=========================
+
+Write for the reader's next goal. Keep the beginner path short, put the
+default before alternatives, and move backend internals or matrices into a
+focused guide or reference page.
+
+Authoring workflow
+==================
+
+1. Read the live implementation, public types, focused tests, and runnable
+   example before writing a behavioral claim.
+2. Choose one page mode: concept, how-to, reference, explanation, or gallery.
+3. Start a how-to with a complete minimal example. Import long examples with
+   ``literalinclude`` from ``examples/``.
+4. Link to advanced options instead of repeating them across landing pages.
+5. Preserve existing URLs. Rewrite landing pages in place or provide a
+   compatibility page when content moves.
+6. Run the deterministic audit, structural tests, docs build, and link check.
+
+.. code-block:: bash
+
+   make docs-audit
+   uv run pytest src/tests/unit/test_docs_structure.py \
+     src/tests/unit/examples/test_htmx_realtime_example.py
+   make docs
+   make docs-linkcheck
+
+Page templates
+==============
+
+**Concept:** define the boundary, show one compact flow, contrast commonly
+confused terms, then link to goal-oriented guides.
+
+**How-to:** state the outcome, show a complete minimal example, explain only
+the decisions in that example, then link to alternatives and operations.
+
+**Reference:** enumerate the public contract, defaults, fields, return values,
+and errors. Do not turn generated API output into a tutorial.
+
+**Gallery:** identify the canonical runnable example, describe variants as
+deltas, state topology requirements, and link to browser acceptance coverage.
+
+Review rubric
+=============
+
+* The page has one audience, one goal, and one dominant mode.
+* The default path appears before optional integrations and edge cases.
+* Queue persistence, execution placement, worker wakeups, live task events,
+  and event history remain separate concepts.
+* Commands, defaults, install extras, statuses, and wire names match source.
+* The README and quickstart use the same complete application.
+* Every toctree and ``literalinclude`` target exists.
+* No primary guide exceeds about 1,200 words without a reference or matrix reason.
+* Cards, callouts, and tables remain readable in light and dark themes.
+
+Audit output
+============
+
+``tools/docs_audit.py`` is read-only. It inventories pages and toctree
+membership, counts words/headings/code, flags mixed API/tutorial pages,
+reviews the primary Python block, reports vocabulary and obsolete terms, and
+notes likely README/quickstart duplication. Review prompts require judgment;
+missing structural targets fail the command.

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -5,3 +5,4 @@ Contributing
    :maxdepth: 1
 
    testing
+   documentation

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -1,12 +1,14 @@
 Testing
 =======
 
-The project test suite lives under ``src/tests``. Keep that layout intact:
-``src/tests/unit`` is for pure-Python behavior, ``src/tests/integration`` is
-for driver-backed queues, service containers, vendor emulators, and execution
-backend coverage, and ``src/tests/_factories`` holds shared test factories.
+The test suite lives under ``src/tests``. Keep these roles separate:
 
-The root ``src/tests/conftest.py`` owns fixtures that every tier can use:
+* ``src/tests/unit`` covers pure-Python behavior.
+* ``src/tests/integration`` covers queue drivers, service containers, vendor
+  emulators, and execution backends.
+* ``src/tests/_factories`` contains shared test factories.
+
+The root ``src/tests/conftest.py`` provides fixtures that every tier can use:
 ``anyio_backend``, task-registry cleanup, and default Litestar app/plugin
 fixtures. Unit tests must not import optional queue drivers. Integration tests
 may import drivers, request pytest-databases services, and use Docker-backed
@@ -47,11 +49,11 @@ tiers. Install their Python dependencies and Chromium, then run:
    uv run playwright install chromium
    make test-examples-e2e
 
-The ``e2e`` dependency group supplies Playwright and pytest-playwright. The E2E
-target installs the group and Chromium again so CI and a fresh workstation use
-the same self-contained command. It starts real Litestar/Vite example
-processes through ``litestar run`` and drives them with Chromium. It is not
-included in ``make test`` or the ordinary integration workflow.
+The ``e2e`` dependency group installs Playwright and pytest-playwright. The E2E
+target installs that group and Chromium so CI and a new workstation use one
+self-contained command. It starts real Litestar/Vite examples with
+``litestar run`` and controls them through Chromium. ``make test`` and the
+normal integration workflow do not include these browser tests.
 
 Browser topology boundaries
 ---------------------------
@@ -72,12 +74,12 @@ Browser topology boundaries
      - Test process only
      - Route content type, authorization hooks, envelopes, keepalives, and sink behavior.
 
-The memory browser cases are process-local and cannot prove a separate worker
-or multiple web replicas. Redis/Valkey cases opt into shared Channels with
-unique queue and Channels prefixes; selecting a Redis/Valkey queue backend by
-itself is not sufficient. Browser tests use demo-only stream authorization.
-Production routes must enforce tenant/user ownership, authenticated service
-connections, and origin/proxy policy.
+The memory browser cases run in one process. They cannot prove behavior with a
+separate worker or multiple web replicas. Redis/Valkey cases enable shared
+Channels and use unique queue and Channels prefixes. Selecting a Redis/Valkey
+queue backend alone is not enough. Browser tests use demo-only stream
+authorization. Production routes must check tenant and user ownership,
+authenticate service connections, and enforce origin and proxy policy.
 
 CI keeps unit/integration and browser jobs separate because Chromium and real
 Redis/Valkey topology have different setup, runtime, and failure diagnostics.
@@ -88,11 +90,11 @@ If you want to prebuild all example frontend assets in one step:
 
    make build-examples-assets
 
-The integration tier intentionally relies on pytest-databases autoskip
-behavior. A test should request a service fixture such as ``postgres_service``,
-``mysql_service``, ``oracle_service``, ``redis_service``, or ``valkey_service`` and let the
-fixture skip when Docker or an emulator dependency is unavailable. Do not add
-custom "Docker is available" assertions to tests.
+Integration tests rely on pytest-databases to skip unavailable services. A
+test should request a fixture such as ``postgres_service``, ``mysql_service``,
+``oracle_service``, ``redis_service``, or ``valkey_service``. Let the fixture
+skip when Docker or an emulator is unavailable. Do not add custom "Docker is
+available" assertions.
 
 Backend Registry
 ----------------
@@ -107,10 +109,11 @@ Backend Registry
 * ``build``: the async builder that returns an unopened queue backend.
 * ``capabilities``: behavior tags used by contract tests.
 
-``src/tests/integration/conftest.py`` parametrizes any test that asks for the
-``queue_backend`` fixture across the registry. It builds a ``FixtureCtx`` with
-``tmp_path`` and any requested service handle, opens the backend, yields it to
-the test, and drops queue artifacts on teardown for service-backed adapters.
+``src/tests/integration/conftest.py`` runs each test that requests
+``queue_backend`` against the registry. It creates a ``FixtureCtx`` with
+``tmp_path`` and any requested service. It then opens the backend, gives it to
+the test, and removes queue artifacts during teardown for service-backed
+adapters.
 
 Adding a Backend
 ----------------
@@ -130,9 +133,8 @@ Adding a Backend
 Cloud Run
 ---------
 
-Google Cloud Run Jobs does not provide a public local emulator. The Cloud Run
-execution suite therefore lives under
-``src/tests/integration/execution/cloudrun`` and uses injected fake
-``JobsClient`` and ``ExecutionsClient`` implementations to exercise request
-construction, dispatch ownership, reconciliation, entrypoint behavior, and the
+Google Cloud Run Jobs has no public local emulator. Tests under
+``src/tests/integration/execution/cloudrun`` therefore inject fake
+``JobsClient`` and ``ExecutionsClient`` implementations. They cover request
+construction, dispatch ownership, status checks, entrypoint behavior, and the
 optional import boundary without calling GCP.

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -43,11 +43,44 @@ tiers. Install their Python dependencies and Chromium, then run:
 
 .. code-block:: bash
 
+   make install-e2e
+   uv run playwright install chromium
    make test-examples-e2e
 
-The E2E target starts the real Litestar/Vite example processes through
-``litestar run`` and drives them with Chromium. It is not included in
-``make test`` or the ordinary integration workflow.
+The ``e2e`` dependency group supplies Playwright and pytest-playwright. The E2E
+target installs the group and Chromium again so CI and a fresh workstation use
+the same self-contained command. It starts real Litestar/Vite example
+processes through ``litestar run`` and drives them with Chromium. It is not
+included in ``make test`` or the ordinary integration workflow.
+
+Browser topology boundaries
+---------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Test slice
+     - Processes and services
+     - What it proves
+   * - Memory SSE/WebSocket browser tests
+     - One Litestar process plus Chromium
+     - HTMX boot, enqueue request, stream lifecycle, DOM progress, terminal event.
+   * - Redis/Valkey topology tests
+     - Web process, standalone ``litestar queues run`` worker, Chromium, real service
+     - Shared queue persistence and explicitly shared Channels delivery.
+   * - Unit stream tests
+     - Test process only
+     - Route content type, authorization hooks, envelopes, keepalives, and sink behavior.
+
+The memory browser cases are process-local and cannot prove a separate worker
+or multiple web replicas. Redis/Valkey cases opt into shared Channels with
+unique queue and Channels prefixes; selecting a Redis/Valkey queue backend by
+itself is not sufficient. Browser tests use demo-only stream authorization.
+Production routes must enforce tenant/user ownership, authenticated service
+connections, and origin/proxy policy.
+
+CI keeps unit/integration and browser jobs separate because Chromium and real
+Redis/Valkey topology have different setup, runtime, and failure diagnostics.
 
 If you want to prebuild all example frontend assets in one step:
 

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -35,14 +35,15 @@ transport is working.
       Run local copies or opt into shared Channels and a standalone worker.
 
 Every variant has its own README, application module, templates, frontend
-source, and asset commands. The memory apps are canonical for concepts; backend
-copies demonstrate persistence wiring rather than repeating the full tutorial.
+source, and asset commands. The memory apps are the main examples. The backend
+copies show only how persistence changes.
 
 .. note::
 
-   Selecting Redis or Valkey queue persistence does not select browser fan-out.
-   The default examples use process-local Channels. Set the documented shared
-   Channels and standalone-worker environment variables together.
+   Selecting Redis or Valkey for queue storage does not configure browser event
+   delivery. By default, the examples use Channels in one process. To run a
+   separate worker, set both the shared-Channels and standalone-worker
+   environment variables described in the example README.
 
 See :doc:`../usage/event-streams` for the source imports and delivery contract,
 or browse the complete `examples directory

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,0 +1,49 @@
+================
+Examples gallery
+================
+
+Start with a memory example. It runs the web app, queue worker, and live
+Channels delivery in one process. Choose a backend variant only after the
+transport is working.
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+   :padding: 0
+
+   .. grid-item-card:: Memory WebSocket
+      :link: https://github.com/cofin/litestar-queues/tree/main/examples/htmx_realtime_websocket
+      :link-type: url
+
+      HTMX WebSocket updates with memory queue persistence and memory Channels.
+
+   .. grid-item-card:: Memory SSE
+      :link: https://github.com/cofin/litestar-queues/tree/main/examples/htmx_realtime_sse
+      :link-type: url
+
+      HTMX Server-Sent Events with memory queue persistence and memory Channels.
+
+   .. grid-item-card:: SQL backends
+      :link: ../usage/backends
+      :link-type: doc
+
+      Run the SQLSpec or Advanced Alchemy copies with SQLite, then adapt schema ownership.
+
+   .. grid-item-card:: Redis and Valkey
+      :link: ../usage/backends/redis-valkey
+      :link-type: doc
+
+      Run local copies or opt into shared Channels and a standalone worker.
+
+Every variant has its own README, application module, templates, frontend
+source, and asset commands. The memory apps are canonical for concepts; backend
+copies demonstrate persistence wiring rather than repeating the full tutorial.
+
+.. note::
+
+   Selecting Redis or Valkey queue persistence does not select browser fan-out.
+   The default examples use process-local Channels. Set the documented shared
+   Channels and standalone-worker environment variables together.
+
+See :doc:`../usage/event-streams` for the source imports and delivery contract,
+or browse the complete `examples directory
+<https://github.com/cofin/litestar-queues/tree/main/examples>`_.

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -1,45 +1,36 @@
-===============
-Getting Started
-===============
+==========
+Start here
+==========
 
-.. grid:: 1
-   :padding: 0
-   :gutter: 2
-
-   .. grid-item-card::
-
-      **Start here.** Litestar Queues keeps the application-facing API small:
-      decorate a callable, configure queue and execution backends, then enqueue
-      records through ``QueueService``.
-
-Choose a Guide
-==============
+Litestar Queues turns a Python callable into tracked background work. Start
+with one process, then choose durable storage and separate workers only when
+your deployment needs them.
 
 .. grid:: 1 1 2 3
    :gutter: 2
    :padding: 0
 
-   .. grid-item-card:: Introduction
-      :link: introduction
-      :link-type: doc
-
-      Understand the core queue, execution, worker, and event concepts.
-
-   .. grid-item-card:: Installation
+   .. grid-item-card:: 1. Install
       :link: installation
       :link-type: doc
 
-      Install the core package and only the optional backend extras you need.
+      Install the small core package and learn when an optional extra is needed.
 
-   .. grid-item-card:: Quickstart
+   .. grid-item-card:: 2. Build the first app
       :link: quickstart
       :link-type: doc
 
-      Register a task, attach the Litestar plugin, and enqueue work.
+      Copy one complete Litestar application, run it, and enqueue a task.
+
+   .. grid-item-card:: 3. Understand the model
+      :link: ../usage/concepts
+      :link-type: doc
+
+      Learn how task records, workers, persistence, execution, and events fit together.
 
 .. toctree::
    :hidden:
 
-   introduction
    installation
    quickstart
+   introduction

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -2,9 +2,9 @@
 Start here
 ==========
 
-Litestar Queues turns a Python callable into tracked background work. Start
-with one process, then choose durable storage and separate workers only when
-your deployment needs them.
+Litestar Queues turns a Python function into tracked background work. Start
+with one process. Add persistent storage and separate workers only when your
+deployment needs them.
 
 .. grid:: 1 1 2 3
    :gutter: 2

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -2,75 +2,39 @@
 Installation
 ============
 
-Install the core package when you need the in-memory queue backend, immediate
-execution, local workers, task registration, and Litestar plugin lifecycle
-support:
+Install the core package for task registration, the Litestar plugin, memory
+queue persistence, and local or immediate execution:
 
 .. code-block:: bash
 
    pip install litestar-queues
 
-Optional Backends
-=================
+Optional extras
+===============
 
-Install backend extras only for the integrations an application uses:
+Install only the integration your application uses:
 
 .. list-table::
    :header-rows: 1
 
-   * - Extra
-     - Enables
-     - Notes
-   * - ``sqlspec``
-     - SQLSpec queue persistence
-     - Installs SQLSpec with the Aiosqlite extra. Install additional SQLSpec
-       adapter drivers in the application when you use them.
-   * - ``advanced-alchemy``
-     - Advanced Alchemy queue persistence
-     - Uses application-owned SQLAlchemy configuration or session makers.
-   * - ``redis``
-     - Redis queue persistence
-     - Imports the Redis client only when opening the Redis backend without an
-       injected client.
-   * - ``valkey``
-     - Valkey queue persistence
-     - Imports the Valkey client only when opening the Valkey backend without an
-       injected client.
-   * - ``cloudrun``
-     - Cloud Run execution
-     - Dispatches persisted queue records to Cloud Run Jobs.
-   * - ``otel``
-     - OpenTelemetry queue traces and metrics
-     - Adds producer, consumer, worker, dispatch, and reconcile telemetry.
-   * - ``prometheus``
-     - Prometheus queue metrics
-     - Exposes bounded queue-domain counters and histograms.
+   * - Command
+     - Adds
+   * - ``pip install "litestar-queues[sqlspec]"``
+     - SQLSpec queue persistence; install the SQLSpec driver for your database separately.
+   * - ``pip install "litestar-queues[advanced-alchemy]"``
+     - Advanced Alchemy and SQLAlchemy queue persistence.
+   * - ``pip install "litestar-queues[redis]"``
+     - Redis queue persistence and worker wakeups.
+   * - ``pip install "litestar-queues[valkey]"``
+     - Valkey queue persistence and worker wakeups.
+   * - ``pip install "litestar-queues[cloudrun]"``
+     - Google Cloud Run Jobs execution.
+   * - ``pip install "litestar-queues[otel]"``
+     - OpenTelemetry instrumentation.
+   * - ``pip install "litestar-queues[prometheus]"``
+     - Prometheus metrics.
+   * - ``pip install "litestar-queues[examples]"``
+     - Dependencies used by the runnable HTMX examples.
 
-.. code-block:: bash
-
-   pip install litestar-queues[sqlspec]
-   pip install litestar-queues[advanced-alchemy]
-   pip install litestar-queues[redis]
-   pip install litestar-queues[valkey]
-   pip install litestar-queues[cloudrun]
-   pip install litestar-queues[otel]
-   pip install litestar-queues[prometheus]
-
-Extras can be combined when a deployment needs multiple integrations:
-
-.. code-block:: bash
-
-   pip install "litestar-queues[sqlspec,cloudrun]"
-   pip install "litestar-queues[otel,prometheus]"
-
-Optional Import Boundaries
-==========================
-
-The package registers optional backend names without importing their external
-client libraries from package root or shared backend import paths. Opening an
-optional backend requires either the matching extra or an injected client/config
-object supplied by the application.
-
-This keeps a core installation usable for tests and simple local workers while
-allowing production deployments to choose SQLSpec adapters, Advanced Alchemy,
-Redis, Valkey, or Cloud Run independently.
+Extras install libraries, but they do not choose your architecture. See
+:doc:`../usage/backends` after completing the :doc:`quickstart`.

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -2,8 +2,8 @@
 Installation
 ============
 
-Install the core package for task registration, the Litestar plugin, memory
-queue persistence, and local or immediate execution:
+Install the core package. It provides task registration, the Litestar plugin,
+in-memory queue storage, and local or immediate execution:
 
 .. code-block:: bash
 
@@ -36,5 +36,6 @@ Install only the integration your application uses:
    * - ``pip install "litestar-queues[examples]"``
      - Dependencies used by the runnable HTMX examples.
 
-Extras install libraries, but they do not choose your architecture. See
-:doc:`../usage/backends` after completing the :doc:`quickstart`.
+An extra installs the libraries for an integration. It does not configure that
+integration or choose where tasks run. Complete the :doc:`quickstart`, then
+see :doc:`../usage/backends`.

--- a/docs/getting_started/introduction.rst
+++ b/docs/getting_started/introduction.rst
@@ -2,48 +2,8 @@
 Introduction
 ============
 
-Litestar Queues is built around three independent runtime boundaries:
+The concepts guide is now the canonical explanation of Litestar Queues. The
+old URL remains available so existing links continue to work.
 
-* ``QueueBackend`` persists queue records and task lifecycle state.
-* ``ExecutionBackend`` decides where a claimed record runs.
-* ``QueueEventSink`` delivers lifecycle, progress, log, and custom task events
-  to application-owned realtime infrastructure.
-
-The core install includes an in-memory queue backend plus immediate and local
-execution backends. SQLSpec, Advanced Alchemy, Redis, Valkey, and Cloud Run are
-optional integrations that are imported only when their backend is opened or
-when the application injects an already configured client.
-
-Task Lifecycle
-==============
-
-Tasks are registered with the :func:`litestar_queues.task` decorator. Enqueueing
-a task creates a queue record containing the task name, arguments, keyword
-arguments, queue name, priority, retry policy, scheduled time, execution backend,
-execution profile, deduplication key, and metadata.
-
-Workers claim due records, execute the registered callable, update the persisted
-record, retry eligible failures, and publish lifecycle events. The same task can
-use different execution backends per enqueue call, so local development,
-database-backed workers, and external execution can share the same task code.
-
-Realtime Events
-===============
-
-Queue events are separate from backend wakeup notifications. Wakeup mechanisms,
-such as Redis pub/sub or SQLSpec Events, are non-durable worker hints. Queue
-events are application-facing envelopes for lifecycle, progress, logs, and
-custom task state that can be sent to Litestar Channels, an in-memory test sink,
-or a custom sink.
-
-Use Cases
-=========
-
-Litestar Queues fits applications that need:
-
-* background jobs started from HTTP routes,
-* scheduled recurring work,
-* status and result polling,
-* progress updates streamed to clients,
-* durable queue records in SQL, Redis, or Valkey,
-* external task execution in Cloud Run Jobs.
+Continue to :doc:`../usage/concepts` to learn how enqueueing, persisted task
+records, workers, execution backends, wakeups, and task events relate.

--- a/docs/getting_started/introduction.rst
+++ b/docs/getting_started/introduction.rst
@@ -2,8 +2,8 @@
 Introduction
 ============
 
-The concepts guide is now the canonical explanation of Litestar Queues. The
-old URL remains available so existing links continue to work.
+The concepts guide now contains the main explanation of Litestar Queues. This
+page remains in place so existing links keep working.
 
 Continue to :doc:`../usage/concepts` to learn how enqueueing, persisted task
 records, workers, execution backends, wakeups, and task events relate.

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -2,51 +2,78 @@
 Quickstart
 ==========
 
-Register a task with :func:`litestar_queues.task`:
+This first application stores work in memory and runs it with the worker that
+starts inside the Litestar process. You can replace both choices later without
+changing the task function or route.
 
-.. code-block:: python
+Install Litestar Queues
+=======================
 
-   from litestar_queues import task
+.. code-block:: bash
 
+   pip install litestar-queues
 
-   @task("accounts.sync", queue="accounts", retries=3, timeout=300)
-   async def sync_account(account_id: str) -> dict[str, str]:
-       return {"account_id": account_id, "status": "synced"}
+Create ``app.py``
+=================
 
-Attach the queue plugin to a Litestar application:
+Copy this complete file:
 
 .. code-block:: python
 
    from litestar import Litestar, post
    from litestar.di import NamedDependency
-   from litestar_queues import QueueConfig, QueuePlugin, QueueService
+
+   from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
+
+
+   @task("accounts.sync", queue="accounts", timeout=30)
+   async def sync_account(account_id: str) -> dict[str, str]:
+       return {"account_id": account_id, "status": "synced"}
 
 
    @post("/accounts/{account_id:str}/sync")
-   async def create_task(account_id: str, queue_service: NamedDependency[QueueService]) -> dict[str, str]:
+   async def create_sync_job(
+       account_id: str,
+       queue_service: NamedDependency[QueueService],
+   ) -> dict[str, str]:
        result = await queue_service.enqueue(sync_account, account_id)
-       return {"task_id": str(result.id), "status": result.status or "queued"}
+       return {"task_id": str(result.id), "status": result.status or "pending"}
 
 
-   app = Litestar(route_handlers=[create_task], plugins=[QueuePlugin(config=QueueConfig())])
+   app = Litestar(
+       route_handlers=[create_sync_job],
+       plugins=[QueuePlugin(config=QueueConfig())],
+   )
 
-The default configuration runs a worker inside the Litestar application process.
-That keeps local and lightweight deployments simple. For heavier deployments,
-use a shared queue backend, disable the in-app worker in the web process, and run
-workers separately:
+Run and verify it
+=================
 
-.. code-block:: python
+Start Litestar:
 
-   config = QueueConfig(in_app_worker=False)
+.. code-block:: bash
 
-.. code-block:: console
+   LITESTAR_APP=app:app litestar run --reload
 
-   $ LITESTAR_APP=app.asgi:app litestar queues run --drain-timeout 30
+In another terminal, enqueue the task:
 
-Next Steps
+.. code-block:: bash
+
+   curl -X POST http://127.0.0.1:8000/accounts/acct-123/sync
+
+You receive JSON shaped like this:
+
+.. code-block:: json
+
+   {"task_id":"...","status":"pending"}
+
+The ID identifies the persisted task record. ``pending`` is the enqueue-time
+status; the in-app worker can complete the task immediately afterward.
+
+Next steps
 ==========
 
-* Configure runtime settings in :doc:`../usage/configuration`.
-* Add retries, keys, metadata, and execution overrides in
-  :doc:`../usage/tasks`.
-* Choose a persistent backend in :doc:`../usage/backends`.
+* :doc:`../usage/concepts` explains records, workers, and backend choices.
+* :doc:`../usage/results` shows how to refresh and wait for a result.
+* :doc:`../usage/workers` moves work into standalone worker processes.
+* :doc:`../usage/backends` replaces process-local storage for production.
+* :doc:`../usage/events` publishes progress for applications and operators.

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -66,8 +66,9 @@ You receive JSON shaped like this:
 
    {"task_id":"...","status":"pending"}
 
-The ID identifies the persisted task record. ``pending`` is the enqueue-time
-status; the in-app worker can complete the task immediately afterward.
+The ID identifies the saved task record. ``pending`` is its status when it
+enters the queue. The in-app worker may complete the task immediately after
+the response is created.
 
 Next steps
 ==========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 .. title:: Litestar Queues
 
 .. meta::
-   :description: Task queues, workers, schedules, backend integrations, and realtime task events for Litestar applications.
-   :keywords: Litestar, task queue, workers, background jobs, schedules, Redis, Valkey, SQLSpec, Advanced Alchemy
+   :description: Beginner-first task queues, workers, schedules, persistence backends, and realtime events for Litestar.
+   :keywords: Litestar, task queue, worker, background job, Redis, Valkey, SQLSpec, Advanced Alchemy
 
 .. container:: title-with-logo
 
@@ -10,9 +10,9 @@
 
       <h1 class="brand-text" aria-label="Litestar Queues">Litestar Queues</h1>
 
-Litestar Queues provides task queue support for Litestar applications: typed
-task registration, queue persistence, worker lifecycle management, scheduled
-jobs, pluggable execution backends, and realtime task event delivery.
+Define background work with a typed decorator, enqueue it through Litestar,
+and let a managed worker execute it. Start in one process; adopt durable queue
+persistence, separate workers, or live task events when the application grows.
 
 .. toctree::
    :hidden:
@@ -20,45 +20,48 @@ jobs, pluggable execution backends, and realtime task event delivery.
    :caption: Documentation
 
    getting_started/index
+   usage/concepts
    usage/index
-   contributing/index
+   examples/index
    reference/index
+   contributing/index
 
-.. grid:: 1 1 2 2
+.. grid:: 1 1 2 3
    :padding: 0
    :gutter: 2
 
-   .. grid-item-card:: Get Started
+   .. grid-item-card:: Start here
       :link: getting_started/index
       :link-type: doc
 
-      Install Litestar Queues, register your first task, and enqueue work from
-      a Litestar route backed by an in-app or standalone worker.
+      Install the package, copy one complete application, and enqueue a task.
 
-   .. grid-item-card:: Usage Guides
+   .. grid-item-card:: Concepts
+      :link: usage/concepts
+      :link-type: doc
+
+      Learn the boundaries between records, persistence, workers, execution, and events.
+
+   .. grid-item-card:: How-to guides
       :link: usage/index
       :link-type: doc
 
-      Configure workers, tasks, schedules, realtime events, and backend
-      integrations.
+      Define tasks, inspect results, operate workers, and choose production options.
 
-   .. grid-item-card:: Backends
-      :link: usage/backends
+   .. grid-item-card:: Examples
+      :link: examples/index
       :link-type: doc
 
-      Choose queue persistence and execution backends without requiring every
-      optional driver dependency.
+      Run visual WebSocket and SSE examples with memory or persistent backends.
 
-   .. grid-item-card:: Contributing
-      :link: contributing/index
-      :link-type: doc
-
-      Run the unit and integration tiers, use the backend registry, and add
-      adapter coverage without making optional drivers mandatory.
-
-   .. grid-item-card:: API Reference
+   .. grid-item-card:: Reference
       :link: reference/index
       :link-type: doc
 
-      Browse the generated API reference grouped by core, backend, execution,
-      and realtime event modules.
+      Browse generated API documentation grouped by subsystem.
+
+   .. grid-item-card:: Developers
+      :link: contributing/index
+      :link-type: doc
+
+      Test changes, maintain examples, and audit documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,9 +10,9 @@
 
       <h1 class="brand-text" aria-label="Litestar Queues">Litestar Queues</h1>
 
-Define background work with a typed decorator, enqueue it through Litestar,
-and let a managed worker execute it. Start in one process; adopt durable queue
-persistence, separate workers, or live task events when the application grows.
+Define background work with a typed decorator, add it to a queue through
+Litestar, and let a managed worker run it. Start in one process. Add persistent
+storage, separate workers, or live task events as the application grows.
 
 .. toctree::
    :hidden:
@@ -40,7 +40,7 @@ persistence, separate workers, or live task events when the application grows.
       :link: usage/concepts
       :link-type: doc
 
-      Learn the boundaries between records, persistence, workers, execution, and events.
+      Learn how task records, storage, workers, execution, and events fit together.
 
    .. grid-item-card:: How-to guides
       :link: usage/index

--- a/docs/reference/backends.rst
+++ b/docs/reference/backends.rst
@@ -31,6 +31,11 @@ Memory
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: litestar_queues.backends.memory.event_log
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 SQLSpec
 =======
 
@@ -50,6 +55,11 @@ SQLSpec
    :show-inheritance:
 
 .. automodule:: litestar_queues.backends.sqlspec.stores.factory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: litestar_queues.backends.sqlspec.event_log
    :members:
    :undoc-members:
    :show-inheritance:
@@ -82,6 +92,16 @@ Advanced Alchemy
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: litestar_queues.backends.advanced_alchemy.event_log
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: litestar_queues.backends.advanced_alchemy.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Redis
 =====
 
@@ -91,6 +111,11 @@ Redis
    :show-inheritance:
 
 .. automodule:: litestar_queues.backends.redis.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: litestar_queues.backends.redis.event_log
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -18,6 +18,19 @@ Publisher
    :undoc-members:
    :show-inheritance:
 
+Buffering and Chunking
+======================
+
+.. automodule:: litestar_queues.events.buffer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: litestar_queues.events.chunking
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Task Context
 ============
 
@@ -42,10 +55,39 @@ Sinks
    :undoc-members:
    :show-inheritance:
 
+Event History
+=============
+
+.. automodule:: litestar_queues.events.log
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+External Producers
+==================
+
+.. automodule:: litestar_queues.events.producer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Litestar Channels
 =================
 
 .. automodule:: litestar_queues.events.litestar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Stream Configuration and Routes
+===============================
+
+.. automodule:: litestar_queues.events.stream_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: litestar_queues.events.streaming
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -2,8 +2,9 @@
 Choose backends
 ===============
 
-Make five independent decisions. Most applications need only the first two;
-the others add latency improvements or user-facing delivery.
+Make these five choices separately. Most applications need only task storage
+and execution placement. The other choices can reduce worker delay or deliver
+events to users.
 
 .. list-table::
    :header-rows: 1
@@ -28,7 +29,7 @@ the others add latency improvements or user-facing delivery.
      - Configure Channels separately
      - :doc:`backends/sqlspec`
    * - SQLAlchemy application
-     - ``AdvancedAlchemyBackendConfig``
+     - ``SQLAlchemyBackendConfig``
      - ``local`` or Cloud Run
      - Optional PostgreSQL hint, otherwise polling
      - Configure Channels separately
@@ -46,10 +47,10 @@ the others add latency improvements or user-facing delivery.
      - Optional Valkey-compatible Channels
      - :doc:`backends/redis-valkey`
 
-The queue backend stores records. ``local`` means worker-process execution,
-``immediate`` means inline execution, and Cloud Run is remote execution—not
-queue storage. A backend notification wakes workers; it does not fan task
-events out to browsers.
+The queue backend stores task records. ``local`` runs work in a worker process.
+``immediate`` runs it during the enqueue call. Cloud Run runs it remotely; it
+does not store the queue. Backend notifications wake workers, but they do not
+send task events to browsers.
 
 Install extras
 ==============
@@ -93,15 +94,16 @@ Event-history support
      - ``EventLogConfig.max_records`` caps records in the process.
    * - SQLSpec
      - Supported
-     - Queue schema, migrations, and SQLSpec session lifecycle.
+     - The app owns the queue schema and migrations; SQLSpec manages the sessions.
    * - Advanced Alchemy
      - Supported
-     - Application-owned model and schema migrations.
+     - The app owns the model and migrations.
    * - Redis / Valkey
      - Supported
-     - Operator controls service durability, retention, backups, and cleanup.
+     - You choose how long records stay and whether to back them up.
 
-History is not a live sink. See :doc:`event-history` and :doc:`event-streams`.
+Event history saves records for later queries. It does not deliver live events.
+See :doc:`event-history` and :doc:`event-streams`.
 
 Topology and security
 =====================

--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -1,988 +1,130 @@
-Backends
-========
+===============
+Choose backends
+===============
 
-Litestar Queues separates queue backends from execution backends.
+Make five independent decisions. Most applications need only the first two;
+the others add latency improvements or user-facing delivery.
 
-Queue backends persist task state. The core package registers the ``memory``
-backend for tests, local development, and in-process workers. The ``sqlspec``
-backend is available when the SQLSpec extra is installed. Additional optional
-extras provide Advanced Alchemy, Redis, and Valkey integrations.
+.. list-table::
+   :header-rows: 1
+   :widths: 18 18 16 18 18 18
 
-Execution backends decide where claimed tasks run. The core package registers
-``immediate`` for inline execution and ``local`` for in-process worker
-execution. The optional ``cloudrun`` extra dispatches records to Cloud Run Jobs.
+   * - Need
+     - Queue persistence
+     - Execution placement
+     - Worker wakeup strategy
+     - User-facing event stream
+     - Next guide
+   * - One process or tests
+     - ``memory`` (process-local)
+     - ``local`` worker or inline ``immediate``
+     - Polling/in-process hint
+     - Memory Channels (process-local)
+     - :doc:`../getting_started/quickstart`
+   * - SQLSpec application
+     - ``SQLSpecBackendConfig``
+     - ``local`` or Cloud Run
+     - SQLSpec transport when supported, otherwise polling
+     - Configure Channels separately
+     - :doc:`backends/sqlspec`
+   * - SQLAlchemy application
+     - ``AdvancedAlchemyBackendConfig``
+     - ``local`` or Cloud Run
+     - Optional PostgreSQL hint, otherwise polling
+     - Configure Channels separately
+     - :doc:`backends/advanced-alchemy`
+   * - Redis infrastructure
+     - ``RedisBackendConfig``
+     - ``local`` or Cloud Run
+     - Redis pub/sub hint
+     - Optional Redis Channels
+     - :doc:`backends/redis-valkey`
+   * - Valkey infrastructure
+     - ``ValkeyBackendConfig``
+     - ``local`` or Cloud Run
+     - Valkey pub/sub hint
+     - Optional Valkey-compatible Channels
+     - :doc:`backends/redis-valkey`
 
-Install optional extras only when an application needs them:
+The queue backend stores records. ``local`` means worker-process execution,
+``immediate`` means inline execution, and Cloud Run is remote execution—not
+queue storage. A backend notification wakes workers; it does not fan task
+events out to browsers.
 
-.. code-block:: bash
-
-   pip install litestar-queues[sqlspec]
-   pip install litestar-queues[advanced-alchemy]
-   pip install litestar-queues[redis]
-   pip install litestar-queues[valkey]
-   pip install litestar-queues[cloudrun]
-
-The core package import does not require optional queue or execution client
-libraries.
-
-Choosing a Live Channels Backend
---------------------------------
-
-Queue persistence and live browser delivery are independent. ``RedisBackendConfig``
-and ``ValkeyBackendConfig`` persist and wake workers; they do not make the
-application's SSE or WebSocket Channels stream cross-process. Use
-``MemoryChannelsBackend`` only for one-process apps, or explicitly configure a
-shared Channels backend as well.
-
-For the Redis/Valkey realtime examples, the shared branch uses
-``RedisChannelsStreamBackend`` because ``EventStreamConfig(history=25)`` needs
-stream history. ``RedisChannelsPubSubBackend`` is a valid low-overhead choice
-only when history is intentionally zero. The Valkey example passes a Valkey
-client into the Litestar Redis-protocol Channels backend; it does not import or
-construct a Redis client in that path.
-
-For PostgreSQL-only deployments, prefer ``AsyncPgChannelsBackend`` or
-``PsycoPgChannelsBackend`` when ephemeral LISTEN/NOTIFY fan-out is sufficient.
-SQLSpec and Advanced Alchemy SQLite queue persistence do not create that
-cross-process fan-out automatically. Oracle AQ and TxEventQ are queue-worker
-wakeup transports, not browser event transports.
-
-SQLSpec
--------
-
-Install the SQLSpec extra when a queue needs SQL-backed persistence:
-
-.. code-block:: bash
-
-   pip install litestar-queues[sqlspec]
-
-Configure SQLSpec queue persistence by passing a SQLSpec adapter config through
-``SQLSpecBackendConfig``:
-
-.. code-block:: python
-
-   from sqlspec.adapters.aiosqlite import AiosqliteConfig
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           config=AiosqliteConfig(
-               connection_config={"database": "queue.db"},
-           ),
-       ),
-       execution_backend="local",
-   )
-
-SQLite ADBC uses the same queue semantics, but it needs the SQLSpec ``adbc``
-extra and the SQLite driver package:
-
-.. code-block:: bash
-
-   pip install "sqlspec[adbc]" adbc-driver-sqlite
-
-.. code-block:: python
-
-   from sqlspec.adapters.adbc import AdbcConfig
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           config=AdbcConfig(
-               connection_config={
-                   "driver_name": "adbc_driver_sqlite",
-                   "uri": "queue.db",
-               },
-           ),
-       ),
-       execution_backend="local",
-   )
-
-By default, the backend creates the queue table on startup. Set
-``create_schema=False`` in ``SQLSpecBackendConfig`` when schema management is
-handled elsewhere. Applications that want SQLSpec to apply the packaged queue
-migration can set ``run_migrations=True``:
-
-.. code-block:: python
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           config=AiosqliteConfig(
-               connection_config={"database": "queue.db"},
-           ),
-           create_schema=False,
-           run_migrations=True,
-       ),
-       execution_backend="local",
-   )
-
-Litestar applications that use SQLSpec sessions should register SQLSpec's
-first-party plugin directly and pass the same ``SQLSpec`` instance and adapter
-config to the queue backend:
-
-.. code-block:: python
-
-   from litestar import Litestar
-   from sqlspec import SQLSpec
-   from sqlspec.adapters.aiosqlite import AiosqliteConfig
-   from sqlspec.extensions.litestar import SQLSpecPlugin
-
-   from litestar_queues import QueueConfig, QueuePlugin
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-   sqlspec = SQLSpec()
-   sqlspec_config = AiosqliteConfig(connection_config={"database": "queue.db"})
-   sqlspec.add_config(sqlspec_config)
-
-   app = Litestar(
-       plugins=[
-           SQLSpecPlugin(sqlspec),
-           QueuePlugin(
-               QueueConfig(
-                   queue_backend=SQLSpecBackendConfig(
-                       sqlspec=sqlspec,
-                       config=sqlspec_config,
-                   ),
-                   execution_backend="local",
-               )
-           )
-       ],
-   )
-
-SQLSpec persists task arguments, keyword arguments, metadata, and results using
-SQLSpec's serializer. Packaged migrations are registered with SQLSpec's
-extension runner as ``ext_litestar_queues_0001``. Applications with their own
-migration flow can set both ``create_schema=False`` and ``run_migrations=False``.
-
-.. _heartbeat-pool-isolation:
-
-Heartbeat Pool Isolation
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Workers issue a heartbeat write every ``QueueConfig.worker_heartbeat_interval``
-seconds for every running task. At high ``worker_max_concurrency`` those writes
-share the main pool with task fetch, claim, and lifecycle UPDATEs, and on
-network databases (AsyncPG, AioMySQL) heartbeats can stall behind queue work
-and miss the stale-recovery window.
-
-Set ``heartbeat_pool_config`` to a second SQLSpec adapter config so heartbeat
-writes run on a small dedicated pool:
-
-.. code-block:: python
-
-   from sqlspec.adapters.asyncpg import AsyncpgConfig
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-   queue_url = "postgresql://queue@db/queues"
-
-   main_config = AsyncpgConfig(
-       pool_config={"dsn": queue_url, "min_size": 4, "max_size": 16},
-   )
-   heartbeat_config = AsyncpgConfig(
-       pool_config={"dsn": queue_url, "min_size": 1, "max_size": 2},
-   )
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           config=main_config,
-           heartbeat_pool_config=heartbeat_config,
-       ),
-       execution_backend="local",
-       worker_max_concurrency=32,
-   )
-
-The dedicated config MUST point at the same database as the main config; the
-backend only uses it for ``touch_heartbeat`` and ``null_heartbeats``. Lifecycle
-writes that touch ``heartbeat_at`` alongside other columns (``claim_task``,
-``complete_task``, ``fail_task``, ``requeue_stale_running``) stay on the main
-pool. Recommended sizing: ``max_size=2`` for AsyncPG / AioMySQL,
-``max_size=1`` for AioSQLite. The dedicated pool's connections add to the
-application's total database connection budget.
-
-When ``heartbeat_pool_config`` is ``None`` (the default), heartbeat writes
-share the main pool exactly as before. If the dedicated pool fails to register
-or open, the backend logs a single warning and falls back to the main pool for
-the lifetime of the backend.
-
-SQLSpec Store Selection
-~~~~~~~~~~~~~~~~~~~~~~~
-
-The SQLSpec queue backend selects stores by SQLSpec adapter configuration, not
-by directly importing database drivers. This keeps driver dependencies optional
-and lets each store use database-specific DDL, column types, JSON behavior, and
-claim/update statements where the database supports them.
+Install extras
+==============
 
 .. list-table::
    :header-rows: 1
 
-   * - SQLSpec adapter
-     - Queue store
-     - Notes
-   * - ``aiomysql``
-     - ``AiomysqlQueueStore``
-     - Async MySQL behavior.
-   * - ``aiosqlite``
-     - ``AiosqliteQueueStore``
-     - Async SQLite behavior.
-   * - ``adbc``
-     - ``AdbcSqliteQueueStore``
-     - SQLite ADBC behavior only. Other ADBC dialects remain unsupported.
-   * - ``asyncmy``
-     - ``AsyncmyQueueStore``
-     - Async MySQL behavior.
-   * - ``asyncpg``
-     - ``AsyncpgQueueStore``
-     - PostgreSQL behavior.
-   * - ``cockroach_asyncpg``
-     - ``CockroachAsyncpgQueueStore``
-     - CockroachDB behavior on the asyncpg driver.
-   * - ``duckdb``
-     - ``DuckDBQueueStore``
-     - DuckDB-specific DDL and JSON behavior.
-   * - ``mysqlconnector``
-     - ``MysqlConnectorAsyncQueueStore`` or ``MysqlConnectorSyncQueueStore``
-     - Async and sync variants are selected from the SQLSpec config type.
-   * - ``pymysql``
-     - ``PymysqlQueueStore``
-     - Sync MySQL behavior.
-   * - ``mssql_python``
-     - ``MssqlPythonQueueStore``
-     - Async and sync SQL Server configs share the same queue store.
-   * - ``pymssql``
-     - ``PymssqlQueueStore``
-     - Sync-only SQL Server adapter.
-   * - ``oracledb``
-     - ``OracledbAsyncQueueStore`` or ``OracledbSyncQueueStore``
-     - Uses Oracle-specific DDL and JSON column choices.
-   * - ``arrow_odbc``
-     - ``ArrowOdbcQueueStore``
-     - SQL Server target only. Other ODBC targets raise ``QueueConfigurationError``.
-   * - ``spanner``
-     - ``SpannerQueueStore``
-     - Google Cloud Spanner behavior with write-capable transactional sessions.
-   * - ``psqlpy``
-     - ``PsqlpyQueueStore``
-     - PostgreSQL behavior.
-   * - ``psycopg``
-     - ``PsycopgAsyncQueueStore`` or ``PsycopgSyncQueueStore``
-     - Async and sync variants are selected from the SQLSpec config type.
-   * - ``cockroach_psycopg``
-     - ``CockroachPsycopgAsyncQueueStore`` or ``CockroachPsycopgSyncQueueStore``
-     - CockroachDB behavior on psycopg; async and sync variants are selected
-       from the SQLSpec config type.
-   * - ``sqlite``
-     - ``SqliteQueueStore``
-     - Sync SQLite behavior.
+   * - Integration
+     - Install extra
+     - Shared scope
+   * - Memory
+     - Core package
+     - Current Python process only
+   * - SQLSpec
+     - ``litestar-queues[sqlspec]`` plus a SQLSpec driver
+     - Shared database
+   * - Advanced Alchemy
+     - ``litestar-queues[advanced-alchemy]``
+     - Shared database
+   * - Redis
+     - ``litestar-queues[redis]``
+     - Shared Redis service
+   * - Valkey
+     - ``litestar-queues[valkey]``
+     - Shared Valkey service
+   * - Cloud Run execution
+     - ``litestar-queues[cloudrun]``
+     - Shared persistent queue required
 
-Unsupported SQLSpec adapters raise ``QueueConfigurationError``. Arrow ODBC is
-supported only when SQLSpec resolves the target dialect to SQL Server; other
-ODBC targets still raise ``QueueConfigurationError``. Applications should
-install the SQLSpec adapter driver they configure; Litestar Queues does not
-install every SQLSpec driver as a package dependency.
-
-BigQuery is intentionally unsupported as a queue backend. Its SQLSpec adapter is
-useful for analytical workloads, but BigQuery does not provide the transactional
-and uniqueness behavior expected from Litestar Queues keyed enqueue and claim
-operations.
-
-SQLSpec Capability Matrix
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-SQLSpec adapters use the strongest queue primitive their configured driver
-advertises, then fall back to the portable path when a capability is absent.
+Event-history support
+=====================
 
 .. list-table::
    :header-rows: 1
 
-   * - Adapter family
-     - Claim strategy
-     - JSON storage and codec
-     - Bulk insert
-     - Notifications
-     - Notes
-   * - ``aiosqlite`` / ``sqlite``
-     - Optimistic compare-and-swap.
-     - ``TEXT`` columns serialized with SQLSpec JSON.
-     - Native Arrow ``load_from_records`` when SQLSpec exposes it; otherwise
-       ``execute_many``.
-     - Polling unless an explicit SQLSpec table queue is configured.
-     - SQLite serializes writes, so the portable path is the concurrency guard.
-   * - ``adbc``
-     - Optimistic compare-and-swap.
-     - ``TEXT`` columns serialized with SQLSpec JSON.
-     - Native Arrow ``load_from_records`` when SQLSpec exposes it; otherwise
-       ``execute_many``.
-     - Polling.
-     - SQLite ADBC uses the same queue table behavior as ``sqlite`` and
-       requires the ``adbc_driver_sqlite`` driver package.
-   * - ``duckdb``
-     - Optimistic compare-and-swap.
-     - ``JSON`` columns serialized with SQLSpec JSON.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - Positional Arrow ingest is contract-tested so column order matches the
-       table definition.
-   * - ``asyncpg`` / ``psycopg``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
-       dialect support; compare-and-swap fallback otherwise.
-     - ``JSONB`` with native decoded JSON columns where the driver returns
-       Python values.
-     - Arrow ``load_from_records`` path.
-     - ``asyncpg`` uses durable LISTEN/NOTIFY; ``psycopg`` and ``psqlpy`` can
-       use SQLSpec's durable table queue.
-     - Stale-recovery statement batches use SQLSpec ``StatementStack``; psycopg
-       can collapse the batch through the driver pipeline.
-   * - ``cockroach_asyncpg`` / ``cockroach_psycopg``
-     - Optimistic compare-and-swap.
-     - ``JSONB`` with native decoded JSON columns where the driver returns
-       Python values.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - CockroachDB keeps PostgreSQL-compatible DDL, but the queue backend
-       stays on the portable claim path instead of relying on ``SKIP LOCKED``.
-   * - ``psqlpy``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
-       dialect support.
-     - ``JSONB`` payload/metadata columns with native decode; ``result`` stays
-       text-backed for driver compatibility.
-     - Arrow ``load_from_records`` path.
-     - SQLSpec durable table queue.
-     - PostgreSQL storage parameters tune queue-table churn where supported.
-   * - ``asyncmy`` / ``aiomysql`` / ``mysqlconnector``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
-       dialect support.
-     - MySQL ``JSON`` columns with native decoded JSON values.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - Index prefixes keep InnoDB key length within portable bounds.
-   * - ``pymysql``
-     - ``FOR UPDATE SKIP LOCKED`` when SQLSpec's data dictionary marks the
-       dialect support.
-     - MySQL ``JSON`` columns with native decoded JSON values.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - Sync MySQL behavior uses the same InnoDB prefix guard.
-   * - ``mssql_python``
-     - Optimistic compare-and-swap.
-     - ``NVARCHAR(MAX)`` text columns serialized with SQLSpec JSON.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - SQL Server support keeps the portable claim path and shares the same
-       queue store across sync and async configs.
-   * - ``pymssql``
-     - Optimistic compare-and-swap.
-     - ``NVARCHAR(MAX)`` text columns serialized with SQLSpec JSON.
-     - ``execute_many`` path.
-     - Polling.
-     - Sync-only SQL Server adapter with the same portable claim path.
-   * - ``oracledb``
-     - ``FOR UPDATE SKIP LOCKED`` through SQLSpec's Oracle data-dictionary
-       capability.
-     - Version-aware ``JSON``, checked ``BLOB``, or plain ``BLOB`` storage.
-     - Arrow ``load_from_records`` path.
-     - Polling by default; explicit ``aq`` or ``txeventq`` when Oracle queues
-       are provisioned.
-     - Oracle object names are kept within the adapter's identifier limits;
-       Oracle 23ai can pipeline stale-recovery statement batches.
-   * - ``arrow_odbc``
-     - Optimistic compare-and-swap.
-     - ``NVARCHAR(MAX)`` JSON text on the SQL Server target.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - SQL Server target only; unsupported ODBC targets fail during store
-       construction.
-   * - ``spanner``
-     - Optimistic compare-and-swap.
-     - ``JSON`` columns with native decoded JSON values.
-     - Arrow ``load_from_records`` path.
-     - Polling.
-     - Spanner sessions are write-capable by default; schema bootstrap uses
-       Spanner's DDL operation API, ``result`` is nullable for pending tasks,
-       and ``task_key`` uses a ``UNIQUE NULL_FILTERED`` index.
+   * - Queue backend
+     - History support
+     - Ownership
+   * - Memory
+     - Supported, bounded and ephemeral
+     - ``EventLogConfig.max_records`` caps records in the process.
+   * - SQLSpec
+     - Supported
+     - Queue schema, migrations, and SQLSpec session lifecycle.
+   * - Advanced Alchemy
+     - Supported
+     - Application-owned model and schema migrations.
+   * - Redis / Valkey
+     - Supported
+     - Operator controls service durability, retention, backups, and cleanup.
 
-Additional SQLSpec adapters can be added by implementing a queue store and
-registering it with the SQLSpec store factory.
+History is not a live sink. See :doc:`event-history` and :doc:`event-streams`.
 
-Advanced Alchemy
-----------------
-
-Install the Advanced Alchemy extra when a queue should persist task state using
-Advanced Alchemy and SQLAlchemy:
-
-.. code-block:: bash
-
-   pip install litestar-queues[advanced-alchemy]
-
-Configure the queue backend with ``SQLAlchemyAsyncConfig``:
-
-.. code-block:: python
-
-   from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
-
-   alchemy_config = SQLAlchemyAsyncConfig(
-       connection_string="sqlite+aiosqlite:///queue.db",
-   )
-
-   config = QueueConfig(
-       queue_backend=AdvancedAlchemyBackendConfig(
-           sqlalchemy_config=alchemy_config,
-           create_schema=True,
-       ),
-       execution_backend="local",
-   )
-
-Queue operations use one queue table by default: ``litestar_queue_task``.
-They run through fresh operation-scoped sessions opened from
-``sqlalchemy_config`` and commit or roll back queue mutations explicitly.
-
-Litestar applications should register Advanced Alchemy's first-party plugin
-directly and pass the same config to the queue backend:
-
-.. code-block:: python
-
-   from advanced_alchemy.base import UUIDAuditBase
-   from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
-   from litestar import Litestar
-
-   from litestar_queues import QueueConfig, QueuePlugin
-   from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, QueueTaskModelMixin
-
-   class AppQueueTask(UUIDAuditBase, QueueTaskModelMixin):
-       __tablename__ = "app_queue_task"
-
-   alchemy_config = SQLAlchemyAsyncConfig(
-       connection_string="sqlite+aiosqlite:///queue.db",
-   )
-
-   app = Litestar(
-       plugins=[
-           SQLAlchemyPlugin(config=alchemy_config),
-           QueuePlugin(
-               QueueConfig(
-                   queue_backend=AdvancedAlchemyBackendConfig(
-                       sqlalchemy_config=alchemy_config,
-                       model_class=AppQueueTask,
-                       create_schema=True,
-                   ),
-                   execution_backend="local",
-               )
-           ),
-       ],
-   )
-
-The queue plugin does not append ``SQLAlchemyPlugin`` or consume request-scoped
-``db_session`` dependencies. Applications that manage schema with Alembic should
-import the queue model they use into their Alembic environment so autogenerate
-can include the queue table in the application migration stream. The default
-model is ``QueueTaskModel`` and uses the ``litestar_queue_task`` table. It is
-imported when ``AdvancedAlchemyBackendConfig()`` is constructed, so app startup
-normally puts it on Advanced Alchemy's base metadata before migration
-autogenerate runs.
-
-App-Owned Queue Model
-~~~~~~~~~~~~~~~~~~~~~
-
-Advanced Alchemy support includes a default queue model. Override it when the
-application needs its own table name, base class, bind metadata, or Alembic
-ownership. Compose ``QueueTaskModelMixin`` with an Advanced Alchemy base that
-provides compatible ``id`` and ``created_at`` columns, then pass the resulting
-model class to the backend:
-
-.. code-block:: python
-
-   from advanced_alchemy.base import UUIDAuditBase
-   from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, QueueTaskModelMixin
-
-   class AppQueueTask(UUIDAuditBase, QueueTaskModelMixin):
-       __tablename__ = "app_queue_task"
-
-   alchemy_config = SQLAlchemyAsyncConfig(
-       connection_string="sqlite+aiosqlite:///queue.db",
-   )
-
-   config = QueueConfig(
-       queue_backend=AdvancedAlchemyBackendConfig(
-           sqlalchemy_config=alchemy_config,
-           model_class=AppQueueTask,
-           create_schema=True,
-       ),
-       execution_backend="local",
-   )
-
-``QueueTaskModelMixin`` carries the queue columns and derives index names from
-the composed class's ``__tablename__``. If your application uses Alembic
-autogenerate, import this model in ``env.py`` and include its metadata in
-``target_metadata``. Use ``create_schema`` only for local bootstrap or tests;
-production schema changes should be generated and reviewed in the application
-migration stream.
-
-Advanced Alchemy Capability Notes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Advanced Alchemy backend uses native SQLAlchemy and Advanced Alchemy
-features where the dialect supports them:
+Topology and security
+=====================
 
 .. list-table::
    :header-rows: 1
 
-   * - Dialect family
-     - Claim strategy
-     - JSON storage
-     - Keyed enqueue
-   * - PostgreSQL
-     - ``FOR UPDATE SKIP LOCKED`` candidate selection plus an ownership update.
-     - ``JSONB`` through Advanced Alchemy's ``JsonB`` type.
-     - Native ``ON CONFLICT`` upsert for keyed records.
-   * - MySQL / MariaDB
-     - ``FOR UPDATE SKIP LOCKED`` candidate selection plus an ownership update.
-     - Native JSON through Advanced Alchemy's ``JsonB`` abstraction.
-     - Native duplicate-key upsert for keyed records.
-   * - Oracle
-     - ``FOR UPDATE SKIP LOCKED`` without ``FETCH FIRST`` so Oracle can lock
-       candidate rows correctly.
-     - Oracle JSON/BLOB handling through Advanced Alchemy's ``JsonB`` type.
-     - Native ``MERGE`` for keyed records.
-   * - SQLite and other dialects
-     - Optimistic compare-and-swap.
-     - Native dialect JSON where SQLAlchemy provides it.
-     - Portable key-check and insert fallback.
-
-All paths keep the same public queue semantics: active keyed records deduplicate,
-terminal keyed records can be replaced, stale recovery returns the affected task
-IDs, and ownership-fence losses surface as normal queue lifecycle events.
-
-.. _aa-heartbeat-session-maker:
-
-Heartbeat Session Maker Isolation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Workers issue a heartbeat write every ``QueueConfig.worker_heartbeat_interval``
-seconds for every running task. At high ``worker_max_concurrency`` those writes
-share the main async SQLAlchemy pool with task fetch, claim, and lifecycle
-UPDATEs. On network databases (AsyncPG, AioMySQL) heartbeats can stall behind
-queue work and miss the stale-recovery window.
-
-Construct a dedicated async engine and ``async_sessionmaker``, then pass it
-through ``heartbeat_session_maker``:
-
-.. code-block:: python
-
-   from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
-   from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
-   from myapp.models import AppQueueTask
-
-   queue_url = "postgresql+asyncpg://queue@db/queues"
-
-   main_config = SQLAlchemyAsyncConfig(connection_string=queue_url)
-   heartbeat_engine = create_async_engine(queue_url, pool_size=1, max_overflow=1)
-   heartbeat_maker = async_sessionmaker(heartbeat_engine, expire_on_commit=False)
-
-   config = QueueConfig(
-       queue_backend=AdvancedAlchemyBackendConfig(
-           sqlalchemy_config=main_config,
-           model_class=AppQueueTask,
-           heartbeat_session_maker=heartbeat_maker,
-       ),
-       execution_backend="local",
-       worker_max_concurrency=32,
-   )
-
-The dedicated engine MUST point at the same database as the main config. The
-backend uses it only for ``touch_heartbeat`` and ``null_heartbeats``; lifecycle
-UPDATEs that touch ``heartbeat_at`` alongside other columns (``claim_task``,
-``complete_task``, ``fail_task``, ``requeue_stale_running``) stay on the main
-session for transactional correctness. Recommended sizing:
-``pool_size=1, max_overflow=1`` for AsyncPG / AioMySQL, ``pool_size=1`` for
-``aiosqlite`` (SQLite serializes writes anyway). The dedicated engine's
-connections add to the application's total database connection budget.
-
-The adopter owns the dedicated engine's lifecycle. ``backend.close()`` does
-NOT dispose the heartbeat engine — call ``engine.dispose()`` from the
-application shutdown hook that owns the engine. Unlike the SQLSpec backend
-(which registers its dedicated config on ``open()``), the Advanced Alchemy
-backend never constructs or owns the heartbeat engine; any construction error
-surfaces from the first ``touch_heartbeat()`` call.
-
-When ``heartbeat_session_maker`` is ``None`` (the default), heartbeat writes
-share the main session exactly as before.
-
-Redis
------
-
-Install the Redis extra when a queue should persist task state in Redis:
-
-.. code-block:: bash
-
-   pip install litestar-queues[redis]
-
-Configure the queue backend with a Redis URL or pass an already configured
-async Redis client:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.redis import RedisBackendConfig
-
-   config = QueueConfig(
-       queue_backend=RedisBackendConfig(
-           url="redis://localhost:6379/0",
-           key_prefix="litestar_queues",
-           notifications=True,
-       ),
-       execution_backend="local",
-   )
-
-Redis queue records are stored in hashes under the configured key prefix. The
-backend keeps an ID set for operational queries, a key hash for deduplication,
-a sorted set for delayed scheduling, and short-lived ``SET NX`` locks around
-claim and key-replacement mutations. Task arguments, keyword arguments,
-metadata, and results must be JSON serializable.
-
-Redis pub/sub is used only as a worker wakeup mechanism. Notifications are not
-durable; workers that miss a message fall back to polling.
-
-Valkey
-------
-
-Install the Valkey extra when a queue should use Valkey's asyncio client:
-
-.. code-block:: bash
-
-   pip install litestar-queues[valkey]
-
-Configure Valkey with the same queue backend settings:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.valkey import ValkeyBackendConfig
-
-   config = QueueConfig(
-       queue_backend=ValkeyBackendConfig(
-           url="redis://localhost:6379/0",
-           key_prefix="litestar_queues",
-           notifications=True,
-       ),
-       execution_backend="local",
-   )
-
-Valkey follows the same queue lifecycle contract as Redis: active key
-deduplication, terminal key replacement, delayed scheduling, atomic claim via
-backend locks, retries, heartbeats, stale running recovery, result lookup,
-stats, cleanup, and optional pub/sub worker wakeups.
-
-Cloud Run
----------
-
-Install the Cloud Run extra when tasks should execute in Cloud Run Jobs:
-
-.. code-block:: bash
-
-   pip install litestar-queues[cloudrun]
-
-Configure Cloud Run execution with generic package settings. Queue persistence
-remains app-owned and can use any queue backend that supports execution
-references:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-   from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(config=...),
-       execution_backend=CloudRunExecutionConfig(
-           project_id="my-project",
-           region="us-central1",
-           job_name="my-worker-job",
-           profiles={"heavy": "my-worker-job-heavy"},
-       ),
-   )
-
-By default, Cloud Run dispatch failures surface through logs and queue events
-and the record remains routed to ``cloudrun`` for operator intervention or a
-later retry. ``CloudRunExecutionConfig.fallback_execution_backend`` defaults to
-``None`` so a failed dispatch is not silently rerouted to a backend that may not
-have a worker. To opt back into rerouting, set an explicit backend such as
-``fallback_execution_backend="local"`` and run a worker that can consume it.
-
-Worker environment contract
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The packaged Cloud Run Job entry point is ``litestar-queues-cloudrun-worker``.
-It rebuilds the shared queue service, imports task modules, claims the persisted
-record, executes the task, and exits with a deterministic status code.
-
-The names below use the default ``CloudRunExecutionConfig.env_prefix`` value,
-``LITESTAR_QUEUES``. If you set a different prefix, every variable name uses
-that prefix; for example ``MY_QUEUE_TASK_ID``.
-
-.. list-table::
-   :header-rows: 1
-
-   * - Env var
-     - Required
-     - Meaning
-   * - ``LITESTAR_QUEUES_CONFIG_FACTORY``
-     - Yes
-     - ``module:attr`` or dotted path returning the shared-DB
-       ``QueueConfig``, ``QueueService``, or async context manager for a
-       ``QueueService``.
-   * - ``LITESTAR_QUEUES_TASK_MODULES``
-     - Recommended
-     - Comma-separated modules to import before task lookup. The entry point
-       merges these with ``QueueConfig.task_modules``.
-   * - ``LITESTAR_QUEUES_TASK_ID``
-     - Injected by dispatcher
-     - Queue record UUID to claim and execute.
-   * - ``LITESTAR_QUEUES_TASK_NAME``
-     - Injected by dispatcher
-     - Task name stored on the queue record.
-   * - ``LITESTAR_QUEUES_TASK_ARGS``
-     - Injected by dispatcher
-     - JSON-encoded positional arguments for diagnostics.
-   * - ``LITESTAR_QUEUES_TASK_KWARGS``
-     - Injected by dispatcher
-     - JSON-encoded keyword arguments for diagnostics.
-   * - ``LITESTAR_QUEUES_EXECUTION_BACKEND``
-     - Injected by dispatcher
-     - Set to ``cloudrun``.
-   * - ``LITESTAR_QUEUES_EXECUTION_PROFILE``
-     - When configured
-     - Profile selector used to pick a profile-specific Cloud Run Job.
-
-Entrypoint exit codes:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Code
-     - Meaning
-   * - ``0``
-     - Task completed successfully.
-   * - ``1``
-     - Task ran and failed.
-   * - ``2``
-     - ``TASK_ID`` was missing.
-   * - ``3``
-     - ``TASK_ID`` was not a UUID.
-   * - ``4``
-     - The queue record was not found.
-   * - ``5``
-     - The task name was not registered after imports.
-   * - ``6``
-     - Claim or heartbeat ownership was lost.
-   * - ``7``
-     - Execution was cancelled.
-   * - ``8``
-     - ``CONFIG_FACTORY`` was missing or could not be loaded.
-
-The full Cloud Run deployment guide lives in :doc:`deployment/cloud-run`. It
-covers the enqueue / dispatch / execute split, the worker env contract, IAM,
-database connectivity, timeout alignment, scheduling, and troubleshooting.
-
-SQLSpec Event Notifications
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The SQLSpec backend falls back to worker polling unless notifications are
-configured. To wake workers through SQLSpec Events, configure the SQLSpec
-``events`` extension and enable queue notifications:
-
-.. code-block:: python
-
-   from sqlspec.adapters.aiosqlite import AiosqliteConfig
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-   sqlspec_config = AiosqliteConfig(
-       connection_config={"database": "queue.db"},
-       extension_config={
-           "events": {
-               "backend": "table_queue",
-               "queue_table": "queue_events",
-               "poll_interval": 0.1,
-           }
-       },
-   )
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           config=sqlspec_config,
-           create_schema=False,
-           run_migrations=True,
-           notifications=True,
-           notification_channel="queue_notifications",
-       ),
-       execution_backend="local",
-   )
-
-PostgreSQL SQLSpec adapters can use SQLSpec's native ``listen_notify`` backend;
-other adapters can use the durable ``table_queue`` backend. Oracle adapters can
-use native ``aq`` or ``txeventq`` transports when the database user has AQ
-privileges and the target queues are provisioned. These Oracle transports stay
-explicit because queue provisioning is DBA-owned:
-
-.. code-block:: python
-
-   from sqlspec.adapters.oracledb import OracleAsyncConfig
-
-   oracle_config = OracleAsyncConfig(
-       connection_config={
-           "host": "db.example.com",
-           "port": 1521,
-           "service_name": "FREEPDB1",
-           "user": "queue_app",
-           "password": "...",
-           "min": 1,
-           "max": 5,
-       },
-       extension_config={
-           "events": {
-               "backend": "txeventq",
-               "aq_queue": "LQ_EVENTS_TXQ",
-           }
-       },
-   )
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           config=oracle_config,
-           notifications=True,
-           notify_transport="txeventq",
-           event_settings={"aq_queue": "LQ_EVENTS_TXQ"},
-       ),
-       execution_backend="local",
-   )
-
-Queue notification channel names must be valid SQLSpec event identifiers.
-
-SQLSpec Observability
-~~~~~~~~~~~~~~~~~~~~~
-
-The SQLSpec backend uses SQLSpec's ``ObservabilityRuntime`` for queue-domain
-counters and spans. SQL statements executed by the backend already flow through
-SQLSpec driver spans and statement observers, so query spans inherit SQLSpec
-correlation context automatically.
-
-Queue counters are recorded with these reserved names:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Metric
-     - Meaning
-   * - ``queue.enqueue``
-     - Queue records inserted by ``enqueue`` or ``enqueue_many``.
-   * - ``queue.claim``
-     - Records successfully claimed for execution.
-   * - ``queue.complete``
-     - Records completed successfully.
-   * - ``queue.fail``
-     - Records moved to terminal failure by ``fail_task``.
-   * - ``queue.retry``
-     - Records requeued for another attempt.
-   * - ``queue.stale_recovered``
-     - Stale running records handled by stale recovery.
-   * - ``queue.notify``
-     - Worker wakeup notifications published through SQLSpec Events.
-   * - ``queue.claim_lost``
-     - Fenced completion or failure attempts rejected after ownership changed.
-   * - ``queue.stale_failed``
-     - Stale records moved to terminal failure.
-
-Counters are available from SQLSpec diagnostics:
-
-.. code-block:: python
-
-   runtime = sqlspec_config.get_observability_runtime()
-   queue_metrics = runtime.metrics_snapshot()
-
-Set ``queue_observability=False`` on ``SQLSpecBackendConfig`` to disable only the
-queue-domain counters and custom queue spans. SQLSpec driver query spans and
-statement observers remain controlled by the SQLSpec config.
-
-When package-level queue observability is enabled through
-``QueueConfig(observability=ObservabilityConfig(...))``, SQLSpec
-queue-domain counters and custom queue spans are disabled by default to avoid
-double counting the same queue operations. SQLSpec driver query spans and
-statement observers still run from the SQLSpec config.
-
-OpenTelemetry tracing and Prometheus statement metrics are enabled through
-SQLSpec's optional extensions:
-
-.. code-block:: python
-
-   from sqlspec import SQLSpec
-   from sqlspec.adapters.asyncpg import AsyncpgConfig
-   from sqlspec.extensions.otel import enable_tracing
-   from sqlspec.extensions.prometheus import enable_metrics
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-   observability = enable_tracing(
-       resource_attributes={"service.name": "queue-worker"},
-   )
-   observability = enable_metrics(base_config=observability)
-
-   sqlspec = SQLSpec(observability_config=observability)
-   sqlspec_config = AsyncpgConfig(
-       pool_config={"dsn": "postgresql://queue@db/queues"},
-   )
-   sqlspec.add_config(sqlspec_config)
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(
-           sqlspec=sqlspec,
-           config=sqlspec_config,
-       ),
-       execution_backend="local",
-   )
-
-Pool, connection, session, and query lifecycle hooks remain SQLSpec-owned. Attach
-them to the same runtime when you need adapter-level lifecycle events:
-
-.. code-block:: python
-
-   def record_query_complete(context: dict[str, object]) -> None:
-       ...
-
-   runtime = sqlspec_config.get_observability_runtime()
-   runtime.register_lifecycle_hook("on_query_complete", record_query_complete)
-
-SQLSpec's Prometheus helper records bounded statement metrics such as
-``sqlspec_driver_query_total`` and ``sqlspec_driver_query_duration_seconds``.
-Applications that want the queue-domain counters in Prometheus can expose the
-``metrics_snapshot()`` values through their own metrics bridge.
-
-Shared SQLSpec Extension Config
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Applications can place queue defaults in ``sqlspec_config.extension_config``.
-Explicit values passed through ``SQLSpecBackendConfig`` take
-precedence:
-
-.. code-block:: python
-
-   sqlspec_config = AiosqliteConfig(
-       connection_config={"database": "queue.db"},
-       extension_config={
-           "litestar_queues": {
-               "table_name": "app_queue_task",
-               "notification_channel": "app_queue_notifications",
-           }
-       },
-   )
+   * - Topology
+     - Queue records
+     - Live events
+     - Security boundary
+   * - Memory examples
+     - Process-local memory
+     - ``MemoryChannelsBackend`` in the same process
+     - Local demo; do not expose as a multi-replica service.
+   * - Separate Redis/Valkey worker
+     - Shared Redis or Valkey
+     - Explicit shared Channels backend and distinct key prefix
+     - Authenticate the service, isolate prefixes, and authorize stream routes.
+   * - SQL/AA workers
+     - Shared database
+     - Separately configured Channels transport
+     - Protect database credentials and authorize subscriber scopes.
+
+Continue with :doc:`workers`, :doc:`worker-wakeups`, or the focused backend
+guide selected above.

--- a/docs/usage/backends/advanced-alchemy.rst
+++ b/docs/usage/backends/advanced-alchemy.rst
@@ -1,0 +1,59 @@
+========================
+Advanced Alchemy backend
+========================
+
+Use this backend when the application already owns SQLAlchemy models and
+migrations through Advanced Alchemy.
+
+Install and configure
+=====================
+
+.. code-block:: bash
+
+   pip install "litestar-queues[advanced-alchemy]" aiosqlite
+
+.. code-block:: python
+
+   from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+   from litestar_queues import QueueConfig
+   from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+
+   alchemy = SQLAlchemyAsyncConfig(
+       connection_string="sqlite+aiosqlite:///queue.db"
+   )
+   queue_config = QueueConfig(
+       queue_backend=AdvancedAlchemyBackendConfig(
+           sqlalchemy_config=alchemy,
+           create_schema=False,
+       ),
+       execution_backend="local",
+   )
+
+The backend opens fresh operation-scoped sessions and commits or rolls back its
+own queue mutations. It never retains a request-scoped ``db_session``.
+
+Own the models and migrations
+=============================
+
+For production, compose ``QueueTaskModelMixin`` with the application's
+declarative base, set ``__tablename__``, and pass the concrete class through
+``model_class``. Import that model into the application's Alembic metadata.
+``create_schema=True`` is only a local/test bootstrap shortcut.
+
+Event history uses a separate concrete model. Compose
+``QueueEventLogModelMixin`` with the same application base and pass it as
+``event_log_model_class``. Enable recording with
+``QueueConfig(event_log=EventLogConfig(...))``. A custom event model
+must expose the columns required by the mixin contract and belong to the same
+database lifecycle as the queue model.
+
+Wakeups and heartbeats
+======================
+
+``notifications=True`` enables direct PostgreSQL notification hints when the
+dialect supports them. The task table remains authoritative and workers keep
+polling. ``heartbeat_session_maker`` may isolate heartbeat-only writes; the
+application owns and disposes its engine.
+
+This direct PostgreSQL hint is not task storage and not browser delivery. See
+:doc:`../worker-wakeups` and :doc:`../event-streams`.

--- a/docs/usage/backends/advanced-alchemy.rst
+++ b/docs/usage/backends/advanced-alchemy.rst
@@ -16,29 +16,62 @@ Install and configure
 
    from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
    from litestar_queues import QueueConfig
-   from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+   from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackendConfig
 
    alchemy = SQLAlchemyAsyncConfig(
-       connection_string="sqlite+aiosqlite:///queue.db"
+       connection_string="sqlite+aiosqlite:///queue.db",
+       create_all=True,
    )
    queue_config = QueueConfig(
-       queue_backend=AdvancedAlchemyBackendConfig(
+       queue_backend=SQLAlchemyBackendConfig(
            sqlalchemy_config=alchemy,
-           create_schema=False,
        ),
        execution_backend="local",
    )
 
-The backend opens fresh operation-scoped sessions and commits or rolls back its
-own queue mutations. It never retains a request-scoped ``db_session``.
+The backend opens a new database session for each queue operation. It commits
+or rolls back its own changes and never keeps a request-scoped ``db_session``.
+Add the same ``SQLAlchemyAsyncConfig`` to the application's
+``SQLAlchemyPlugin``. The queue backend is not a schema manager.
 
 Own the models and migrations
 =============================
 
-For production, compose ``QueueTaskModelMixin`` with the application's
-declarative base, set ``__tablename__``, and pass the concrete class through
-``model_class``. Import that model into the application's Alembic metadata.
-``create_schema=True`` is only a local/test bootstrap shortcut.
+For production, combine ``QueueTaskModelMixin`` with the application's
+declarative base. ``model_class`` is the mapped queue-task model class, not a
+table-name string. Its ``__tablename__`` is the name of the queue task table.
+Import that model into the application's metadata and let Advanced Alchemy
+``create_all`` or Alembic migrations create it.
+
+The built-in models use ``litestar_queue_task`` for queue records and
+``litestar_queue_task_event_log`` for event history. Use the same pattern for
+custom models:
+
+.. code-block:: python
+
+   from advanced_alchemy.base import UUIDAuditBase
+   from litestar_queues.backends.advanced_alchemy import (
+       SQLAlchemyBackendConfig,
+       QueueEventLogModelMixin,
+       QueueTaskModelMixin,
+   )
+
+   class AppQueueTask(UUIDAuditBase, QueueTaskModelMixin):
+       __tablename__ = "app_queue_task"
+
+   class AppQueueEventLog(UUIDAuditBase, QueueEventLogModelMixin):
+       __tablename__ = "app_queue_task_event_log"
+
+   queue_config = QueueConfig(
+       queue_backend=SQLAlchemyBackendConfig(
+           sqlalchemy_config=alchemy,
+           model_class=AppQueueTask,
+           event_log_model_class=AppQueueEventLog,
+       ),
+   )
+
+The ``_event_log`` suffix keeps the two table names together. The queue
+backend checks the model shape, but it does not create either table.
 
 Event history uses a separate concrete model. Compose
 ``QueueEventLogModelMixin`` with the same application base and pass it as
@@ -50,10 +83,10 @@ database lifecycle as the queue model.
 Wakeups and heartbeats
 ======================
 
-``notifications=True`` enables direct PostgreSQL notification hints when the
-dialect supports them. The task table remains authoritative and workers keep
-polling. ``heartbeat_session_maker`` may isolate heartbeat-only writes; the
-application owns and disposes its engine.
+``notifications=True`` enables direct PostgreSQL wakeup hints when the dialect
+supports them. The task table remains the source of truth, so workers keep
+polling. ``heartbeat_session_maker`` may use a separate session for heartbeat
+writes. The application owns and closes its engine.
 
 This direct PostgreSQL hint is not task storage and not browser delivery. See
 :doc:`../worker-wakeups` and :doc:`../event-streams`.

--- a/docs/usage/backends/redis-valkey.rst
+++ b/docs/usage/backends/redis-valkey.rst
@@ -47,12 +47,11 @@ to queue operations, not browser Channels.
 Event history and live delivery
 ===============================
 
-Backend-managed event history is supported. Redis/Valkey operators control
-persistence configuration, retention, backups, memory policy, and cleanup;
-the library cannot make an ephemeral service durable.
+Backend-managed event history is supported. You choose how long Redis or
+Valkey keeps history, what it backs up, and when it removes old records. The
+library cannot make an otherwise temporary service durable.
 
-A Redis or Valkey queue backend does not automatically provide live fan-out.
-Configure a shared Channels backend with a separate Channels key prefix for
-standalone workers and multiple web processes. Redis pub/sub is ephemeral
-broadcast; Redis Streams can retain backlog. Keep stream authorization at the
-Litestar route boundary.
+A Redis or Valkey queue backend does not automatically send events to browsers.
+For standalone workers or multiple web processes, configure a shared Channels
+backend with its own key prefix. Redis pub/sub is temporary; Redis Streams can
+keep a backlog. Protect stream access at the Litestar route.

--- a/docs/usage/backends/redis-valkey.rst
+++ b/docs/usage/backends/redis-valkey.rst
@@ -1,0 +1,58 @@
+==========================
+Redis and Valkey backends
+==========================
+
+Redis and Valkey store queue records in a shared service and use pub/sub hints
+to wake workers. Choose the client that matches the service your application
+operates.
+
+.. code-block:: bash
+
+   pip install "litestar-queues[redis]"
+   # or: pip install "litestar-queues[valkey]"
+
+.. code-block:: python
+
+   from litestar_queues import QueueConfig
+   from litestar_queues.backends.redis import RedisBackendConfig
+
+   queue_config = QueueConfig(
+       queue_backend=RedisBackendConfig(
+           url="redis://localhost:6379/0",
+           key_prefix="myapp:queues",
+           notifications=True,
+       ),
+       execution_backend="local",
+       in_app_worker=False,
+   )
+
+Use ``ValkeyBackendConfig`` from ``litestar_queues.backends.valkey`` for
+Valkey. Both accept the same URL-shaped connection syntax, but Valkey uses the
+Valkey client and does not require Redis as an import side effect.
+
+Payloads and key isolation
+==========================
+
+Task arguments, keyword arguments, metadata, results, and errors must be JSON
+serializable. Give each application and environment a distinct ``key_prefix``;
+do not use ``FLUSHALL`` for test cleanup on shared infrastructure.
+
+Worker wakeups
+==============
+
+``notifications=True`` publishes non-durable worker hints. Workers still poll
+the stored queue state. ``notification_channel`` and queue key prefixes belong
+to queue operations, not browser Channels.
+
+Event history and live delivery
+===============================
+
+Backend-managed event history is supported. Redis/Valkey operators control
+persistence configuration, retention, backups, memory policy, and cleanup;
+the library cannot make an ephemeral service durable.
+
+A Redis or Valkey queue backend does not automatically provide live fan-out.
+Configure a shared Channels backend with a separate Channels key prefix for
+standalone workers and multiple web processes. Redis pub/sub is ephemeral
+broadcast; Redis Streams can retain backlog. Keep stream authorization at the
+Litestar route boundary.

--- a/docs/usage/backends/sqlspec.rst
+++ b/docs/usage/backends/sqlspec.rst
@@ -1,0 +1,69 @@
+===============
+SQLSpec backend
+===============
+
+Use SQLSpec when the application already uses SQLSpec or needs queue
+persistence across its supported adapter families without adopting an ORM.
+
+Install and configure
+=====================
+
+Install the queue extra and the SQLSpec driver for your database. This SQLite
+example is suitable for local development:
+
+.. code-block:: bash
+
+   pip install "litestar-queues[sqlspec]" aiosqlite
+
+.. code-block:: python
+
+   from sqlspec.adapters.aiosqlite import AiosqliteConfig
+   from litestar_queues import QueueConfig
+   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+
+   queue_config = QueueConfig(
+       queue_backend=SQLSpecBackendConfig(
+           config=AiosqliteConfig(connection_config={"database": "queue.db"}),
+           run_migrations=True,
+       ),
+       execution_backend="local",
+       in_app_worker=False,
+   )
+
+Adapter selection follows the supplied SQLSpec config. Unsupported adapters
+raise a configuration error instead of silently using a generic SQL path.
+
+Schema ownership
+================
+
+Packaged migrations run as SQLSpec extension migrations. Do not replace the
+application migration ``script_location``. Set ``manage_schema=False`` when
+the application owns an existing table; use ``table_name``, ``column_map``,
+and ``native_json_columns`` to map it safely.
+
+Wakeups
+-------
+
+Set ``notifications`` and ``notify_transport`` only for a SQLSpec transport
+supported by the selected adapter. ``notification_channel`` defaults to
+``litestar_queues_tasks``. Canonical PostgreSQL-family choices are ``notify``
+(ephemeral broadcast hint), ``notify_queue`` (durable notify-assisted queue),
+and ``poll_queue`` (durable polled queue). ``polling`` disables push wakeups;
+Oracle can use explicitly provisioned ``aq`` or ``txeventq``. Durable queue
+transports are competing-consumer queues; do not use them as multi-process
+browser fan-out. See :doc:`../worker-wakeups`.
+
+Heartbeat isolation
+===================
+
+``heartbeat_pool_config`` can route heartbeat-only writes through a dedicated
+pool pointing at the same database. The backend owns that pool's open/close
+lifecycle and falls back to the main pool if registration fails.
+
+Event history
+=============
+
+SQLSpec event history uses the queue schema, packaged migration path, and
+SQLSpec session lifecycle. ``event_log_table_name`` customizes the table.
+Live SSE/WebSocket delivery still needs a Channels backend. See
+:doc:`../event-history`.

--- a/docs/usage/backends/sqlspec.rst
+++ b/docs/usage/backends/sqlspec.rst
@@ -2,8 +2,8 @@
 SQLSpec backend
 ===============
 
-Use SQLSpec when the application already uses SQLSpec or needs queue
-persistence across its supported adapter families without adopting an ORM.
+Use SQLSpec when the application already uses it or needs SQL queue storage
+without an object-relational mapper (ORM).
 
 Install and configure
 =====================
@@ -17,29 +17,50 @@ example is suitable for local development:
 
 .. code-block:: python
 
+   from litestar import Litestar
    from sqlspec.adapters.aiosqlite import AiosqliteConfig
-   from litestar_queues import QueueConfig
+   from litestar_queues import QueueConfig, QueuePlugin
    from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+
+   sqlspec_config = AiosqliteConfig(connection_config={"database": "queue.db"})
 
    queue_config = QueueConfig(
        queue_backend=SQLSpecBackendConfig(
-           config=AiosqliteConfig(connection_config={"database": "queue.db"}),
-           run_migrations=True,
+           config=sqlspec_config,
        ),
        execution_backend="local",
-       in_app_worker=False,
    )
+   app = Litestar(plugins=[QueuePlugin(queue_config)])
 
-Adapter selection follows the supplied SQLSpec config. Unsupported adapters
-raise a configuration error instead of silently using a generic SQL path.
+   # Run this from the app's normal SQLSpec migration command or deploy step.
+   await sqlspec_config.migrate_up(echo=False)
+
+The supplied SQLSpec config selects the adapter. ``QueuePlugin`` registers the
+queue migration during app and CLI initialization; SQLSpec then runs it through
+the same migration command used by the rest of the application. The queue
+backend does not migrate the database when it opens. An unsupported adapter
+raises a configuration error instead of silently using generic SQL.
 
 Schema ownership
 ================
 
-Packaged migrations run as SQLSpec extension migrations. Do not replace the
-application migration ``script_location``. Set ``manage_schema=False`` when
-the application owns an existing table; use ``table_name``, ``column_map``,
-and ``native_json_columns`` to map it safely.
+Packaged migrations run through SQLSpec's extension system. Do not replace the
+application's migration ``script_location``. When migrations run outside the
+Litestar app, call ``configure_queue_migration_extension(sqlspec_config)``
+before the normal SQLSpec migration command. If the application owns an
+existing table, set ``manage_schema=False``. Map that table with
+``queue_table_name``, ``column_map``, and ``native_json_columns``.
+
+For a small local bootstrap without a migration command, call the backend's
+explicit ``create_schema()`` operation after ``open()``. This emits adapter-
+specific DDL directly and does not record a migration revision; it is a
+development fallback, not a replacement for application migrations.
+
+The default queue table is ``litestar_queue_task``. When event history is
+enabled, SQLSpec derives its table by adding ``_event_log`` to the queue table,
+so the default is ``litestar_queue_task_event_log``. Set
+``event_log_table_name`` only when the application needs a different name.
+Schema-qualified names keep their schema and add the suffix to the table part.
 
 Wakeups
 -------
@@ -56,14 +77,16 @@ browser fan-out. See :doc:`../worker-wakeups`.
 Heartbeat isolation
 ===================
 
-``heartbeat_pool_config`` can route heartbeat-only writes through a dedicated
-pool pointing at the same database. The backend owns that pool's open/close
-lifecycle and falls back to the main pool if registration fails.
+``heartbeat_pool_config`` can use a dedicated connection pool for heartbeat
+writes. It must point to the same database. The backend opens and closes that
+pool, and falls back to the main pool if registration fails.
 
 Event history
 =============
 
-SQLSpec event history uses the queue schema, packaged migration path, and
-SQLSpec session lifecycle. ``event_log_table_name`` customizes the table.
+SQLSpec event history uses the queue schema, the packaged SQLSpec migration,
+and the SQLSpec session lifecycle. Its table naming follows the queue-table
+``_event_log`` suffix described above. ``event_log_table_name`` customizes the
+table.
 Live SSE/WebSocket delivery still needs a Channels backend. See
 :doc:`../event-history`.

--- a/docs/usage/background-tasks.rst
+++ b/docs/usage/background-tasks.rst
@@ -41,11 +41,11 @@ background phase:
            background=QueuedBackgroundTask(process_import, "/tmp/data.csv"),
        )
 
-Here the response lifecycle begins first and the queue record is persisted
-afterward. The plugin keeps its application-scoped service alive for this
-phase. This shape cannot return a queue task ID in the initial body unless the
-application creates and manages one separately.
+Here Litestar starts the response before it saves the queue record. The plugin
+keeps the app's queue service open until that step finishes. The initial
+response cannot include a queue task ID unless the application creates and
+manages an ID separately.
 
-A plain Litestar ``BackgroundTask`` executes its callable in the web process;
-it does not persist a queue record. ``QueuedBackgroundTask`` uses the same
-response hook but enqueues through the active ``QueuePlugin`` service.
+A plain Litestar ``BackgroundTask`` runs its function in the web process. It
+does not save a queue record. ``QueuedBackgroundTask`` uses the same response
+hook, but adds the task through the active ``QueuePlugin`` service.

--- a/docs/usage/background-tasks.rst
+++ b/docs/usage/background-tasks.rst
@@ -1,0 +1,51 @@
+====================
+Background responses
+====================
+
+Litestar background tasks and queue tasks begin at different points in the
+response lifecycle.
+
+Persist before responding
+=========================
+
+Enqueue inside the handler when the task record must exist before Litestar
+sends the response:
+
+.. code-block:: python
+
+   @post("/imports")
+   async def start_import(
+       queue_service: NamedDependency[QueueService],
+   ) -> dict[str, str]:
+       result = await queue_service.enqueue(process_import, "/tmp/data.csv")
+       return {"task_id": str(result.id)}
+
+If enqueueing fails, the handler fails and no success response is sent.
+
+Enqueue after the response starts
+=================================
+
+:class:`~litestar_queues.QueuedBackgroundTask` uses Litestar's response
+background phase:
+
+.. code-block:: python
+
+   from litestar import Response, post
+   from litestar_queues import QueuedBackgroundTask
+
+
+   @post("/imports/deferred")
+   async def defer_import() -> Response[dict[str, str]]:
+       return Response(
+           {"status": "accepted"},
+           background=QueuedBackgroundTask(process_import, "/tmp/data.csv"),
+       )
+
+Here the response lifecycle begins first and the queue record is persisted
+afterward. The plugin keeps its application-scoped service alive for this
+phase. This shape cannot return a queue task ID in the initial body unless the
+application creates and manages one separately.
+
+A plain Litestar ``BackgroundTask`` executes its callable in the web process;
+it does not persist a queue record. ``QueuedBackgroundTask`` uses the same
+response hook but enqueues through the active ``QueuePlugin`` service.

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -3,29 +3,28 @@ Command-Line Interface
 ==========================
 
 ``QueuePlugin`` implements Litestar's :class:`~litestar.plugins.CLIPluginProtocol`
-and contributes a ``queues`` subcommand group to the ``litestar`` CLI. Three
-subcommands ship today: ``run``, ``status``, and ``scheduler-health``. A
-``discover_tasks`` helper supports adopters with ``app.domain.<x>.jobs/``
-layouts.
+and adds a ``queues`` group to the ``litestar`` CLI. It provides ``run``,
+``status``, and ``scheduler-health``. The ``discover_tasks`` helper supports
+applications that keep tasks under ``app.domain.<x>.jobs/``.
 
 Pre-requisites
 ==============
 
-Every ``litestar queues …`` invocation resolves the application the same way
+Every ``litestar queues …`` command finds the application the same way
 ``litestar run`` and ``litestar routes`` do: via ``LITESTAR_APP``, the
 ``--app`` flag, or one of the standard discovery paths (``app.py``,
 ``asgi.py``, ``application.py``, ``app/__init__.py``). When none are
 present, the CLI errors before any queue subcommand runs.
 
-``click`` is not a runtime dependency of ``litestar-queues``. It arrives
-transitively through ``litestar``; importing ``litestar_queues`` (without
-invoking the CLI) does **not** load ``click`` into ``sys.modules``.
+``click`` is not a direct runtime dependency of ``litestar-queues``. Litestar
+installs it. Importing ``litestar_queues`` without using the CLI does **not**
+load ``click`` into ``sys.modules``.
 
 ``litestar queues run``
 =======================
 
-Starts a standalone worker fleet outside the Litestar web app process. Use
-this for sidecar worker containers, ``systemd`` units, or Cloud Run jobs.
+Starts standalone workers outside the Litestar web process. Use this command
+for sidecar worker containers, ``systemd`` units, or Cloud Run jobs.
 
 .. code-block:: console
 
@@ -45,10 +44,9 @@ Options:
 Signal handling
 ---------------
 
-``SIGTERM`` and ``SIGINT`` both trigger a graceful drain:
-``Worker.stop()`` is set and the worker task is awaited up to
-``--drain-timeout``. A **second** signal during drain escalates: every
-running asyncio task is cancelled immediately. Exit codes:
+``SIGTERM`` and ``SIGINT`` both start a graceful shutdown. The worker stops
+claiming new tasks and waits up to ``--drain-timeout`` for running tasks. A
+**second** signal cancels every running asyncio task immediately. Exit codes:
 
 ============  ==================================================================
 Code          Meaning
@@ -95,8 +93,8 @@ Exit codes: ``0`` on success, ``1`` on backend error.
 ``litestar queues scheduler-health``
 ====================================
 
-Exits non-zero when no completion record exists for a configured canary
-task within the staleness window.
+Exits with a nonzero code when the configured canary task has no recent
+completion record. A canary is a small recurring task used as a health check.
 
 .. code-block:: console
 
@@ -135,10 +133,10 @@ subcommand.
 ``discover_tasks``
 ==================
 
-Adopters with an ``app.domain.<x>.jobs/`` layout can use the
-:func:`~litestar_queues.discover_tasks` walker to import every module
-under any ``jobs`` subpackage at startup, replacing manual enumeration
-in :attr:`QueueConfig.task_modules`:
+Applications with an ``app.domain.<x>.jobs/`` layout can use
+:func:`~litestar_queues.discover_tasks` to import every module under each
+``jobs`` package at startup. This replaces a manual list in
+:attr:`QueueConfig.task_modules`:
 
 .. code-block:: python
 
@@ -156,17 +154,16 @@ Signature:
 .. autofunction:: litestar_queues.discover_tasks
    :noindex:
 
-The default ``subpackage="jobs"`` matches modules whose dotted path
-contains a ``jobs`` segment (e.g. ``app.domain.billing.jobs.send_invoice``).
-The return value is a sorted, deduplicated tuple of fully-qualified task
-names that reflects the post-walk registry, suitable for logging or
-metrics labels.
+The default ``subpackage="jobs"`` matches modules with a ``jobs`` segment in
+their dotted path, such as ``app.domain.billing.jobs.send_invoice``. The
+function returns a sorted tuple of unique, fully qualified task names found in
+the registry. You can use it in logs or metric labels.
 
 Deployment example
 ==================
 
-For a sidecar worker fleet behind Granian-served web pods (e.g. Cloud
-Run service + Cloud Run job, or Kubernetes Deployment + StatefulSet):
+This shortened ``systemd`` unit shows a sidecar worker command. The same
+command can run beside Granian web pods on Cloud Run or Kubernetes:
 
 .. code-block:: yaml
 
@@ -177,6 +174,5 @@ Run service + Cloud Run job, or Kubernetes Deployment + StatefulSet):
    Restart=on-failure
    TimeoutStopSec=90
 
-The ``TimeoutStopSec`` value should exceed ``--drain-timeout`` so the
-service manager does not ``SIGKILL`` the worker while it is still
-draining.
+Set ``TimeoutStopSec`` higher than ``--drain-timeout``. Otherwise, the service
+manager may send ``SIGKILL`` while the worker is still shutting down.

--- a/docs/usage/concepts.rst
+++ b/docs/usage/concepts.rst
@@ -2,8 +2,8 @@
 Concepts
 ========
 
-Litestar Queues separates the durable description of work from the place that
-runs it. This keeps the task API stable while deployment choices change.
+Litestar Queues stores a description of the work separately from the process
+that runs it. You can change the deployment without changing the task API.
 
 The task flow
 =============
@@ -24,10 +24,10 @@ The record—not the Python coroutine—is what a worker claims.
 Queue backend
 =============
 
-The **queue backend** stores task records and their states. Memory is the
-default and is process-local. SQLSpec, Advanced Alchemy, Redis, and Valkey can
-share records between web and worker processes. Persisted task state remains
-the source of truth.
+The **queue backend** stores task records and their states. The default memory
+backend stores them in one process. SQLSpec, Advanced Alchemy, Redis, and
+Valkey can share records between web and worker processes. The saved task
+record is always the source of truth.
 
 Execution backend
 =================
@@ -39,25 +39,26 @@ it to a Cloud Run Job. Execution placement does not replace queue persistence.
 Worker lifecycle
 ================
 
-A worker finds due records, claims them, runs or dispatches them, records the
-outcome, and retries eligible failures. The plugin can start a worker in the
-web process; production deployments commonly run workers separately.
+A worker finds tasks that are ready, claims them, and runs or dispatches them.
+It then saves the result and retries failures when allowed. The plugin can
+start a worker in the web process. Production deployments often run workers
+separately.
 
 Wakeups and reconciliation
 ==========================
 
-A backend may notify workers when work arrives. A **worker wakeup is a hint**:
-notifications can be delayed or dropped, so workers also poll and reconcile
-against persisted state. A wakeup is never durable task storage.
+A backend may notify workers when work arrives. A **worker wakeup** is only a
+hint to check the queue. Because notifications may be late or lost, workers
+also poll the saved task state. A wakeup never stores a task.
 
 Task events
 ===========
 
-Tasks can publish lifecycle, progress, log, and custom events for application
-or operator consumers. Live task event delivery uses event sinks and Litestar
-Channels. It is separate from queue-backend wakeups and is not worker discovery.
-Durable event history is another queue-backend capability and is also separate
-from live browser fan-out.
+Tasks can publish lifecycle, progress, log, and custom events for applications
+and operators. Event sinks and Litestar Channels deliver these events live.
+This live delivery is not worker discovery. It does not wake workers or help
+them find tasks. Event history is stored by the queue backend and is also
+separate from live browser delivery.
 
 Choose the next guide
 =====================

--- a/docs/usage/concepts.rst
+++ b/docs/usage/concepts.rst
@@ -1,0 +1,69 @@
+========
+Concepts
+========
+
+Litestar Queues separates the durable description of work from the place that
+runs it. This keeps the task API stable while deployment choices change.
+
+The task flow
+=============
+
+.. code-block:: text
+
+   enqueue -> queued task record -> worker wakeup or polling -> claim -> execute
+   -> retry/terminal state -> optional task event delivery
+
+Task and record
+===============
+
+A function decorated with :func:`~litestar_queues.task` is a registered
+``Task``. Calling ``QueueService.enqueue()`` creates a queued task record with
+the task name, arguments, queue, state, retry count, and execution choice.
+The record—not the Python coroutine—is what a worker claims.
+
+Queue backend
+=============
+
+The **queue backend** stores task records and their states. Memory is the
+default and is process-local. SQLSpec, Advanced Alchemy, Redis, and Valkey can
+share records between web and worker processes. Persisted task state remains
+the source of truth.
+
+Execution backend
+=================
+
+The **execution backend** controls where claimed work runs. ``local`` runs it
+in the worker process, ``immediate`` runs it inline, and Cloud Run dispatches
+it to a Cloud Run Job. Execution placement does not replace queue persistence.
+
+Worker lifecycle
+================
+
+A worker finds due records, claims them, runs or dispatches them, records the
+outcome, and retries eligible failures. The plugin can start a worker in the
+web process; production deployments commonly run workers separately.
+
+Wakeups and reconciliation
+==========================
+
+A backend may notify workers when work arrives. A **worker wakeup is a hint**:
+notifications can be delayed or dropped, so workers also poll and reconcile
+against persisted state. A wakeup is never durable task storage.
+
+Task events
+===========
+
+Tasks can publish lifecycle, progress, log, and custom events for application
+or operator consumers. Live task event delivery uses event sinks and Litestar
+Channels. It is separate from queue-backend wakeups and is not worker discovery.
+Durable event history is another queue-backend capability and is also separate
+from live browser fan-out.
+
+Choose the next guide
+=====================
+
+* :doc:`tasks` defines and enqueues work.
+* :doc:`results` observes the persisted record.
+* :doc:`workers` chooses in-app or standalone worker placement.
+* :doc:`backends` chooses persistence and execution independently.
+* :doc:`events` publishes user-facing progress.

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -2,159 +2,65 @@
 Configuration
 =============
 
-``QueueConfig`` configures the queue backend, execution backend, Litestar plugin
-lifecycle, workers, scheduled tasks, and realtime event publishing.
-
-Litestar Plugin
-===============
-
-Use :class:`litestar_queues.QueuePlugin` when a Litestar app should own the
-queue service lifecycle:
+Pass one :class:`~litestar_queues.QueueConfig` to the plugin:
 
 .. code-block:: python
 
-   from litestar import Litestar
    from litestar_queues import QueueConfig, QueuePlugin
 
-
-   queue_config = QueueConfig(
-       queue_backend="memory",
-       execution_backend="local",
-       in_app_worker=True,
-       task_modules=("app.tasks",),
+   queue_plugin = QueuePlugin(
+       config=QueueConfig(
+           queue_backend="memory",
+           execution_backend="local",
+           in_app_worker=True,
+       )
    )
 
-   app = Litestar(plugins=[QueuePlugin(config=queue_config)])
-
-The plugin registers a ``QueueService`` dependency, stores the opened service on
-application state, loads configured task modules during startup, initializes
-registered schedules, and starts a local worker when ``in_app_worker=True``.
-The default in-app worker is a low-friction setup for tests, local development,
-and lightweight deployments; heavier production workloads can run standalone
-workers when web and background capacity should scale independently.
-Route handlers should request the dependency explicitly with
-``queue_service: NamedDependency[QueueService]``.
-
-Worker Placement
-================
-
-By default, ``QueuePlugin`` starts a worker inside the Litestar application
-process. To split web and background capacity, use a shared queue backend,
-disable the in-app worker in the web process, and run a separate worker process:
-
-.. code-block:: python
-
-   queue_config = QueueConfig(in_app_worker=False)
-
-.. code-block:: console
-
-   $ LITESTAR_APP=app.asgi:app litestar queues run --drain-timeout 30
-
-Core Settings
-=============
+Use this page as a map; each linked guide owns the detailed behavior.
 
 .. list-table::
    :header-rows: 1
 
-   * - Setting
-     - Default
-     - Purpose
-   * - ``queue_backend``
-     - ``"memory"``
-     - Queue persistence backend name or typed backend config object.
-   * - ``execution_backend``
-     - ``"local"``
-     - Default execution backend name or typed execution config object.
-   * - ``task_modules``
-     - ``()``
-     - Modules imported on startup so task decorators register tasks.
-   * - ``initialize_schedules``
-     - ``True``
-     - Create or refresh pending records for scheduled tasks on startup.
-   * - ``quiet_success``
-     - ``True``
-     - Suppress the operator log line for successful task completion by
-       default.
-   * - ``in_app_worker``
-     - ``True``
-     - Start an in-process worker with the Litestar app.
+   * - Concern
+     - Settings
+     - Guide
+   * - Persistence
+     - ``queue_backend``
+     - :doc:`backends`
+   * - Execution placement
+     - ``execution_backend``
+     - :doc:`backends`
+   * - Worker placement
+     - ``in_app_worker``
+     - :doc:`workers`
+   * - Claiming and concurrency
+     - ``worker_batch_size``, ``worker_max_concurrency``
+     - :doc:`workers`
+   * - Idle waiting
+     - ``worker_poll_interval``
+     - :doc:`worker-wakeups`
+   * - Heartbeats and recovery
+     - ``worker_heartbeat_interval``, ``worker_heartbeat_miss_threshold``,
+       ``worker_stale_after``, ``worker_stale_check_interval``
+     - :doc:`worker-recovery`
+   * - Shutdown
+     - ``worker_graceful_shutdown_timeout``, ``worker_final_cancel_timeout``
+     - :doc:`workers`
+   * - Task discovery
+     - ``task_modules``
+     - :doc:`tasks`
+   * - Schedules
+     - ``initialize_schedules``, ``scheduler_canary_task``
+     - :doc:`schedules`
+   * - Events
+     - ``event``, ``event_log``, ``event_stream``
+     - :doc:`events`, :doc:`event-history`, :doc:`event-streams`
+   * - Observability
+     - ``observability``
+     - :doc:`observability`
+   * - External dependencies
+     - ``task_dependency_resolver``
+     - :doc:`dependency-resolver`
 
-``quiet_success`` is a logging default only. It does not suppress
-``task.completed`` lifecycle events, task progress/log events, stream delivery,
-or backend-managed event history. Use ``QueueConfig(quiet_success=False)`` to
-emit successful completion logs by default, then override individual tasks or
-enqueue calls with ``quiet_success=True`` when they are too noisy. Queue-level
-quieting is not part of the public configuration.
-
-Dependency and State Keys
-=========================
-
-The default Litestar dependency key is ``queue_service``. The plugin also stores
-the service, worker, event publisher, and optional Channels backend on app
-state. Override these keys when an application needs multiple queue services or
-custom naming:
-
-.. code-block:: python
-
-   config = QueueConfig(
-       queue_service_dependency_key="jobs",
-       queue_service_state_key="jobs_service",
-       queue_worker_state_key="jobs_worker",
-   )
-
-Worker Settings
-===============
-
-Worker settings are used when ``in_app_worker=True`` or when constructing a
-``Worker`` manually:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Setting
-     - Default
-     - Purpose
-   * - ``worker_batch_size``
-     - ``10``
-     - Maximum due records fetched per worker iteration.
-   * - ``worker_poll_interval``
-     - ``0.1``
-     - Fallback sleep when no work is available.
-   * - ``worker_max_concurrency``
-     - ``1``
-     - Concurrent local task executions.
-   * - ``worker_heartbeat_interval``
-     - ``30``
-     - Seconds between heartbeat updates for running records.
-   * - ``worker_reconcile_interval``
-     - ``30``
-     - Seconds between external execution reconciliation passes.
-   * - ``worker_stale_after``
-     - ``None``
-     - Seconds after which stale running records can be requeued on startup.
-   * - ``worker_stale_check_interval``
-     - ``60``
-     - Seconds between stale-running recovery sweeps.
-   * - ``error_sanitizer``
-     - ``None``
-     - Optional callable that converts task exceptions into persisted error
-       messages and failed-event messages.
-
-Event Settings
-==============
-
-``event`` controls application-facing queue event delivery. Events are disabled
-when ``QueueConfig.event`` is ``None``. Providing ``EventConfig`` enables them
-by default unless ``enabled=False`` is explicit:
-
-.. code-block:: python
-
-   from litestar_queues.events import EventConfig
-
-
-   config = QueueConfig(
-       event=EventConfig(channels_backend=channels),
-   )
-
-See :doc:`events` for the event envelope, channels, helper APIs, and streaming
-patterns.
+Defaults favor a one-process development app: memory persistence, local
+execution, and an in-app worker. Make production choices explicit.

--- a/docs/usage/dependency-resolver.rst
+++ b/docs/usage/dependency-resolver.rst
@@ -11,7 +11,7 @@ until Litestar 3.0 beta DI becomes the standard integration.
 Litestar Queues awaits the resolver once for each task attempt. This happens
 after the ``task.started`` event and before the task function runs. It adds the
 returned mapping to the task's keyword arguments. The package-owned
-``_job_id`` and ``_task_context`` values always override resolver output.
+``_task_context`` value always overrides resolver output.
 
 Type Alias
 ==========
@@ -113,6 +113,5 @@ See Also
 ========
 
 * :doc:`configuration` for the rest of the ``QueueConfig`` surface
-* :doc:`tasks` for task registration and the ``_job_id`` / ``_task_context``
-  sentinels
+* :doc:`tasks` for task registration and the typed ``_task_context`` value
 * :doc:`events` for the lifecycle events that bracket resolver execution

--- a/docs/usage/dependency-resolver.rst
+++ b/docs/usage/dependency-resolver.rst
@@ -2,18 +2,16 @@
 Dependency Resolver
 ===================
 
-The ``QueueConfig.task_dependency_resolver`` hook lets callers wire an external
-dependency container into queued task callables. Until Litestar 3.0 beta DI
-becomes the canonical answer, this is the bridge that lets adopters with their
-own DI machinery (Dishka, an in-house container, or a hand-rolled provider)
-inject services such as database sessions, settings, or HTTP clients into task
-functions.
+``QueueConfig.task_dependency_resolver`` lets queued tasks receive services
+from an external dependency-injection (DI) container. A DI container creates
+and supplies objects such as database sessions, settings, and HTTP clients.
+Use this hook with Dishka, an in-house container, or a simple custom provider
+until Litestar 3.0 beta DI becomes the standard integration.
 
-When configured, the resolver is awaited exactly once per task execution
-attempt, after the ``task.started`` lifecycle event and before the registered
-task callable runs. The returned mapping is merged into the task's keyword
-arguments. The package-owned sentinels ``_job_id`` and ``_task_context`` always
-take precedence over resolver output.
+Litestar Queues awaits the resolver once for each task attempt. This happens
+after the ``task.started`` event and before the task function runs. It adds the
+returned mapping to the task's keyword arguments. The package-owned
+``_job_id`` and ``_task_context`` values always override resolver output.
 
 Type Alias
 ==========
@@ -23,25 +21,25 @@ Type Alias
    from litestar_queues import TaskDependencyResolver
 
 ``TaskDependencyResolver`` is exported from the package root and is also
-available through :attr:`litestar_queues.QueueConfig.signature_namespace`. It
-is an alias for an ``async`` callable with the signature::
+available through :attr:`litestar_queues.QueueConfig.signature_namespace`.
+It names an async function with this signature::
 
    async def resolver(task, record, task_context) -> dict[str, Any]: ...
 
-* ``task`` - the registered :class:`litestar_queues.Task` wrapper
+* ``task`` - the registered :class:`litestar_queues.Task` wrapper.
 * ``record`` - the :class:`litestar_queues.QueuedTaskRecord` that is about to
-  execute
+  run.
 * ``task_context`` - the active
   :class:`litestar_queues.TaskExecutionContext` (the same instance bound to the
-  contextvar for the duration of the attempt)
+  context variable for the duration of the attempt).
 
 Wiring an External Container
 ============================
 
-The example below uses a tiny home-grown container so the pattern is portable
-across DI frameworks. Replace ``Container.get(...)`` with whatever your
-container exposes - the resolver only has to return a mapping of kwargs that
-match parameters declared on the task callable.
+This example uses a small custom container so the pattern works with any DI
+framework. Replace ``Container.get(...)`` with the equivalent method from your
+container. The resolver only needs to return keyword arguments that match the
+task function's parameters.
 
 .. code-block:: python
 
@@ -97,23 +95,19 @@ match parameters declared on the task callable.
 Resolver Failures and Retries
 =============================
 
-The resolver participates in the standard task failure path. If it raises, the
-exception is recorded through ``fail_task``, counts toward
-``record.max_retries``, and emits a ``task.failed`` lifecycle event. There is
-no separate retry budget for resolver failures. A resolver that connects to an
-external system should treat connection errors the same way the task body
-does.
+Resolver errors follow the normal task failure path. Litestar Queues records
+the exception through ``fail_task``, counts it against ``record.max_retries``,
+and emits ``task.failed``. Resolver failures do not have a separate retry
+limit. Handle connection errors in the same way as errors from the task body.
 
 Per-Attempt Invocation
 ======================
 
-Resolvers are called once per attempt. They should treat each invocation as a
-fresh attempt and avoid memoizing per-record state across retries. Reusing a
-session, transaction, or cached object that survived a previous failed attempt
-is an easy way to leak corrupted state into a retry. If a resource is
-expensive to build, build it once at process scope (a module-level singleton or
-a shared connection pool) and let the resolver hand out fresh handles per
-attempt.
+The resolver runs once per attempt. Return fresh per-attempt resources. Do not
+reuse a session, transaction, or cached object from a failed attempt because it
+may contain invalid state. You may create an expensive shared resource, such as
+a connection pool, once per process. The resolver should still return a fresh
+handle from that resource for each attempt.
 
 See Also
 ========

--- a/docs/usage/deployment/cloud-run.rst
+++ b/docs/usage/deployment/cloud-run.rst
@@ -52,6 +52,28 @@ configuration. A 403 on an enqueue POST is an auth/CSRF problem, not a
 Channels delivery failure. A stream error after a successful enqueue is a
 Channels, origin, or proxy problem.
 
+Topology and security
+---------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Component
+     - Required shared state
+     - Security boundary
+   * - Web service
+     - Persistent queue backend
+     - Authenticate enqueue routes and protect queue credentials.
+   * - Dispatcher service
+     - Same queue backend and Cloud Run configuration
+     - Grant only ``run.jobs.runWithOverrides``-equivalent access.
+   * - Cloud Run Job
+     - Same queue backend and task modules
+     - Use a dedicated service account and least-privilege data access.
+   * - Browser event replicas
+     - Explicit shared Channels transport
+     - Authorize stream scopes; queue wakeups are not browser events.
+
 Recommended topology
 ====================
 

--- a/docs/usage/deployment/cloud-run.rst
+++ b/docs/usage/deployment/cloud-run.rst
@@ -2,14 +2,13 @@
 Cloud Run Deployment
 ====================
 
-This guide covers the generic Cloud Run pattern for ``litestar-queues``.
-Replace the project, region, service, job, and import-path placeholders with
-your own values.
+This guide shows a general Cloud Run setup for ``litestar-queues``. Replace the
+project, region, service, job, and import-path placeholders with your values.
 
 The core model
 ==============
 
-Cloud Run deployments work best when you keep three responsibilities separate:
+A Cloud Run deployment has three separate responsibilities:
 
 .. code-block:: text
 
@@ -25,32 +24,31 @@ Cloud Run deployments work best when you keep three responsibilities separate:
                                                                      │ executes task │
                                                                      └───────────────┘
 
-The important rule is simple:
+Each part has one job:
 
 * ``enqueue()`` writes a pending queue record.
-* ``dispatch()`` happens only inside a running worker loop.
-* ``execute`` happens inside the Cloud Run Job container.
+* A running worker loop calls ``dispatch()``.
+* The Cloud Run Job container executes the task.
 
-If no dispatcher process is running, records routed to ``cloudrun`` stay
-pending forever.
+The **dispatcher** is the worker loop that starts Cloud Run Jobs. Without a
+running dispatcher, records routed to ``cloudrun`` remain pending.
 
 Realtime fan-out is a separate concern
 --------------------------------------
 
-If the web service and dispatcher are separate Cloud Run processes, do not use
-``MemoryChannelsBackend`` for browser events. It is process-local even when the
-queue records are stored in a shared database. Configure a shared Redis
-Channels Streams backend (or a PostgreSQL Channels backend when that is the
-existing stack) in both processes, with the same channel key prefix and event
-contract. Redis/Valkey queue notifications only wake the dispatcher; they do
-not carry SSE or WebSocket event payloads.
+If the web service and dispatcher run in separate processes, do not use
+``MemoryChannelsBackend`` for browser events. It works in one process only,
+even when queue records use a shared database. Configure the same shared
+Channels backend in both processes. Use Redis Channels Streams, or PostgreSQL
+Channels when it matches the existing stack, with the same channel prefix and
+event contract. Redis/Valkey queue notifications only wake the dispatcher.
+They do not carry SSE or WebSocket events.
 
-Keep browser authentication and proxy behavior explicit: same-origin relative
-stream URLs are the simplest deployment, while a separate frontend origin
-needs the corresponding CORS, cookie, WebSocket upgrade, and proxy timeout
-configuration. A 403 on an enqueue POST is an auth/CSRF problem, not a
-Channels delivery failure. A stream error after a successful enqueue is a
-Channels, origin, or proxy problem.
+Configure browser authentication and proxies explicitly. Same-origin relative
+stream URLs are the simplest choice. A separate frontend origin also needs the
+right CORS, cookie, WebSocket upgrade, and proxy timeout settings. A ``403`` on
+an enqueue POST points to authentication or CSRF, not Channels. If enqueueing
+succeeds but the stream fails, check Channels, the origin, and the proxy.
 
 Topology and security
 ---------------------
@@ -78,7 +76,7 @@ Recommended topology
 ====================
 
 Use one web service, one always-on dispatcher service, and one Cloud Run Job
-that actually runs the queued task.
+that runs the queued task.
 
 The web service should keep ``in_app_worker=False`` so it only enqueues
 records. The dispatcher service owns the worker loop.
@@ -106,9 +104,9 @@ records. The dispatcher service owns the worker loop.
        task_modules=("myapp.tasks",),
    )
 
-The same queue backend must be reachable from the web service, the dispatcher,
-and the Cloud Run Job. The dispatcher needs the typed
-``CloudRunExecutionConfig`` so it can resolve the job name for each record.
+The web service, dispatcher, and Cloud Run Job must all reach the same queue
+backend. The dispatcher needs ``CloudRunExecutionConfig`` to choose the Cloud
+Run Job for each record.
 
 Example deployment commands:
 
@@ -130,16 +128,15 @@ Example deployment commands:
      --no-cpu-throttling \
      --add-cloudsql-instances my-project:my-region:my-db
 
-The dispatcher service should keep CPU available between requests. That is why
-the recommended pattern uses ``--min-instances 1`` together with
+The dispatcher must keep CPU available while it waits for tasks. Therefore,
+the recommended command uses both ``--min-instances 1`` and
 ``--no-cpu-throttling``.
 
 In-app worker alternative
 ==========================
 
-You can run the dispatcher inside the API process instead of splitting it out.
-This is simpler, but Cloud Run only keeps background polling healthy when the
-service stays warm and CPU is not throttled.
+You can run the dispatcher in the API process. This uses fewer services, but
+background polling works only while the service stays warm and has CPU.
 
 .. code-block:: python
 
@@ -167,20 +164,20 @@ service stays warm and CPU is not throttled.
      --no-cpu-throttling \
      --add-cloudsql-instances my-project:my-region:my-db
 
-Use this only for low-volume deployments. The dedicated dispatcher service is
-the safer default because web and background capacity can scale independently.
+Use this only for low-volume deployments. A dedicated dispatcher is the safer
+default because web and background capacity can scale separately.
 
 Cloud Run Job worker
 ====================
 
-The Cloud Run Job is the process that executes the queued task. The shipped
-console script is ``litestar-queues-cloudrun-worker``. The equivalent module
-invocation is ``python -m litestar_queues.execution.cloudrun.entrypoint``.
+The Cloud Run Job executes the queued task. Run it with the shipped
+``litestar-queues-cloudrun-worker`` command or the equivalent module command,
+``python -m litestar_queues.execution.cloudrun.entrypoint``.
 
-The worker loads the shared queue configuration, imports the configured task
-modules, claims the persisted record, executes the task, and exits with a
-deterministic code. The entry point resolves the config factory before it reads
-``TASK_ID``, so custom ``env_prefix`` values are honored end-to-end.
+The worker loads the shared queue config, imports task modules, claims the
+saved record, runs the task, and exits with a defined code. It resolves the
+config factory before reading ``TASK_ID``. This lets a custom ``env_prefix``
+work throughout the process.
 
 Environment contract
 --------------------
@@ -228,8 +225,8 @@ prefix changes everywhere.
 Profile-based job selection
 ---------------------------
 
-Use ``execution_profile`` when different task families should run in different
-Cloud Run Jobs. The dispatcher resolves the job name in this order:
+Use ``execution_profile`` to send different task families to different Cloud
+Run Jobs. The dispatcher chooses the job name in this order:
 
 1. ``profiles[record.execution_profile]``
 2. ``job_name``
@@ -251,9 +248,9 @@ Example job command:
      LITESTAR_QUEUES_TASK_MODULES=myapp.tasks \
      --task-timeout 3600s
 
-The task timeout should match the longest task you expect the Job to run.
-Set the queue timeout and the Cloud Run Job timeout to the same ceiling, or to
-values where the Job timeout is at least as long as the queue timeout.
+Set the timeout for the longest expected task. The Cloud Run Job timeout must
+be at least as long as the queue timeout. Using the same value for both is the
+simplest option.
 
 If you need a different prefix for the worker environment variables, set it on
 ``CloudRunExecutionConfig.env_prefix`` and use the matching prefix when you
@@ -262,9 +259,9 @@ deploy the Job.
 IAM
 ===
 
-The dispatcher or API service account needs permission to run the worker Job
-with container overrides. The simplest grant is ``roles/run.developer`` on the
-worker Job, because it includes ``run.jobs.runWithOverrides``.
+The dispatcher or API service account must be allowed to run the worker Job
+with container overrides. The simplest grant is ``roles/run.developer`` on
+that Job because it includes ``run.jobs.runWithOverrides``.
 
 .. code-block:: bash
 
@@ -280,7 +277,7 @@ Database connectivity
 =====================
 
 The web service, dispatcher, and Job must all reach the same queue database.
-That requirement is separate from the Cloud Run Job itself.
+Creating the Cloud Run Job does not provide that connection.
 
 If you use Cloud SQL:
 
@@ -309,28 +306,28 @@ Example:
      --region my-region \
      --set-cloudsql-instances my-project:my-region:my-db
 
-Use the connection form your driver expects. The important part is that all
-three processes point at the same durable queue store.
+Use the connection format required by your driver. All three processes must
+point to the same persistent queue store.
 
 Dispatch failure behavior
 ==========================
 
-By default, dispatch failures surface in logs and events and the record stays
-routed to ``cloudrun``. The default fallback backend is ``None``.
+By default, Litestar Queues reports dispatch failures in logs and events. The
+record remains routed to ``cloudrun``. The default fallback backend is
+``None``.
 
 If you want the older reroute behavior, set
 ``fallback_execution_backend="local"`` explicitly and run a local worker that
 can consume the fallback queue.
 
-Transient Cloud Run status probe failures are treated as still running so
-reconciliation does not create false terminal states. If the remote execution
-is missing, reconciliation marks the record failed so retryable work can run
-again.
+A temporary Cloud Run status-check failure is treated as still running. This
+prevents a false final state. If the remote execution is missing, the status
+check marks the record failed so retryable work can run again.
 
 Scheduling
 ==========
 
-Scheduled work still needs a dispatcher. You have two common options:
+Scheduled work still needs a dispatcher. Choose one of these options:
 
 * use ``@task(schedule=...)`` so the dispatcher creates the pending records on
   a schedule, or

--- a/docs/usage/event-history.rst
+++ b/docs/usage/event-history.rst
@@ -1,0 +1,61 @@
+=============
+Event history
+=============
+
+Event history records task events through the queue backend before live sink
+delivery. It supports later queries and stage summaries; it is not a live sink
+and does not fan events out to browsers.
+
+Enable history
+==============
+
+.. code-block:: python
+
+   from litestar_queues import QueueConfig
+   from litestar_queues.events import EventConfig, EventLogConfig
+
+   queue_config = QueueConfig(
+       event=EventConfig(channels_backend=channels_backend),
+       event_log=EventLogConfig(
+           buffer_size=20,
+           flush_interval=1.0,
+           max_records=1000,
+       ),
+   )
+
+``strict=False`` keeps history failures from turning successful task work into
+failure. Choose ``strict=True`` only when event retention is a business
+transaction requirement.
+
+Support matrix
+==============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Backend
+     - Support and persistence boundary
+   * - Memory
+     - Bounded ephemeral history. ``EventLogConfig.max_records`` caps retained records in the process.
+   * - SQLSpec
+     - Durable history in the SQLSpec queue schema and migration/session lifecycle.
+   * - Advanced Alchemy
+     - Durable history through an application-owned concrete event-log model and migrations.
+   * - Redis / Valkey
+     - Shared history whose durability and cleanup depend on operator persistence, retention, and backup policy.
+
+Query and cleanup
+=================
+
+The backend-owned ``QueueEventLog`` lists events by task ID or task name,
+summarizes stages, flushes buffered writes, and removes records older than a
+timestamp. Retention should match audit and privacy requirements. Terminal
+task-record cleanup and event-history cleanup are separate operations.
+
+History versus live delivery
+============================
+
+History answers “what happened?” after the fact. SSE/WebSocket Channels answer
+“what is happening now?” A deployment may use either or both. Replaying
+history into a newly connected client is an application policy; do not assume
+a live Channels backend reads the queue event log.

--- a/docs/usage/event-history.rst
+++ b/docs/usage/event-history.rst
@@ -2,9 +2,8 @@
 Event history
 =============
 
-Event history records task events through the queue backend before live sink
-delivery. It supports later queries and stage summaries; it is not a live sink
-and does not fan events out to browsers.
+Event history saves task events in the queue backend. You can query the records
+later and review their stages. It is separate from live SSE/WebSocket delivery.
 
 Enable history
 ==============
@@ -23,9 +22,8 @@ Enable history
        ),
    )
 
-``strict=False`` keeps history failures from turning successful task work into
-failure. Choose ``strict=True`` only when event retention is a business
-transaction requirement.
+With ``strict=False``, a history write failure does not fail the task. Use
+``strict=True`` only when saving every event is required.
 
 Support matrix
 ==============
@@ -36,21 +34,48 @@ Support matrix
    * - Backend
      - Support and persistence boundary
    * - Memory
-     - Bounded ephemeral history. ``EventLogConfig.max_records`` caps retained records in the process.
+     - Bounded, temporary history. ``EventLogConfig.max_records`` sets the limit in that process.
    * - SQLSpec
-     - Durable history in the SQLSpec queue schema and migration/session lifecycle.
+     - History stored in the SQLSpec queue schema.
    * - Advanced Alchemy
-     - Durable history through an application-owned concrete event-log model and migrations.
+     - History stored through an app-owned event-log model and migrations.
    * - Redis / Valkey
-     - Shared history whose durability and cleanup depend on operator persistence, retention, and backup policy.
+     - Shared history. You choose how long it stays and whether it is backed up.
 
 Query and cleanup
 =================
 
-The backend-owned ``QueueEventLog`` lists events by task ID or task name,
-summarizes stages, flushes buffered writes, and removes records older than a
-timestamp. Retention should match audit and privacy requirements. Terminal
-task-record cleanup and event-history cleanup are separate operations.
+Use ``QueueEventLog`` to find events by task ID or task name, review stages,
+flush pending writes, and delete old records. Choose retention rules that fit
+your audit and privacy needs. Deleting finished task records does not delete
+event history, and vice versa.
+
+Run cleanup from an application-owned scheduler, cron job, or maintenance
+worker. The library does not create a hidden cleanup task, because retention
+and the number of maintenance workers are deployment decisions:
+
+.. code-block:: python
+
+   from datetime import datetime, timedelta, timezone
+
+   from litestar_queues import QueueService
+   from litestar_queues.events import EventLogConfig
+
+   async def prune_queue_history(service: QueueService) -> None:
+       cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+       backend = service.get_queue_backend()
+
+       # These are separate policies. Use different cutoffs when needed.
+       await backend.cleanup_terminal(cutoff)
+       event_log = backend.get_event_log(EventLogConfig(enabled=True))
+       if event_log is not None:
+           await event_log.flush_events()
+           await event_log.cleanup_before(cutoff)
+
+Memory history is bounded by ``max_records`` and disappears with the process.
+SQLSpec, Advanced Alchemy, Redis, and Valkey history is durable or shared, so
+those deployments should schedule cleanup and include it in their backup and
+privacy policies.
 
 History versus live delivery
 ============================

--- a/docs/usage/event-streams.rst
+++ b/docs/usage/event-streams.rst
@@ -2,8 +2,8 @@
 SSE and WebSockets
 ===================
 
-The plugin can register task, queue, worker, global, and custom stream routes
-under ``/queues/events``:
+The plugin can add task, queue, worker, global, and custom stream routes under
+``/queues/events``:
 
 .. code-block:: python
 
@@ -27,30 +27,30 @@ Both deliver the same JSON ``QueueEvent`` envelope.
 Envelope and delivery semantics
 ===============================
 
-Top-level fields use camel case on the wire, including ``taskId``,
+Top-level JSON fields use camel case, including ``taskId``,
 ``workerId``, ``scopeKey``, ``progressCurrent``, ``occurredAt``, and
 ``eventKey``. Null-valued keys are preserved; user-owned ``payload`` keys are
 not renamed. Consumers should deduplicate by ``eventKey`` when present and by
 ``id`` otherwise.
 
-Live streams are delivery paths, not durable work queues. Keepalives preserve
-idle connections; they do not confirm task health. Slow clients can miss
-best-effort events depending on the Channels backend and backlog policy. Query
-:doc:`event-history` when replay is required.
+Live streams deliver events; they do not store tasks. Keepalives keep an idle
+connection open, but they do not prove that a task is healthy. A slow client
+may miss best-effort events, depending on the Channels backend and its backlog
+policy. Query :doc:`event-history` when a client must replay events.
 
 Authorization
 =============
 
-Use ``guards`` for route-wide access and ``channel_authorizer`` for each scope
-and key. Never accept an arbitrary task ID or queue name from a client without
-checking tenant and user ownership. Set ``include_in_schema=True`` only when
-the generated route surface is intended to be public.
+Use ``guards`` to protect an entire route. Use ``channel_authorizer`` to check
+each scope and key. Never accept a task ID or queue name from a client without
+checking that the tenant and user may access it. Set ``include_in_schema=True``
+only when these generated routes should be public.
 
 Canonical runnable sources
 ==========================
 
-The memory examples are the long-form authority. The backend copies change
-persistence wiring while preserving the same frontend contract.
+The memory examples are the complete examples. Each backend copy changes only
+the queue-storage setup and keeps the same frontend behavior.
 
 WebSocket application:
 
@@ -98,6 +98,6 @@ The gallery includes these runnable source families:
 * ``examples/htmx_realtime_websocket_valkey`` and
   ``examples/htmx_realtime_sse_valkey``
 
-Browser acceptance clicks the restart control, observes the enqueue request,
-watches DOM updates, and waits for the terminal event. A curl stream alone
-does not prove the HTMX extension or browser connection lifecycle.
+The browser test clicks Restart, observes the enqueue request and page updates,
+then waits for the final event. A curl stream cannot prove that the HTMX
+extension starts or that the browser opens and closes the connection correctly.

--- a/docs/usage/event-streams.rst
+++ b/docs/usage/event-streams.rst
@@ -1,0 +1,103 @@
+===================
+SSE and WebSockets
+===================
+
+The plugin can register task, queue, worker, global, and custom stream routes
+under ``/queues/events``:
+
+.. code-block:: python
+
+   from litestar_queues import QueueConfig
+   from litestar_queues.events import EventConfig, EventStreamConfig
+
+   queue_config = QueueConfig(
+       event=EventConfig(channels_backend=channels_backend),
+       event_stream=EventStreamConfig(
+           sse=True,
+           websocket=True,
+           scopes={"task", "queue"},
+           channel_authorizer=authorize_channel,
+       ),
+   )
+
+Use SSE for server-to-browser updates with automatic browser reconnection. Use
+WebSockets when the connection also needs bidirectional application messages.
+Both deliver the same JSON ``QueueEvent`` envelope.
+
+Envelope and delivery semantics
+===============================
+
+Top-level fields use camel case on the wire, including ``taskId``,
+``workerId``, ``scopeKey``, ``progressCurrent``, ``occurredAt``, and
+``eventKey``. Null-valued keys are preserved; user-owned ``payload`` keys are
+not renamed. Consumers should deduplicate by ``eventKey`` when present and by
+``id`` otherwise.
+
+Live streams are delivery paths, not durable work queues. Keepalives preserve
+idle connections; they do not confirm task health. Slow clients can miss
+best-effort events depending on the Channels backend and backlog policy. Query
+:doc:`event-history` when replay is required.
+
+Authorization
+=============
+
+Use ``guards`` for route-wide access and ``channel_authorizer`` for each scope
+and key. Never accept an arbitrary task ID or queue name from a client without
+checking tenant and user ownership. Set ``include_in_schema=True`` only when
+the generated route surface is intended to be public.
+
+Canonical runnable sources
+==========================
+
+The memory examples are the long-form authority. The backend copies change
+persistence wiring while preserving the same frontend contract.
+
+WebSocket application:
+
+.. literalinclude:: ../../examples/htmx_realtime_websocket/app.py
+   :language: python
+   :caption: examples/htmx_realtime_websocket/app.py
+
+WebSocket frontend:
+
+.. literalinclude:: ../../examples/htmx_realtime_websocket/resources/main.ts
+   :language: typescript
+   :caption: examples/htmx_realtime_websocket/resources/main.ts
+
+.. literalinclude:: ../../examples/htmx_realtime_websocket/templates/index.html
+   :language: html+jinja
+   :caption: examples/htmx_realtime_websocket/templates/index.html
+
+SSE application:
+
+.. literalinclude:: ../../examples/htmx_realtime_sse/app.py
+   :language: python
+   :caption: examples/htmx_realtime_sse/app.py
+
+SSE frontend:
+
+.. literalinclude:: ../../examples/htmx_realtime_sse/resources/main.ts
+   :language: typescript
+   :caption: examples/htmx_realtime_sse/resources/main.ts
+
+.. literalinclude:: ../../examples/htmx_realtime_sse/templates/index.html
+   :language: html+jinja
+   :caption: examples/htmx_realtime_sse/templates/index.html
+
+Backend variants
+================
+
+The gallery includes these runnable source families:
+
+* ``examples/htmx_realtime_websocket_sqlspec`` and
+  ``examples/htmx_realtime_sse_sqlspec``
+* ``examples/htmx_realtime_websocket_advanced_alchemy`` and
+  ``examples/htmx_realtime_sse_advanced_alchemy``
+* ``examples/htmx_realtime_websocket_redis`` and
+  ``examples/htmx_realtime_sse_redis``
+* ``examples/htmx_realtime_websocket_valkey`` and
+  ``examples/htmx_realtime_sse_valkey``
+
+Browser acceptance clicks the restart control, observes the enqueue request,
+watches DOM updates, and waits for the terminal event. A curl stream alone
+does not prove the HTMX extension or browser connection lifecycle.

--- a/docs/usage/event-testing.rst
+++ b/docs/usage/event-testing.rst
@@ -23,14 +23,14 @@ publisher and task tests:
 
        assert any(event.type == "task.progress" for event in sink.events)
 
-Inspect ``sink.published`` when the channel names matter, or
-``events_for(channel)`` for one canonical task/queue channel. Disable buffering
-or flush it before assertions that require intermediate non-terminal events.
+Inspect ``sink.published`` when channel names matter. Use
+``events_for(channel)`` for one task or queue channel. Turn off buffering, or
+flush it, before checking events that occur before the task's final state.
 
-Stream tests should focus on package-owned SSE/WebSocket route behavior,
-authorization, content type, keepalives, and envelope delivery. Browser-facing
-claims belong to the Playwright suite in ``src/tests/e2e`` because curl cannot
-prove HTMX boot, DOM updates, reconnection, or socket cleanup.
+Stream tests should cover the package's SSE/WebSocket routes, authorization,
+content type, keepalives, and event envelopes. Use the Playwright suite in
+``src/tests/e2e`` for browser behavior. Curl cannot prove that HTMX starts,
+updates the page, reconnects, or closes sockets.
 
 Use unique Redis/Valkey queue and Channels prefixes in topology tests. Never
 flush a shared service globally.

--- a/docs/usage/event-testing.rst
+++ b/docs/usage/event-testing.rst
@@ -1,0 +1,36 @@
+===================
+Test task events
+===================
+
+Use :class:`~litestar_queues.events.InMemoryQueueEventSink` for focused
+publisher and task tests:
+
+.. code-block:: python
+
+   from litestar_queues import QueueConfig, QueueService
+   from litestar_queues.events import EventConfig, InMemoryQueueEventSink
+
+
+   async def test_import_publishes_progress() -> None:
+       sink = InMemoryQueueEventSink()
+       config = QueueConfig(
+           execution_backend="immediate",
+           event=EventConfig(sink=sink),
+       )
+
+       async with QueueService(config) as service:
+           await service.enqueue(process_import, "/tmp/data.csv")
+
+       assert any(event.type == "task.progress" for event in sink.events)
+
+Inspect ``sink.published`` when the channel names matter, or
+``events_for(channel)`` for one canonical task/queue channel. Disable buffering
+or flush it before assertions that require intermediate non-terminal events.
+
+Stream tests should focus on package-owned SSE/WebSocket route behavior,
+authorization, content type, keepalives, and envelope delivery. Browser-facing
+claims belong to the Playwright suite in ``src/tests/e2e`` because curl cannot
+prove HTMX boot, DOM updates, reconnection, or socket cleanup.
+
+Use unique Redis/Valkey queue and Channels prefixes in topology tests. Never
+flush a shared service globally.

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -1,571 +1,99 @@
-======
-Events
-======
+===========
+Task events
+===========
 
-Queue events deliver task lifecycle, progress, log, and custom updates to
-application-owned realtime infrastructure. They are distinct from queue backend
-wakeup notifications.
+Task events are application-facing lifecycle, progress, log, and custom
+messages. They are distinct from queue-backend notifications that wake
+workers. Event delivery does not discover work, claim records, or replace
+queue persistence.
 
-Enable Events
-=============
+Enable publishing
+=================
 
-Events are disabled when ``QueueConfig.event`` is ``None``. Providing
-``EventConfig`` enables them by default unless ``enabled=False`` is explicit:
+Provide a sink or Channels backend:
 
 .. code-block:: python
 
    from litestar_queues import QueueConfig
    from litestar_queues.events import EventConfig
 
-
-   config = QueueConfig(
+   queue_config = QueueConfig(
        event=EventConfig(
-           channels_backend=channels,
+           channels_backend=channels_backend,
            publish_global_lifecycle=True,
-       ),
+       )
    )
 
-Use ``strict=True`` when publish failures should fail the task execution path.
-The default is best-effort publishing with warnings on sink failures.
+Without a configured sink or Channels backend, event publishing is a no-op.
+Live delivery is best effort by default; set ``strict=True`` only when a sink
+failure should fail the publishing path.
 
-Event Envelope
-==============
-
-``QueueEvent`` is a stable JSON-compatible envelope with a camelCase wire
-format. Field names on the wire are the camelCase aliases produced by
-``msgspec.Struct(rename="camel")``; the Python attribute names stay
-snake_case. Null-valued top-level fields are preserved so clients can rely on
-a consistent shape for lifecycle, progress, log, and custom events.
-
-Core fields (Python name → wire name):
-
-* ``id`` → ``id``, ``schema_version`` → ``schemaVersion``
-* ``type`` → ``type``, ``scope`` → ``scope``, ``scope_key`` → ``scopeKey``
-* ``task_id`` → ``taskId``, ``task_name`` → ``taskName``
-* ``queue`` → ``queue``, ``worker_id`` → ``workerId``
-  (``workerId`` is populated for events emitted from worker-driven
-  executions; the default identity is ``worker-{pid}``. Service-driven
-  executions without an attached :class:`~litestar_queues.Worker` leave
-  it ``null``.)
-* ``execution_backend`` → ``executionBackend``,
-  ``execution_profile`` → ``executionProfile``
-* ``attempt``, ``sequence``, ``level``, ``message``
-* ``progress_current`` → ``progressCurrent``,
-  ``progress_total`` → ``progressTotal``,
-  ``progress_percent`` → ``progressPercent``
-* ``actor``, ``entity``, ``payload`` (payload contents are passed through
-  verbatim and are NOT renamed)
-* ``occurred_at`` → ``occurredAt`` (RFC 3339 UTC with a trailing ``Z``)
-* ``event_key`` → ``eventKey``: optional dedup key for
-  subscribers; plugin-owned streams deduplicate on this when set and fall back
-  to ``id`` otherwise.
-
-Publishing From Tasks
-=====================
-
-Tasks can accept ``_task_context`` or use the helper functions that publish
-through the current task context:
+Publish from a task
+===================
 
 .. code-block:: python
 
    from litestar_queues import task
-   from litestar_queues.events import publish_task_event, publish_task_log, publish_task_progress
+   from litestar_queues.events import publish_task_log, publish_task_progress
 
 
-   @task("videos.transcode")
-   async def transcode_video(video_id: str) -> None:
-       await publish_task_log("Transcode started", payload={"video_id": video_id})
-       await publish_task_progress(current=1, total=4, message="Fetched source")
-       await publish_task_event("task.event", message="Preview ready", payload={"video_id": video_id})
+   @task("imports.process", timeout=300)
+   async def process_import(path: str) -> None:
+       await publish_task_log("Import started", payload={"path": path})
+       await publish_task_progress(current=50, total=100, message="Halfway")
 
-Producer Facade
-===============
+The active task context fills in task ID, task name, queue, worker identity,
+attempt, execution backend, and sequence. Use ``publish_task_event()`` for a
+custom type, or accept ``_task_context`` when direct context methods are more
+convenient.
 
-Use ``queue_events`` when application handlers or services need to publish queue
-events outside a running task context. The dependency injects a
-``QueueEventProducer`` backed by the app-scoped publisher:
-
-.. code-block:: python
-
-   from litestar import post
-   from litestar.di import NamedDependency
-   from litestar_queues.events import QueueEventProducer
-
-
-   @post("/imports/{import_id:str}/status")
-   async def update_import_status(
-       import_id: str,
-       queue_events: NamedDependency[QueueEventProducer],
-   ) -> dict[str, str]:
-       await queue_events.channel(f"imports:{import_id}").publish(
-           "import.status",
-           message="Import queued",
-           payload={"import_id": import_id},
-       )
-       return {"status": "accepted"}
-
-``QueueEventProducer`` exposes scoped handles:
-
-* ``task(task_id)`` for task logs, progress, and custom task events;
-* ``queue(name)`` for queue-scoped events;
-* ``worker(worker_id)`` for worker-scoped events; and
-* ``channel(scope_key)`` for application-defined custom channels.
-
-``QueueService.get_event_producer()`` returns the same facade when code already
-has a service instance:
-
-.. code-block:: python
-
-   queue_events = queue_service.get_event_producer()
-   await queue_events.task(task_id).progress(current=2, total=5)
-
-External processes can publish without opening a queue backend or worker by
-using ``create_event_producer(config)``. Prefer the async context manager so the
-configured sink or Channels backend is opened and closed around the publish
-window:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.events import EventConfig, create_event_producer
-
-
-   config = QueueConfig(event=EventConfig(channels_backend=channels))
-
-   async with create_event_producer(config) as queue_events:
-       await queue_events.channel("imports:batch-42").publish(
-           "import.note",
-           payload={"batch_id": "batch-42"},
-       )
-
-Buffered Live Delivery
-======================
-
-Live delivery is buffered by default for publishers owned by ``QueueService`` or
-``QueuePlugin`` when ``EventConfig`` is enabled. A publish call means "accepted
-into the queue event publisher"; it does not always mean the live sink has sent
-bytes to subscribers yet. Durable event history, when configured, is recorded
-before the live event is accepted into the buffer.
-
-The buffer flushes when one of these happens:
-
-* ``EventBufferConfig.buffer_size`` pending live events is reached;
-* ``EventBufferConfig.flush_interval`` elapses while the service is open;
-* ``QueueEventPublisher.flush_buffer()`` or service shutdown drains the buffer;
-* a task helper, task context, or producer handle publishes with
-  ``immediate=True``; or
-* a terminal task event is published.
-
-Terminal events are always immediate. ``task.completed``, ``task.failed``,
-``task.cancelled``, ``task.claim_lost``, and ``task.stale_failed`` flush the
-current task's buffered live events first, then publish the terminal event.
-This preserves task-scoped ordering without requiring every call site to pass
-``immediate=True``.
-
-Configure buffering on ``EventConfig``:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.events import EventBufferConfig, EventConfig
-
-
-   config = QueueConfig(
-       event=EventConfig(
-           channels_backend=channels,
-           buffer=EventBufferConfig(
-               buffer_size=50,
-               flush_interval=0.25,
-               max_pending=5000,
-           ),
-       ),
-   )
-
-Set ``EventBufferConfig(enabled=False)`` to restore immediate live publishing:
-
-.. code-block:: python
-
-   config = QueueConfig(
-       event=EventConfig(
-           channels_backend=channels,
-           buffer=EventBufferConfig(enabled=False),
-       ),
-   )
-
-Overflow behavior is controlled by ``overflow``:
-
-* ``"drop_oldest"`` drops the oldest pending event and accepts the new event;
-* ``"drop_newest"`` drops the incoming event;
-* ``"block"`` waits for a flush before accepting more events; and
-* ``"error"`` raises ``QueueEventBufferFull``.
-
-The default live publish path remains best effort. Set ``strict=True`` when
-buffer add, buffer flush, or live sink failures should raise into the caller.
-
-Channels
-========
-
-``QueueEventPublisher`` resolves canonical channels from the event scope:
-
-* task channels: ``litestar_queues:task:<task-id>:events``,
-* queue channels: ``litestar_queues:queue:<queue>:events``,
-* worker channels: ``litestar_queues:worker:<worker-id>:events``,
-* global channel: ``litestar_queues:global:events``,
-* custom channels: ``litestar_queues:custom:<scope-key>:events``.
-
-Explicit channels passed by task helpers are appended and duplicates are
-removed.
-
-Streaming With Litestar Channels
+Buffering and external producers
 ================================
 
-``ChannelsQueueEventSink`` publishes event JSON to an app-owned Channels backend
-or plugin. Configure ``EventStreamConfig`` on ``QueueConfig`` when clients need
-live updates. The plugin registers WebSocket and SSE endpoints for the configured
-scopes and applies the same guards and ``channel_authorizer`` to both transports:
+The publisher records configured history before live delivery. It micro-batches
+non-terminal live events and flushes a task's buffered events before its
+terminal event. Sinks with ``publish_many`` receive a batch; other sinks fall
+back to ordered single-event ``publish`` calls.
+
+Code outside a worker uses the lifecycle-owning context manager:
 
 .. code-block:: python
 
-   from litestar_queues import QueueConfig, QueuePlugin
-   from litestar_queues.events import EventConfig, EventStreamConfig
+   from litestar_queues.events import create_event_producer
 
+   async with create_event_producer(queue_config) as events:
+       await events.task(task_id).progress(current=1, total=2, message="Started")
 
-   config = QueueConfig(
-       event=EventConfig(channels_backend=channels),
-       event_stream=EventStreamConfig(
-           path="/queues/events",
-           scopes={"task", "queue", "worker", "global", "custom"},
-           guards=[...],
-           channel_authorizer=authorize_channel,
-       ),
-   )
+The context manager opens the configured resource, starts and flushes the
+buffer, then closes the resource. ``QueueEventProducer`` itself is a thin,
+lifecycle-free facade.
 
-   plugin = QueuePlugin(config)
-
-The default path is ``/queues/events``. Task-scoped streams are available at
-``/queues/events/tasks/{task_id}`` for WebSocket clients and
-``/queues/events/sse/tasks/{task_id}`` for SSE clients. Queue, worker, global,
-and custom scopes follow the same path pattern. Both transports are served by
-default; set ``EventStreamConfig(websocket=False)`` or ``sse=False`` to serve a
-single transport (disabling both while ``enabled=True`` raises
-``QueueConfigurationError``).
-
-Subscribers receive at-most-once delivery per ``eventKey`` (or per ``id`` when
-no key is set) within a single connection. Set ``QueueEvent(..., event_key=...)``
-at publish time when worker-level retries should not double-emit downstream.
-
-Queue Storage, Worker Wakeups, and Browser Fan-Out
-==================================================
-
-These are three separate decisions. Queue storage holds task records. A queue
-backend's notification mechanism is a worker wakeup hint. The Channels backend
-is the live event fan-out path consumed by SSE or WebSocket clients. Choosing a
-Redis or Valkey queue backend does not configure shared browser Channels.
-
-.. list-table::
-   :header-rows: 1
-
-   * - Topology
-     - Queue storage
-     - Worker wakeup
-     - Browser event fan-out
-   * - Local example
-     - Memory
-     - In-process
-     - ``MemoryChannelsBackend``
-   * - Shared Redis
-     - ``RedisBackendConfig``
-     - Redis queue pub/sub (hint)
-     - ``RedisChannelsStreamBackend``
-   * - Shared Valkey
-     - ``ValkeyBackendConfig``
-     - Valkey queue pub/sub (hint)
-     - Redis Channels Streams with the Valkey client
-   * - SQLSpec / Advanced Alchemy SQLite
-     - SQLite database
-     - Polling or in-process
-     - ``MemoryChannelsBackend`` unless a separate Channels backend is configured
-   * - Oracle AQ / TxEventQ
-     - Oracle queue backend
-     - AQ or TxEventQ worker wakeup
-     - Not a browser Channels transport
-
-The shipped Redis and Valkey realtime copies keep ``MemoryChannelsBackend`` by
-default. Set their shared-Channels environment switch and run a separate
-``litestar queues run --queue demo --drain-timeout 30`` process when the web
-service and worker are split. Because the examples request event history, the
-shared branch uses Redis Streams rather than Redis Pub/Sub; Pub/Sub has no
-history for a subscriber that connects later.
-
-The queue record remains the source of truth if a wakeup is dropped or
-coalesced. Conversely, a successful worker wakeup does not prove that a
-browser subscriber received an event. Test these planes independently.
-
-Consuming Stream Events
-=======================
-
-Queue event streams expose the same event envelope through WebSocket and SSE.
-WebSocket streams send one JSON object per message. Heartbeats are JSON frames
-with ``{"type": "ping"}``; clients should ignore those frames or use them only
-to update a connection liveness timestamp.
-
-The task stream is available to WebSocket clients at
-``/queues/events/tasks/{task_id}``. Custom WebSocket clients subscribe at
-``/queues/events/custom/{scope_key}``.
-
-The standalone WebSocket example in ``examples/htmx_realtime_websocket`` is a
-runnable server-rendered app: a full-screen animated crawl fed by task events,
-with a single planet-styled restart button. It registers only the task event
-stream:
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/app.py
-   :language: python
-   :start-after: # -- docs-app-config-start --
-   :end-before: # -- docs-app-config-end --
-
-Its restart endpoint returns a small partial whose element the htmx WebSocket
-extension turns into a live socket; replacing that element on the next restart
-closes the old socket, so the connection lifecycle equals the swap lifecycle:
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/app.py
-   :language: python
-   :start-after: # -- docs-routes-start --
-   :end-before: # -- docs-routes-end --
-
-A small adapter parses each JSON frame, ignores ping frames, and appends a
-crawl line, cancelling the extension's default HTML swap:
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/resources/main.ts
-   :language: typescript
-   :start-after: // docs: websocket-client-start
-   :end-before: // docs: websocket-client-end
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/resources/main.ts
-   :language: typescript
-   :start-after: // docs: stream-adapter-start
-   :end-before: // docs: stream-adapter-end
-
-SSE streams emit named frames whose event name is the queue event type and whose
-data is the JSON form of ``QueueEvent.to_dict()``:
-
-.. code-block:: text
-
-   event: task.progress
-   data: {"id":"...","type":"task.progress","scope":"task",...}
-
-SSE streams send keepalive comments instead of JSON ping frames. The task stream
-is available to SSE clients at ``/queues/events/sse/tasks/{task_id}``. Custom
-SSE clients subscribe at ``/queues/events/sse/custom/{scope_key}``.
-
-The standalone SSE example in ``examples/htmx_realtime_sse`` uses the same queue
-event configuration, but returns only SSE stream URLs to the browser:
-
-.. literalinclude:: ../../examples/htmx_realtime_sse/app.py
-   :language: python
-   :start-after: # -- docs-app-config-start --
-   :end-before: # -- docs-app-config-end --
-
-.. literalinclude:: ../../examples/htmx_realtime_sse/app.py
-   :language: python
-   :start-after: # -- docs-routes-start --
-   :end-before: # -- docs-routes-end --
-
-A small adapter parses each named SSE frame and appends a crawl line,
-cancelling the extension's default HTML swap:
-
-.. literalinclude:: ../../examples/htmx_realtime_sse/resources/main.ts
-   :language: typescript
-   :start-after: // docs: sse-client-start
-   :end-before: // docs: sse-client-end
-
-.. literalinclude:: ../../examples/htmx_realtime_sse/resources/main.ts
-   :language: typescript
-   :start-after: // docs: stream-adapter-start
-   :end-before: // docs: stream-adapter-end
-
-Both examples use the same task body, which publishes heartbeat details,
-progress, logs, and a terminal completion event:
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/app.py
-   :language: python
-   :start-after: # -- docs-task-start --
-   :end-before: # -- docs-task-end --
-
-The page shell publishes htmx on ``window``, registers the Litestar Vite HTMX
-helper, and dynamically imports the stream extension after the global exists. A
-single restart button carries the ``hx-post`` directly, and a muted corner
-caption uses ``hx-ext="litestar"`` for ``ls-*`` JSON templates:
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/resources/main.ts
-   :language: typescript
-   :start-after: // docs: htmx-extension-start
-   :end-before: // docs: htmx-extension-end
-
-.. literalinclude:: ../../examples/htmx_realtime_websocket/templates/index.html
-   :language: html
-   :start-after: <!-- docs: template-start -->
-   :end-before: <!-- docs: template-end -->
-
-.. literalinclude:: ../../examples/htmx_realtime_sse/templates/index.html
-   :language: html
-   :start-after: <!-- docs: template-start -->
-   :end-before: <!-- docs: template-end -->
-
-Backend-specific WebSocket copies are available under
-``examples/htmx_realtime_websocket_sqlspec``,
-``examples/htmx_realtime_websocket_advanced_alchemy``,
-``examples/htmx_realtime_websocket_redis``, and
-``examples/htmx_realtime_websocket_valkey``.
-
-Backend-specific SSE copies are available under
-``examples/htmx_realtime_sse_sqlspec``,
-``examples/htmx_realtime_sse_advanced_alchemy``,
-``examples/htmx_realtime_sse_redis``, and
-``examples/htmx_realtime_sse_valkey``. The SQLSpec and Advanced Alchemy copies
-use local ``aiosqlite`` files; Redis and Valkey read their connection URL from
-environment variables.
-
-Subscriber backpressure is owned by the configured Litestar Channels plugin or
-backend. The default Channels subscriber backlog is unbounded. For browser
-streams, configure a bounded backlog and drop older messages in favor of newer
-state updates:
-
-.. code-block:: python
-
-   from litestar.channels import ChannelsPlugin
-
-
-   channels = ChannelsPlugin(
-       backend=channels_backend,
-       arbitrary_channels_allowed=True,
-       subscriber_max_backlog=1000,
-       subscriber_backlog_strategy="dropleft",
-   )
-
-.. important::
-
-   Register ``ChannelsPlugin`` **before** ``QueuePlugin`` in the application
-   ``plugins`` list::
-
-       app = Litestar(plugins=[channels, QueuePlugin(config)])
-
-   Litestar exits lifespan managers in reverse (LIFO) order, so channels-first
-   registration drains the queue worker on shutdown before the Channels backend
-   closes. ``QueuePlugin`` validates this at startup and raises
-   ``QueueConfigurationError`` with the corrected registration when the order is
-   reversed, so a misordered app fails fast instead of flushing in-flight task
-   events into a closed sink.
-
-   When ``EventConfig()`` is configured without an explicit
-   ``channels_backend`` (and no custom ``sink``), ``QueuePlugin`` auto-resolves
-   the app's registered ``ChannelsPlugin`` as the live sink, so no manual
-   wiring is needed.
-
-Transport Recommendations
-=========================
-
-Choose the Channels backend based on whether browser clients need broadcast
-fan-out, replay, or durable claim semantics:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Transport
-     - Semantics
-     - Recommended Use
-   * - Redis Channels pub/sub backend
-     - Broadcast fan-out across processes, ephemeral delivery, no history.
-     - Live-only browser fan-out across multiple web processes.
-   * - Redis Streams Channels backend
-     - Broadcast fan-out with stream history through ``XADD``/``XRANGE`` and
-       ``MAXLEN``.
-     - Browser fan-out when replay or subscriber backlog is required.
-   * - ``SQLSpecChannelsBackend`` over sqlspec events ``listen_notify``
-       (``AsyncpgEventsBackend``, ``backend_name="listen_notify"``)
-     - Broadcast fan-out across processes through ``pg_notify``. Delivery is
-       ephemeral: ``ack``/``nack`` are no-ops and no history is stored. The
-       payload is sent inline through PostgreSQL notify, so it is subject to the
-       roughly 8 KB ``pg_notify`` cap.
-     - SQLSpec applications that need live multi-replica browser fan-out and can
-       keep payloads small. Use ``EventConfig.max_payload_bytes`` to chunk larger
-       events.
-   * - ``SQLSpecChannelsBackend`` over sqlspec events
-       ``listen_notify_durable`` (``AsyncpgHybridEventsBackend``) or
-       ``table_queue`` (``AsyncTableEventQueue``)
-     - Durable table-backed events with claim, lease, and ack. Rows move from
-       ``pending`` to ``leased`` to ``acked`` under ``FOR UPDATE SKIP LOCKED``.
-       This is competing-consumer delivery: each event is claimed and acked by
-       exactly one consumer.
-     - Durable worker-style consumers. A single web process can still fan out to
-       its local browser subscribers through ``ChannelsPlugin``, but multiple
-       web processes subscribed to the same channel will compete and split
-       events. Use a distinct consumer/channel per process, or use
-       ``listen_notify`` or Redis for multi-replica browser fan-out. The hybrid
-       stores payloads in the table and notifies only ``event_id``, avoiding the
-       PostgreSQL notify payload cap.
-
-Litestar's own asyncpg and psycopg Channels backends are useful for simple
-deployments, but they open a fresh connection per publish, loop
-``SELECT pg_notify`` once per channel, and raise ``NotImplementedError`` for
-history reads. Buffering amortizes the connect storm, but it does not add
-history. For production fan-out, prefer Redis Channels or
-``SQLSpecChannelsBackend`` with the semantics above.
-
-Durable Event History
+Topology and security
 =====================
 
-Live event sinks are delivery transports. They publish events to memory,
-Channels, or a custom realtime system and should not be used as durable storage.
-Queryable event history belongs to the configured queue backend so task state
-and task event history share the same database, schema lifecycle, and deployment
-boundary.
+.. list-table::
+   :header-rows: 1
 
-Backend-managed event history is configured separately from
-``EventConfig.sink``. When durable history is enabled, events can be
-recorded even if live delivery is disabled.
+   * - Example topology
+     - Live delivery
+     - Boundary
+   * - Memory WebSocket/SSE
+     - Same-process ``MemoryChannelsBackend``
+     - Local demo; web and worker stay together.
+   * - Separate Redis/Valkey worker
+     - Explicit shared Channels backend
+     - Use separate queue/Channels prefixes and authenticated services.
+   * - Multiple web replicas
+     - Broadcast-capable shared Channels transport
+     - Authorize task/queue/worker/custom scope subscriptions.
 
-SQLSpec provides backend-managed history through the same database lifecycle as
-the queue table:
+SQLSpec durable table queues use competing-consumer semantics. They are not
+broadcast fan-out for multiple browser-serving processes.
 
-.. code-block:: python
+Next steps
+==========
 
-   from litestar_queues import QueueConfig
-   from litestar_queues.events import EventLogConfig
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
-
-
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(config=sqlspec_config),
-       event_log=EventLogConfig(),
-   )
-
-By default SQLSpec stores history in ``<queue_table>_event_log``. For example,
-``litestar_queue_task`` uses ``litestar_queue_task_event_log``. Override the
-table with ``SQLSpecBackendConfig.event_log_table_name`` when an adopter needs a
-specific table name or compatibility view.
-
-Testing Events
-==============
-
-Use ``InMemoryQueueEventSink`` for tests:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.events import (
-       EventBufferConfig,
-       EventConfig,
-       InMemoryQueueEventSink,
-   )
-
-
-   sink = InMemoryQueueEventSink()
-   config = QueueConfig(
-       event=EventConfig(
-           sink=sink,
-           buffer=EventBufferConfig(enabled=False),
-       ),
-   )
-
-   # After task execution:
-   assert [event.type for event in sink.events] == ["task.started", "task.completed"]
+* :doc:`event-streams` exposes SSE and WebSocket endpoints.
+* :doc:`event-history` retains backend-managed history.
+* :doc:`event-testing` tests delivery without external infrastructure.
+* :doc:`../examples/index` runs the canonical visual examples.

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -2,10 +2,10 @@
 Task events
 ===========
 
-Task events are application-facing lifecycle, progress, log, and custom
-messages. They are distinct from queue-backend notifications that wake
-workers. Event delivery does not discover work, claim records, or replace
-queue persistence.
+Task events tell applications and operators about a task's lifecycle, progress,
+logs, or custom state. They are not the queue-backend notifications that wake
+workers. Delivering an event does not help a worker find or claim a task, and
+it does not store the queue record.
 
 Enable publishing
 =================
@@ -24,9 +24,9 @@ Provide a sink or Channels backend:
        )
    )
 
-Without a configured sink or Channels backend, event publishing is a no-op.
-Live delivery is best effort by default; set ``strict=True`` only when a sink
-failure should fail the publishing path.
+Without a configured sink or Channels backend, publishing does nothing. By
+default, a live-delivery failure does not fail the task. Set ``strict=True``
+only when the caller must receive a sink error.
 
 Publish from a task
 ===================
@@ -42,20 +42,20 @@ Publish from a task
        await publish_task_log("Import started", payload={"path": path})
        await publish_task_progress(current=50, total=100, message="Halfway")
 
-The active task context fills in task ID, task name, queue, worker identity,
-attempt, execution backend, and sequence. Use ``publish_task_event()`` for a
-custom type, or accept ``_task_context`` when direct context methods are more
-convenient.
+The active task context adds the task ID, task name, queue, worker ID, attempt,
+execution backend, and sequence. Use ``publish_task_event()`` for a custom
+event type. Accept ``_task_context`` when you prefer to call the context
+methods directly.
 
 Buffering and external producers
 ================================
 
-The publisher records configured history before live delivery. It micro-batches
-non-terminal live events and flushes a task's buffered events before its
-terminal event. Sinks with ``publish_many`` receive a batch; other sinks fall
-back to ordered single-event ``publish`` calls.
+When enabled, history is written before live delivery. Non-terminal live events
+are sent in small batches, and the buffer is flushed before the final event.
+Sinks with ``publish_many`` receive a batch; other sinks receive the events one
+at a time in order.
 
-Code outside a worker uses the lifecycle-owning context manager:
+Code outside a worker should use this context manager:
 
 .. code-block:: python
 
@@ -64,9 +64,8 @@ Code outside a worker uses the lifecycle-owning context manager:
    async with create_event_producer(queue_config) as events:
        await events.task(task_id).progress(current=1, total=2, message="Started")
 
-The context manager opens the configured resource, starts and flushes the
-buffer, then closes the resource. ``QueueEventProducer`` itself is a thin,
-lifecycle-free facade.
+The context manager opens the resource, starts it, flushes pending events, and
+closes it. ``QueueEventProducer`` does not manage resources by itself.
 
 Topology and security
 =====================
@@ -87,8 +86,8 @@ Topology and security
      - Broadcast-capable shared Channels transport
      - Authorize task/queue/worker/custom scope subscriptions.
 
-SQLSpec durable table queues use competing-consumer semantics. They are not
-broadcast fan-out for multiple browser-serving processes.
+SQLSpec durable table queues are shared work queues: one consumer claims each
+record. They are not broadcast delivery for multiple browser-serving processes.
 
 Next steps
 ==========

--- a/docs/usage/failures-and-cancellation.rst
+++ b/docs/usage/failures-and-cancellation.rst
@@ -25,17 +25,17 @@ Cancel pending work
 
    cancelled = await queue_service.cancel_task(result.id)
 
-Pending and scheduled records can be cancelled before claim. Bulk cancellation
-can filter by task name, queue, keyword arguments, or metadata.
+You can cancel pending and scheduled records before a worker claims them. Bulk
+cancellation can filter by task name, queue, keyword arguments, or metadata.
 
 Cooperative running cancellation
 ================================
 
-A running task can terminate itself with ``job_cancelled("reason")`` or raise
+A running task can stop itself with ``job_cancelled("reason")`` or raise
 :class:`~litestar_queues.JobCancelledError`. This records ``cancelled`` and
 does not retry. Backend cancellation with ``include_running=True`` changes the
-record state, but user code must still cooperate with cancellation and release
-its resources safely.
+record state, but it cannot force user code to stop. The task must check for
+cancellation and release its resources safely.
 
-Timeouts use normal failure handling. Make external calls cancellable and
-idempotent so a retry can safely resume after partial work.
+Timeouts use normal failure handling. Make external calls cancellable and safe
+to repeat so a retry does not corrupt partially completed work.

--- a/docs/usage/failures-and-cancellation.rst
+++ b/docs/usage/failures-and-cancellation.rst
@@ -1,0 +1,41 @@
+=========================
+Failures and cancellation
+=========================
+
+Retry ordinary failures by setting ``retries``:
+
+.. code-block:: python
+
+   from litestar_queues import non_retryable, task
+
+
+   @task("billing.charge", retries=3, timeout=60)
+   async def charge(invoice_id: str) -> None:
+       if invoice_id.startswith("invalid-"):
+           non_retryable("Invoice cannot be charged")
+
+An ordinary exception is retried while attempts remain. ``non_retryable()``
+raises :class:`~litestar_queues.NonRetryableError` and moves directly to a
+terminal failure. Inspect ``TaskResult.error`` after refreshing the result.
+
+Cancel pending work
+===================
+
+.. code-block:: python
+
+   cancelled = await queue_service.cancel_task(result.id)
+
+Pending and scheduled records can be cancelled before claim. Bulk cancellation
+can filter by task name, queue, keyword arguments, or metadata.
+
+Cooperative running cancellation
+================================
+
+A running task can terminate itself with ``job_cancelled("reason")`` or raise
+:class:`~litestar_queues.JobCancelledError`. This records ``cancelled`` and
+does not retry. Backend cancellation with ``include_running=True`` changes the
+record state, but user code must still cooperate with cancellation and release
+its resources safely.
+
+Timeouts use normal failure handling. Make external calls cancellable and
+idempotent so a retry can safely resume after partial work.

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -1,111 +1,139 @@
-Usage
-=====
+=============
+How-to guides
+=============
 
-This section contains focused guides for runtime configuration and production
-queue behavior.
+After the :doc:`../getting_started/quickstart`, follow this three-step route:
 
-Choose a Topic
-==============
+1. :doc:`tasks` — define and enqueue work.
+2. :doc:`workers` and :doc:`results` — run and observe it.
+3. :doc:`backends` and :doc:`events` — choose production persistence,
+   execution, and delivery options.
+
+Define and control tasks
+========================
 
 .. grid:: 1 1 2 3
    :gutter: 2
    :padding: 0
 
-   .. grid-item-card:: Configuration
-      :link: configuration
-      :link-type: doc
-
-      Configure the plugin, service, workers, dependency keys, and runtime
-      settings.
-
-   .. grid-item-card:: Tasks
+   .. grid-item-card:: Define and enqueue
       :link: tasks
       :link-type: doc
 
-      Register tasks, enqueue work, set retries, deduplicate records, and use
-      task context helpers.
+      Register task functions and enqueue them through ``QueueService``.
+
+   .. grid-item-card:: Configure task options
+      :link: task-options
+      :link-type: doc
+
+      Set retries, timeouts, priority, delay, metadata, and deduplication keys.
+
+   .. grid-item-card:: Inspect results
+      :link: results
+      :link-type: doc
+
+      Refresh records, wait for terminal state, and inspect results or errors.
+
+   .. grid-item-card:: Background responses
+      :link: background-tasks
+      :link-type: doc
+
+      Choose whether enqueueing happens before or after the response starts.
+
+   .. grid-item-card:: Failures and cancellation
+      :link: failures-and-cancellation
+      :link-type: doc
+
+      Control retries and cooperative cancellation.
 
    .. grid-item-card:: Schedules
       :link: schedules
       :link-type: doc
 
-      Run recurring interval and cron tasks with startup synchronization.
+      Register interval and cron tasks.
 
-   .. grid-item-card:: Workers
+Run and operate workers
+=======================
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+   :padding: 0
+
+   .. grid-item-card:: Run workers
       :link: workers
       :link-type: doc
 
-      Run local workers, process batches, send heartbeats, and reconcile
-      external execution.
+      Pick in-app or standalone placement and start worker processes.
 
-   .. grid-item-card:: Events
-      :link: events
+   .. grid-item-card:: Understand wakeups
+      :link: worker-wakeups
       :link-type: doc
 
-      Publish lifecycle, progress, log, and custom task events to application
-      realtime infrastructure.
+      Combine notification hints with polling and shutdown interruption.
 
-   .. grid-item-card:: Observability
+   .. grid-item-card:: Recover stale work
+      :link: worker-recovery
+      :link-type: doc
+
+      Configure heartbeats, recovery, identity, and diagnosis.
+
+   .. grid-item-card:: Observe queues
       :link: observability
       :link-type: doc
 
-      Add OpenTelemetry traces, OpenTelemetry metrics, and Prometheus metrics
-      for queue operations, workers, and external execution.
+      Add traces, metrics, logs, and operational status checks.
 
-   .. grid-item-card:: Backends
+Choose production options
+=========================
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+   :padding: 0
+
+   .. grid-item-card:: Choose backends
       :link: backends
       :link-type: doc
 
-      Select queue and execution backends while keeping optional drivers
-      optional.
+      Select queue persistence, execution placement, and wakeups independently.
 
-   .. grid-item-card:: Deployment
+   .. grid-item-card:: Publish task events
+      :link: events
+      :link-type: doc
+
+      Publish progress and connect live SSE or WebSocket consumers.
+
+   .. grid-item-card:: Deploy Cloud Run execution
       :link: deployment/cloud-run
       :link-type: doc
 
-      Plan Cloud Run dispatcher services, worker Jobs, IAM, and database
-      connectivity for external execution.
-
-   .. grid-item-card:: Dependency Resolver
-      :link: dependency-resolver
-      :link-type: doc
-
-      Inject services into task callables through an external DI container
-      with the optional ``task_dependency_resolver`` hook.
-
-   .. grid-item-card:: CLI
-      :link: cli
-      :link-type: doc
-
-      Run worker fleets, inspect queue status, and check scheduler health
-      via the ``litestar queues`` subcommand group.
-
-Recommended Path
-----------------
-
-1. Start with :doc:`../getting_started/quickstart` to wire the plugin and
-   enqueue a task.
-2. Configure deployment defaults in :doc:`configuration`.
-3. Add task-level behavior with :doc:`tasks` and recurring work with
-   :doc:`schedules`.
-4. Choose queue persistence and execution integrations in :doc:`backends`.
-5. Read :doc:`deployment/cloud-run` when you are deploying on Cloud Run.
-6. Add progress streaming or external subscribers with :doc:`events`.
-7. Add telemetry with :doc:`observability`.
+      Persist, dispatch, and execute work across Cloud Run services and Jobs.
 
 .. toctree::
    :hidden:
-   :maxdepth: 1
+   :maxdepth: 2
 
-   configuration
+   concepts
    tasks
+   task-options
+   results
+   background-tasks
+   failures-and-cancellation
    schedules
    workers
-   events
-   observability
-   backends
-   deployment/cloud-run
+   worker-wakeups
+   worker-recovery
+   configuration
    cli
-   dependency-resolver
    testing
+   backends
+   backends/sqlspec
+   backends/advanced-alchemy
+   backends/redis-valkey
+   events
+   event-streams
+   event-history
+   event-testing
+   observability
+   dependency-resolver
+   deployment/cloud-run
    migration

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -2,7 +2,7 @@
 How-to guides
 =============
 
-After the :doc:`../getting_started/quickstart`, follow this three-step route:
+After the :doc:`../getting_started/quickstart`, use these guides in order:
 
 1. :doc:`tasks` — define and enqueue work.
 2. :doc:`workers` and :doc:`results` — run and observe it.
@@ -94,7 +94,7 @@ Choose production options
       :link: backends
       :link-type: doc
 
-      Select queue persistence, execution placement, and wakeups independently.
+      Choose task storage, execution placement, and worker wakeups separately.
 
    .. grid-item-card:: Publish task events
       :link: events

--- a/docs/usage/migration.rst
+++ b/docs/usage/migration.rst
@@ -1,252 +1,31 @@
-Migration Guide
+===============
+Migration notes
 ===============
 
-This guide covers moving an application-specific worker package onto
-``litestar_queues`` while keeping the application-owned task code, database
-configuration, and deployment choices.
+Use canonical queue terminology in application code and documentation:
 
-Port Tasks
-----------
+.. list-table::
+   :header-rows: 1
 
-Keep task callables in application modules and decorate them with
-``litestar_queues.task``:
+   * - Older wording
+     - Current wording
+   * - Storage backend
+     - Queue backend
+   * - Job notification/event bus
+     - Worker wakeup hint
+   * - Realtime job event
+     - Task event
+   * - Live event sink as history
+     - Queue-backend event history
 
-.. code-block:: python
+Queue persistence, worker wakeups, live task-event delivery, and durable event
+history are separate capabilities. Configure each explicitly instead of
+assuming one transport provides the others.
 
-   from litestar_queues import task
-   from litestar_queues.events import publish_task_log, publish_task_progress
+When moving from memory to a persistent backend, make task arguments
+serializable, provision schema or data structures through the selected
+backend, disable the in-app worker if workers run separately, and refresh
+``TaskResult`` before reading later state.
 
-   @task(
-       "files.process",
-       queue="files",
-       retries=3,
-       timeout=600,
-       execution_backend="cloudrun",
-       execution_profile="worker-heavy",
-       description="Process an uploaded file.",
-       log_level="info",
-   )
-   async def process_file(file_id: str, *, _job_id: str) -> dict[str, str]:
-       await publish_task_progress(current=1, total=3, message="started")
-       await publish_task_log("file processing started", payload={"file_id": file_id})
-       return {"task_id": str(_job_id), "file_id": file_id}
-
-Tasks that accept ``_job_id`` receive the queue record ID. Tasks can also
-accept ``_task_context`` to publish events directly through the bound
-``TaskExecutionContext``.
-
-Use ``Task.using()`` or ``QueueService.enqueue()`` keyword arguments for
-per-call overrides:
-
-.. code-block:: python
-
-   result = await queue_service.enqueue(
-       process_file.using(key=f"file:{file_id}", priority=10),
-       file_id,
-       quiet_success=True,
-   )
-
-Configure Backends
-------------------
-
-Choose a queue backend independently from where tasks execute. Optional drivers
-are imported only by their own public subpackages:
-
-.. code-block:: bash
-
-   pip install litestar-queues[sqlspec]
-   pip install litestar-queues[advanced-alchemy]
-   pip install litestar-queues[redis]
-   pip install litestar-queues[valkey]
-   pip install litestar-queues[cloudrun]
-
-Applications that already configure SQLSpec or Advanced Alchemy should keep
-owning those framework plugins and pass the configured objects to
-the typed queue backend config object. ``litestar_queues`` does not register
-SQLSpec or Advanced Alchemy plugins on behalf of the application.
-
-Schedules
----------
-
-Recurring jobs use the same decorator. Interval and cron schedules preserve
-task metadata on the queued record, including description, log level, quiet
-success, execution backend, execution profile, and schedule metadata:
-
-.. code-block:: python
-
-   @task(
-       "maintenance.cleanup",
-       cron="0 2 * * *",
-       timezone="UTC",
-       description="Remove expired queue records.",
-       log_level="debug",
-   )
-   async def cleanup() -> None:
-       ...
-
-   @task(
-       "integrations.sync",
-       interval=300,
-       initial_delay=60,
-       jitter=30,
-       max_instances=1,
-   )
-   async def sync_external_data() -> None:
-       ...
-
-When ``QueueConfig.initialize_schedules`` is enabled, startup creates one
-deduplicated scheduled record per registered schedule key. If a pending
-scheduled record exists but the schedule metadata has changed, startup cancels
-the old record and creates a new one with the updated definition.
-Scheduled records use ``QueueConfig.quiet_success`` when the task does not set
-``quiet_success`` itself, and task-level values continue to win over the config
-default.
-
-Cron schedules use five fields: minute, hour, day-of-month, month, and
-day-of-week. Litestar Queues supports wildcards, lists, ranges, named months and
-weekdays, positive steps, Sunday as ``0`` or ``7``, and ``?`` in the two day
-fields. It does not support Quartz-style extensions such as seconds or year
-fields, ``@reboot``, ``L``, ``W``, or ``#`` modifiers. Rewrite those schedules as
-multiple supported cron expressions or move the advanced calendar rule into
-application code.
-
-Realtime Updates
-----------------
-
-Queue persistence notifications are for waking workers only. Application
-progress, logs, lifecycle events, and custom events should use the queue event
-contract:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig
-   from litestar_queues.backends.redis import RedisBackendConfig
-   from litestar_queues.events import EventConfig
-
-   config = QueueConfig(
-       queue_backend=RedisBackendConfig(url="redis://localhost:6379/0"),
-       execution_backend="local",
-       event=EventConfig(
-           channels_backend=app_channels_backend,
-           publish_global_lifecycle=True,
-       ),
-   )
-
-``EventConfig.sink`` can point at an in-process test sink, a Litestar
-Channels sink, or a custom sink that forwards events outside the application.
-Event publishing is best effort by default; set ``strict=True`` when event
-delivery failures should fail task execution.
-
-If existing WebSocket routes call ``stream_queue_events(socket, ...)``, replace
-them with plugin-owned stream routes configured through ``EventStreamConfig``.
-Task-scoped streams are available at ``/queues/events/tasks/{task_id}`` for
-WebSocket clients and ``/queues/events/sse/tasks/{task_id}`` for SSE clients by
-default. Queue, worker, global, and custom scopes follow the same route pattern.
-The old helper is no longer part of the public ``litestar_queues.events`` API.
-
-Cloud Run Workers
------------------
-
-External execution uses the same queue record contract. Configure Cloud Run as
-an execution backend and run the packaged entry point in the job container:
-
-.. code-block:: bash
-
-   litestar-queues-cloudrun-worker
-
-The entry point loads configured task modules, reconstructs the queue service,
-claims the persisted record, executes the task, publishes lifecycle and task
-events through the configured event sink, and exits with a deterministic status
-code.
-
-``CloudRunExecutionConfig.fallback_execution_backend`` defaults to ``None``.
-This is intentional: dispatch failures should surface instead of silently
-rerouting to a backend that may not have a worker. If you want local rerouting,
-set ``fallback_execution_backend="local"`` explicitly and run a local worker
-that can consume those records.
-
-Stateless Data Migration Runbook
---------------------------------
-
-Use this checklist when moving an existing job table to ``litestar_queues``.
-Run it with workers drained unless you have separately verified that old and new
-workers can safely share the table during the cutover.
-
-1. Back up the job table and any job-log table before changing schema.
-2. Point SQLSpec at the existing table. If it already uses the default
-   physical names (``task_key``, ``task_name``, ``task_args``,
-   ``task_kwargs``, ``execution_backend``, ``result``, and ``metadata``), no
-   ``column_map`` is needed:
-
-   .. code-block:: python
-
-      SQLSpecBackendConfig(table_name="job")
-
-   If an existing table uses different names, set ``column_map`` only for
-   those differences.
-
-3. Add the columns required by ``litestar_queues`` when they are missing:
-   ``task_args`` (backfill ``[]``), ``task_kwargs`` (backfill ``{}``),
-   ``queue`` (backfill ``"default"``), ``execution_profile``, and
-   ``execution_ref``. Backfill
-   ``execution_profile`` and ``execution_ref`` from existing metadata keys such
-   as ``profile``, ``execution_ref``, or ``cloudrun_execution`` before adding
-   ``NOT NULL`` constraints where your schema requires them.
-4. Keep the six lifecycle states unchanged: ``pending``, ``scheduled``,
-   ``running``, ``completed``, ``failed``, and ``cancelled``. Drain or
-   explicitly account for ``running`` rows before switching workers.
-5. If existing result values are wrapped as ``{"result": value}``, unwrap them
-   into the raw ``result`` value expected by ``litestar_queues``.
-6. Rewrite schedule rows:
-
-   * keys from ``scheduled-<name>`` to ``scheduled:<name>``;
-   * schedule config from task data into ``metadata["schedule"]``;
-   * ``max_retries`` to ``0`` unless a task explicitly opts into another value;
-   * remove legacy schedule-only columns after validation.
-
-7. Audit task declarations and callers:
-
-   * ``execution_target`` becomes ``execution_backend``;
-   * ``profile`` becomes ``execution_profile``;
-   * ``requeue`` becomes ``requeue_on_stale``;
-   * ``quiet_when_healthy`` becomes ``quiet_success``;
-   * retry defaults are ``0`` unless ``retries=`` is explicit;
-   * task priority defaults to ``0``; scheduled rows preserve explicit task
-     priority;
-   * ``TaskResult.wait(max_wait=...)`` becomes ``wait(timeout=...)``; and
-   * private progress/log calls become ``publish_task_progress()`` and
-     ``publish_task_log()``.
-
-8. Audit cron schedules. Unsupported seconds fields, year fields, ``@reboot``,
-   ``L``, ``W``, and ``#`` are rejected at decoration time. Replace those with
-   multiple supported schedules or application code.
-9. Configure backend-managed event history if the application reads durable job
-   logs. Live event sinks are delivery transports only; queryable history should
-   be written by the durable queue backend so task state and task events share
-   the same database boundary. SQLSpec writes history to the backend-managed
-   event-log table, or to the table named by
-   ``SQLSpecBackendConfig.event_log_table_name`` when a compatibility view or
-   adopter-owned name is required.
-10. Configure Cloud Run workers with the new environment contract:
-    ``CONFIG_FACTORY`` is required by the packaged worker entry point, and
-    queue-specific environment variables should use the ``LITESTAR_QUEUES_*``
-    prefix. The Cloud Run worker exits with deterministic status codes, so use
-    Cloud Run Job execution status plus queue record status during validation.
-11. Configure ``QueueConfig.error_sanitizer`` if persisted errors must not carry
-    secrets, tenant data, or provider payloads. The sanitizer controls both the
-    stored error and the ``task.failed`` message.
-12. Validate by enqueuing representative immediate, scheduled, retrying,
-    stale-recovered, cancelled, Cloud Run, and event-publishing tasks against
-    the migrated table before opening user traffic.
-
-Migration Checklist
--------------------
-
-1. Move generic worker behavior to ``litestar_queues`` configuration.
-2. Keep application-specific task modules, settings, and service dependencies
-   in the application.
-3. Replace private queue storage code with an optional backend subpackage that
-   matches the deployed adapter.
-4. Replace private progress or log publishers with ``litestar_queues.events``.
-5. Add tests that enqueue representative immediate, scheduled, retrying,
-   external, and event-publishing tasks against the selected backend.
+See :doc:`backends` for the current support matrix and :doc:`event-history`
+for event-history ownership.

--- a/docs/usage/migration.rst
+++ b/docs/usage/migration.rst
@@ -18,14 +18,16 @@ Use canonical queue terminology in application code and documentation:
    * - Live event sink as history
      - Queue-backend event history
 
-Queue persistence, worker wakeups, live task-event delivery, and durable event
-history are separate capabilities. Configure each explicitly instead of
-assuming one transport provides the others.
+Task storage, worker wakeups, live task-event delivery, and saved event history
+are separate features. Configure each one explicitly. Do not assume that one
+transport provides the others.
 
-When moving from memory to a persistent backend, make task arguments
-serializable, provision schema or data structures through the selected
-backend, disable the in-app worker if workers run separately, and refresh
-``TaskResult`` before reading later state.
+When moving from memory to a persistent backend:
+
+* use task arguments the backend can serialize;
+* create its schema or data structures;
+* disable the in-app worker if workers run separately; and
+* refresh ``TaskResult`` before reading a later state.
 
 See :doc:`backends` for the current support matrix and :doc:`event-history`
 for event-history ownership.

--- a/docs/usage/observability.rst
+++ b/docs/usage/observability.rst
@@ -2,9 +2,10 @@
 Observability
 =============
 
-Litestar Queues can emit package-level queue telemetry for enqueue, task
-execution, worker claims, worker loop errors, idle waits, stale recovery,
-heartbeats, Cloud Run dispatch, and Cloud Run reconciliation.
+Litestar Queues can report traces, metrics, and logs for enqueueing, task
+execution, worker claims and errors, idle waits, stale recovery, heartbeats,
+Cloud Run dispatch, and Cloud Run status checks. These signals are called
+telemetry.
 
 Install Extras
 ==============
@@ -20,10 +21,10 @@ OpenTelemetry and Prometheus are optional:
 Configure a Litestar App
 ========================
 
-Set ``enable_otel=True`` and/or ``enable_prometheus=True`` on
-``ObservabilityConfig``. The queue plugin creates the observability runtime
-during Litestar startup, so in-app workers, request handlers, and plugin-owned
-event streams share the same queue telemetry settings.
+Set ``enable_otel=True`` or ``enable_prometheus=True`` on
+``ObservabilityConfig``. You may enable both. The queue plugin starts telemetry
+with the Litestar app. In-app workers, request handlers, and plugin-owned event
+streams then use the same settings.
 
 .. code-block:: python
 
@@ -89,14 +90,14 @@ CLI workers should load a config factory that returns the same settings:
 Trace Context
 =============
 
-Producer spans are created around ``QueueService.enqueue()``. When
-OpenTelemetry is enabled, the current W3C context is injected into queue record
-metadata under the reserved ``_otel_context`` key.
+Litestar Queues creates a producer span around ``QueueService.enqueue()``. A
+span is one timed operation in a distributed trace. When OpenTelemetry is
+enabled, Litestar Queues stores the current W3C trace context in the queue
+record's reserved ``_otel_context`` metadata key.
 
-Consumer spans are created around ``QueueService.execute_record()``. Local,
-immediate, and Cloud Run entrypoint execution all call that method, so task
-execution extracts the parent context from the queued record metadata before
-running task code.
+It creates a consumer span around ``QueueService.execute_record()``. Local,
+immediate, and Cloud Run execution all call this method. Before running task
+code, the method restores the parent trace context from the queue record.
 
 Do not write application metadata under ``_otel_context``. That key is reserved
 for trace propagation.
@@ -104,7 +105,8 @@ for trace propagation.
 Bounded Attributes
 ==================
 
-Queue telemetry uses bounded attributes and metric labels:
+Queue telemetry limits attributes and metric labels to the following known
+values. This prevents unbounded label counts:
 
 - ``messaging.system``
 - ``messaging.operation.name``
@@ -120,18 +122,18 @@ Queue telemetry uses bounded attributes and metric labels:
 - ``scope`` on plugin-owned stream metrics
 - ``reason`` on stream authorization-denial metrics only
 
-The package does not use task args, kwargs, result payloads, arbitrary metadata,
-tenant ids, user ids, job ids, exception messages, or Cloud Run execution refs
-as metric labels.
+The package never uses task arguments, results, arbitrary metadata, tenant IDs,
+user IDs, job IDs, exception messages, or Cloud Run execution references as
+metric labels.
 
 Stream Metrics
 ==============
 
-When ``QueueConfig.event_stream`` is enabled and package observability is
-configured, plugin-owned WebSocket and SSE streams record bounded metrics
-through the same runtime. Stream labels are limited to ``scope`` and, for
-authorization denials, ``reason``. They never include task ids, queue names,
-tenant ids, user ids, exception messages, or payload fields.
+When ``QueueConfig.event_stream`` and observability are enabled, plugin-owned
+WebSocket and SSE streams report metrics through the same runtime. Stream
+labels use only ``scope`` and, for denied access, ``reason``. They never include
+task IDs, queue names, tenant IDs, user IDs, exception messages, or payload
+fields.
 
 .. list-table::
    :header-rows: 1
@@ -174,21 +176,20 @@ tenant ids, user ids, exception messages, or payload fields.
 Event Buffer Signals
 ====================
 
-Live event buffering keeps observability low-cardinality. Buffer overflow
-handling does not add task IDs or payload data to metric labels.
+Live event buffering keeps the number of distinct metric labels small. Buffer
+overflow handling does not add task IDs or payload data to labels.
 
-When ``EventBufferConfig.overflow`` drops events, the buffer emits one bounded
-warning per buffer instance:
+When ``EventBufferConfig.overflow`` drops events, each buffer emits this warning
+once:
 
 .. code-block:: text
 
    Queue event buffer full; dropping event
 
-The log record includes the queue event scope and event type. It does not
-include task IDs, payloads, or arbitrary metadata. ``drop_oldest`` drops a
-pending event before accepting the new event; ``drop_newest`` drops the incoming
-event. ``block`` waits for a flush, and ``error`` raises
-``QueueEventBufferFull``.
+The log record includes the event scope and type, but not task IDs, payloads,
+or arbitrary metadata. ``drop_oldest`` removes a pending event before it adds
+the new event. ``drop_newest`` rejects the incoming event. ``block`` waits for
+a flush. ``error`` raises ``QueueEventBufferFull``.
 
 Flush and publish failures are also logged without payload data:
 
@@ -198,19 +199,17 @@ Flush and publish failures are also logged without payload data:
    Queue event batch publish failed
    Queue event publish failed
 
-By default these failures are best effort and do not fail the task execution
-path. Set ``EventConfig(strict=True)`` when the caller should receive the
-exception.
+By default, these failures do not fail the task. Set
+``EventConfig(strict=True)`` when the caller must receive the exception.
 
 SQLSpec Coexistence
 ===================
 
-SQLSpec statement spans, query spans, statement observers, and lifecycle hooks
-remain controlled by SQLSpec. Package-level queue observability owns
-queue-domain telemetry when ``QueueConfig`` is supplied with a
-``ObservabilityConfig`` through ``observability=...``.
+SQLSpec continues to control its statement spans, query spans, statement
+observers, and lifecycle hooks. Litestar Queues controls queue-specific
+telemetry when ``QueueConfig`` receives an ``ObservabilityConfig`` through
+``observability=...``.
 
-By default, package-level queue observability disables SQLSpec's custom
-queue-domain counters and spans for the SQLSpec queue backend. This avoids
-double counting ``enqueue``, ``claim``, ``complete``, ``fail``, and
-stale-recovery events.
+By default, Litestar Queues disables SQLSpec's custom queue counters and spans
+for the SQLSpec backend. This prevents duplicate ``enqueue``, ``claim``,
+``complete``, ``fail``, and stale-recovery signals.

--- a/docs/usage/results.rst
+++ b/docs/usage/results.rst
@@ -1,0 +1,41 @@
+-------
+Results
+-------
+
+Every enqueue returns a :class:`~litestar_queues.TaskResult` linked to its
+``QueueService``:
+
+.. code-block:: python
+
+   result = await queue_service.enqueue(render_report, "report-123")
+   await result.wait(timeout=30)
+
+   if result.status == "completed":
+       report_path = result.result
+   elif result.status == "failed":
+       error = result.error
+
+``wait()`` polls until ``completed``, ``failed``, or ``cancelled`` and raises
+``TimeoutError`` if its timeout expires. The queue record continues running
+after that local timeout.
+
+Refresh cached state
+====================
+
+``TaskResult.status``, ``result``, ``error``, and ``record`` are cached. Call:
+
+.. code-block:: python
+
+   await result.refresh()
+
+before reading later state. This is essential with persistent backends, which
+return fresh record objects instead of mutating the enqueue-time object in
+place. Code that works with every backend should refresh explicitly.
+
+Result ownership
+================
+
+The queue backend owns the authoritative record. A ``TaskResult`` is only a
+handle and needs its associated service for ``refresh()`` or ``wait()``.
+Terminal cleanup policies can eventually remove records, so copy business
+results into application-owned storage when they must be retained indefinitely.

--- a/docs/usage/results.rst
+++ b/docs/usage/results.rst
@@ -15,9 +15,9 @@ Every enqueue returns a :class:`~litestar_queues.TaskResult` linked to its
    elif result.status == "failed":
        error = result.error
 
-``wait()`` polls until ``completed``, ``failed``, or ``cancelled`` and raises
-``TimeoutError`` if its timeout expires. The queue record continues running
-after that local timeout.
+``wait()`` checks the task until its state is ``completed``, ``failed``, or
+``cancelled``. It raises ``TimeoutError`` when its timeout expires. That local
+timeout does not stop the queued task.
 
 Refresh cached state
 ====================
@@ -28,14 +28,14 @@ Refresh cached state
 
    await result.refresh()
 
-before reading later state. This is essential with persistent backends, which
-return fresh record objects instead of mutating the enqueue-time object in
-place. Code that works with every backend should refresh explicitly.
+before reading a later state. Persistent backends return a new record object
+instead of changing the original object in place. Call ``refresh()`` so the
+same code works with every backend.
 
 Result ownership
 ================
 
-The queue backend owns the authoritative record. A ``TaskResult`` is only a
-handle and needs its associated service for ``refresh()`` or ``wait()``.
-Terminal cleanup policies can eventually remove records, so copy business
-results into application-owned storage when they must be retained indefinitely.
+The queue backend owns the source record. A ``TaskResult`` is a handle to that
+record and needs its queue service for ``refresh()`` or ``wait()``. Cleanup may
+eventually remove finished records. Copy business results into app-owned
+storage when you must keep them indefinitely.

--- a/docs/usage/schedules.rst
+++ b/docs/usage/schedules.rst
@@ -109,3 +109,10 @@ Configuration
 
 Set ``initialize_schedules=False`` when schedules are initialized by a separate
 worker or management command.
+
+See also
+========
+
+Use :doc:`task-options` for retry, timeout, and execution defaults on scheduled
+tasks. Use :doc:`workers` to ensure exactly one intended startup path
+synchronizes schedules and enough workers are running to execute due records.

--- a/docs/usage/schedules.rst
+++ b/docs/usage/schedules.rst
@@ -2,8 +2,8 @@
 Schedules
 =========
 
-Tasks can declare a recurring interval or cron schedule. Scheduled tasks are
-registered in process and synchronized to the queue backend during startup when
+Tasks can declare a recurring interval or cron schedule. The process registers
+these tasks. At startup, it writes their schedules to the queue backend when
 ``QueueConfig.initialize_schedules`` is enabled.
 
 Interval Schedules
@@ -79,15 +79,14 @@ unsupported cron extensions.
 Startup Synchronization
 =======================
 
-When startup synchronization runs, Litestar Queues creates a pending queue
-record keyed as ``scheduled:<task-name>``. If an active record already exists
-with matching schedule metadata, it is reused. If schedule metadata changed,
-the old active record is cancelled and a replacement is created.
+During startup synchronization, Litestar Queues creates a pending record with
+the key ``scheduled:<task-name>``. It reuses an active record when its schedule
+metadata still matches. If the schedule changed, it cancels the old record and
+creates a new one.
 
-Completed and failed scheduled records are rescheduled after execution using the
-next run time from the persisted schedule metadata. This keeps scheduling data
-close to the queue record and allows durable backends to recover after process
-restarts.
+After a scheduled task completes or fails, Litestar Queues reads the saved
+schedule metadata and creates its next run. Keeping the schedule with the
+queue record lets persistent backends recover after a process restart.
 
 Scheduled records include the same task metadata used by normal enqueue calls.
 When a task does not set ``quiet_success``, schedule startup stores

--- a/docs/usage/task-options.rst
+++ b/docs/usage/task-options.rst
@@ -1,0 +1,57 @@
+============
+Task options
+============
+
+Set behavior that applies to every enqueue on the decorator:
+
+.. code-block:: python
+
+   from litestar_queues import task
+
+
+   @task(
+       "reports.render",
+       queue="reports",
+       retries=2,
+       timeout=120,
+       priority=5,
+       run_after=10,
+       key="daily-report",
+   )
+   async def render_report(report_id: str) -> str:
+       return report_id
+
+``retries`` is the number of retries after the first attempt. ``timeout`` is
+the execution ceiling in seconds. Lower numeric priority values are claimed
+first. ``run_after`` delays eligibility. ``key`` deduplicates non-terminal
+records for the same logical job.
+
+Override one enqueue
+====================
+
+.. code-block:: python
+
+   result = await queue_service.enqueue(
+       render_report,
+       "report-123",
+       retries=4,
+       timeout=600,
+       priority=1,
+       run_after=30,
+       key="report:report-123",
+       metadata={"requested_by": "user-42"},
+       description="Render the monthly report",
+   )
+
+Queue records store JSON-like arguments and metadata. Persistent backends
+require values their serializer can encode.
+
+Execution overrides
+===================
+
+``execution_backend`` selects inline, local-worker, or external execution for
+one task. ``execution_profile`` lets an external backend select a configured
+profile. These options change placement, not queue persistence.
+
+Use a key only when duplicate requests should share one active record. A
+terminal record does not permanently reserve the key.

--- a/docs/usage/task-options.rst
+++ b/docs/usage/task-options.rst
@@ -22,9 +22,9 @@ Set behavior that applies to every enqueue on the decorator:
        return report_id
 
 ``retries`` is the number of retries after the first attempt. ``timeout`` is
-the execution ceiling in seconds. Lower numeric priority values are claimed
-first. ``run_after`` delays eligibility. ``key`` deduplicates non-terminal
-records for the same logical job.
+the maximum run time in seconds. Workers claim lower numeric priority values
+first. ``run_after`` delays when the task can run. ``key`` names the logical
+job and prevents more than one active record for that key.
 
 Override one enqueue
 ====================
@@ -43,8 +43,8 @@ Override one enqueue
        description="Render the monthly report",
    )
 
-Queue records store JSON-like arguments and metadata. Persistent backends
-require values their serializer can encode.
+Queue records store JSON-like arguments and metadata. A persistent backend can
+store only values supported by its serializer.
 
 Execution overrides
 ===================
@@ -53,5 +53,8 @@ Execution overrides
 one task. ``execution_profile`` lets an external backend select a configured
 profile. These options change placement, not queue persistence.
 
-Use a key only when duplicate requests should share one active record. A
-terminal record does not permanently reserve the key.
+Use a key when duplicate requests should share one active record. If an active
+record already has that key, enqueueing returns that record. A task in a final
+state does not reserve the key forever, so the next enqueue can create a new
+record. Omit the key, or generate a different one, when concurrent
+invocations are wanted.

--- a/docs/usage/tasks.rst
+++ b/docs/usage/tasks.rst
@@ -25,9 +25,9 @@ Start with a named task and enqueue it through the injected
        result = await queue_service.enqueue(render_report, report_id)
        return {"task_id": str(result.id)}
 
-The decorator registers the callable under ``reports.render``. Enqueueing
-persists its arguments and returns a :class:`~litestar_queues.TaskResult`; it
-does not wait for the task body to finish.
+The decorator registers the function as ``reports.render``. Enqueueing saves
+its arguments and returns a :class:`~litestar_queues.TaskResult`. It does not
+wait for the task function to finish.
 
 Enqueue by name
 ===============

--- a/docs/usage/tasks.rst
+++ b/docs/usage/tasks.rst
@@ -1,234 +1,51 @@
-=====
-Tasks
-=====
+==================
+Define and enqueue
+==================
 
-Decorate a callable with :func:`litestar_queues.task` to register it in the
-process task registry:
+Start with a named task and enqueue it through the injected
+:class:`~litestar_queues.QueueService`:
 
 .. code-block:: python
 
-   from litestar_queues import task
+   from litestar import post
+   from litestar.di import NamedDependency
+   from litestar_queues import QueueService, task
 
 
-   @task("reports.render", queue="reports", priority=10, retries=2, timeout=120)
+   @task("reports.render", queue="reports", timeout=120)
    async def render_report(report_id: str) -> str:
        return report_id
 
-The decorated object can still be called directly:
+
+   @post("/reports/{report_id:str}")
+   async def start_report(
+       report_id: str,
+       queue_service: NamedDependency[QueueService],
+   ) -> dict[str, str]:
+       result = await queue_service.enqueue(render_report, report_id)
+       return {"task_id": str(result.id)}
+
+The decorator registers the callable under ``reports.render``. Enqueueing
+persists its arguments and returns a :class:`~litestar_queues.TaskResult`; it
+does not wait for the task body to finish.
+
+Enqueue by name
+===============
+
+String names let a caller avoid importing the task function:
 
 .. code-block:: python
 
-   value = await render_report("report-1")
+   result = await queue_service.enqueue("reports.render", "report-123")
 
-Enqueueing
-==========
+The task module must still be imported before execution. Set
+``QueueConfig(task_modules=("myapp.tasks",))`` or call
+:func:`~litestar_queues.discover_tasks` during startup.
 
-Use ``QueueService.enqueue()`` from a route handler, service layer, script, or
-worker entry point:
-
-.. code-block:: python
-
-   result = await queue_service.enqueue(render_report, "report-1")
-   await result.wait(timeout=30)
-
-``TaskResult`` caches the last known record state. Call ``refresh()`` to reload
-the record or ``wait()`` to poll until it reaches a terminal status.
-
-Per-Enqueue Overrides
-=====================
-
-Task decorator defaults can be overridden for one enqueue call:
-
-.. code-block:: python
-
-   result = await queue_service.enqueue(
-       render_report,
-       "report-1",
-       queue="slow-reports",
-       priority=1,
-       retries=5,
-       timeout=600,
-       run_after=30,
-       execution_backend="cloudrun",
-       execution_profile="heavy",
-       metadata={"requested_by": "user-123"},
-   )
-
-Use ``Task.using()`` when a configured copy is easier to pass around:
-
-.. code-block:: python
-
-   heavy_render = render_report.using(execution_backend="cloudrun", execution_profile="heavy")
-   await queue_service.enqueue(heavy_render, "report-1")
-
-Successful Completion Logs
+Choose where defaults live
 ==========================
 
-Successful task completion logs are quiet by default. ``QueueConfig`` sets
-``quiet_success=True``, so a completed task still updates its queue record and
-still publishes ``task.completed`` lifecycle events, stream messages, and event
-history, but the worker does not emit the ``"Queue task completed"`` Python log
-line.
-
-Set the package-level default when those logs are useful for an operator:
-
-.. code-block:: python
-
-   config = QueueConfig(quiet_success=False)
-
-The override order is:
-
-1. ``QueueService.enqueue(..., quiet_success=...)``
-2. ``@task(..., quiet_success=...)`` or ``Task.using(quiet_success=...)``
-3. ``metadata={"quiet_success": ...}``
-4. ``QueueConfig.quiet_success``
-
-Use task or enqueue overrides for specific noisy or important tasks. There is
-no queue-level quiet setting.
-
-Deduplication Keys
-==================
-
-Pass ``key=`` to deduplicate active work. Queue backends should reuse or replace
-records according to the backend contract instead of creating duplicate active
-records for the same key:
-
-.. code-block:: python
-
-   await queue_service.enqueue(render_report, "report-1", key="report:report-1")
-
-Task Context
-============
-
-When a task accepts ``_job_id`` or ``_task_context``, the worker injects those
-values during queued execution:
-
-.. code-block:: python
-
-   from litestar_queues.events import TaskExecutionContext
-
-
-   @task("imports.run")
-   async def run_import(path: str, _job_id: object, _task_context: TaskExecutionContext) -> None:
-       await _task_context.progress(current=1, total=10, message=f"Started {_job_id}")
-
-You can also publish through the helper functions while a task context is bound:
-
-.. code-block:: python
-
-   from litestar_queues.events import publish_task_log, publish_task_progress
-
-
-   @task("imports.process")
-   async def process_import(path: str) -> None:
-       await publish_task_log("Import started")
-       await publish_task_progress(current=5, total=10)
-
-Retries
-=======
-
-Unhandled exceptions retry until ``max_retries`` is exhausted. Raise
-``NonRetryableError`` or use the ``non_retryable`` helper when a failure should
-move directly to the terminal ``failed`` state.
-
-Cancellation
-============
-
-Use ``job_cancelled("message")`` from inside a task when the task detects a
-domain cancellation and should stop without retrying. The worker marks the
-record ``cancelled`` and emits ``task.cancelled``.
-
-Backends also expose ``cancel_tasks(...)`` for exact top-level predicate
-cancellation across pending and scheduled records. Pass ``include_running=True``
-when the caller is intentionally cancelling running records that cooperate with
-``job_cancelled``.
-
-Background Tasks
-================
-
-Litestar can run a small function after it sends the HTTP response. Use this
-when the route should return first and enqueue the queue job second.
-
-This only saves the job in the queue. Your queue settings decide when the task
-runs.
-
-If the job must be saved before the response is sent, enqueue inside the route
-instead:
-
-.. code-block:: python
-
-   result = await queue_service.enqueue(background_process, 42)
-   return {"task_id": str(result.id)}
-
-Native BackgroundTask
----------------------
-
-Pass the task's ``enqueue`` method to Litestar's ``BackgroundTask``:
-
-.. code-block:: python
-
-   from litestar import post, Response
-   from litestar.background_tasks import BackgroundTask
-   from litestar_queues import task
-
-   @task("tasks.background_process")
-   async def background_process(value: int) -> None:
-       pass
-
-   @post("/trigger")
-   async def trigger() -> Response[dict[str, str]]:
-       return Response(
-           {"status": "queued"},
-           background=BackgroundTask(background_process.enqueue, 42)
-       )
-
-QueuedBackgroundTask Helper
----------------------------
-
-Use ``QueuedBackgroundTask`` when you want to pass the queue task itself. It
-finds the app's active ``QueueService`` for you.
-
-``QueuePlugin`` must be registered on the app before you use this helper.
-
-.. code-block:: python
-
-   from litestar import post, Response
-   from litestar_queues import QueuedBackgroundTask, task
-
-   @task("tasks.background_process")
-   async def background_process(value: int) -> None:
-       pass
-
-   @post("/trigger")
-   async def trigger() -> Response[dict[str, str]]:
-       return Response(
-           {"status": "queued"},
-           background=QueuedBackgroundTask(background_process, 42)
-       )
-
-If the route already receives ``QueueService`` from Litestar, pass it to the
-helper:
-
-.. code-block:: python
-
-   from litestar.di import NamedDependency
-
-
-   @post("/trigger")
-   async def trigger(queue_service: NamedDependency[QueueService]) -> Response[dict[str, str]]:
-       return Response(
-           {"status": "queued"},
-           background=QueuedBackgroundTask(background_process, 42, service=queue_service)
-       )
-
-Which Form To Use
------------------
-
-Use ``await queue_service.enqueue(...)`` when the job must be saved before the
-route returns.
-
-Use ``BackgroundTask(background_process.enqueue, ...)`` when you want Litestar's
-standard background task behavior.
-
-Use ``QueuedBackgroundTask(background_process, ...)`` when you want a short
-helper that finds ``QueueService`` for you.
+Put stable defaults on ``@task`` and request-specific values on
+``QueueService.enqueue()``. See :doc:`task-options` for retries, priority,
+delay, keys, and metadata. See :doc:`results` when a caller must observe
+completion.

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -19,9 +19,10 @@ Use immediate execution when a test should receive the terminal record before
        assert result.status == "completed"
        assert result.result == "report-123"
 
-Use local execution when the worker lifecycle is part of the behavior. Start a
-``Worker``, enqueue work, and await ``TaskResult.wait()`` before asserting the
-terminal state. Do not treat ``Worker.run_once()`` as a completion barrier.
+Use local execution when the test covers worker behavior. Start a ``Worker``,
+enqueue work, and await ``TaskResult.wait()`` before checking the final state.
+``Worker.run_once()`` schedules claimed work; it does not mean the work has
+finished.
 
 Backend contracts
 =================

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -1,33 +1,35 @@
-Testing
--------
+=============
+Testing tasks
+=============
 
-With ``QueuePlugin``, the default ``QueueConfig`` uses the memory queue backend,
-local execution, and an in-app worker. Use immediate execution when a test needs
-completed results without running a worker:
-
-.. code-block:: python
-
-   from litestar_queues import QueueConfig, QueueService, task
-
-   @task("math.double")
-   async def double(value: int) -> int:
-       return value * 2
-
-   config = QueueConfig(execution_backend="immediate")
-
-   async with QueueService(config) as queue_service:
-       result = await queue_service.enqueue(double, 21)
-
-   assert result.status == "completed"
-   assert result.result == 42
-
-Use ``QueueConfig.provide_service()`` when a test needs the same lifecycle shape
-as Litestar dependency injection:
+Use immediate execution when a test should receive the terminal record before
+``enqueue()`` returns:
 
 .. code-block:: python
 
-   async with config.provide_service() as queue_service:
-       assert queue_service.config is config
+   from litestar_queues import QueueConfig, QueueService
 
-Use ``execution_backend="local"`` with ``Worker.run_once()`` when a test needs
-to assert queued state before processing.
+
+   async def test_report_task() -> None:
+       async with QueueService(
+           QueueConfig(queue_backend="memory", execution_backend="immediate")
+       ) as service:
+           result = await service.enqueue(render_report, "report-123")
+
+       assert result.status == "completed"
+       assert result.result == "report-123"
+
+Use local execution when the worker lifecycle is part of the behavior. Start a
+``Worker``, enqueue work, and await ``TaskResult.wait()`` before asserting the
+terminal state. Do not treat ``Worker.run_once()`` as a completion barrier.
+
+Backend contracts
+=================
+
+Persistent backends return fresh record objects. Always call
+``await result.refresh()`` before post-execution assertions so the test does
+not depend on memory backend object mutation.
+
+For event publishing and stream tests, see :doc:`event-testing`. Repository
+contributors should use :doc:`../contributing/testing` for the package's unit,
+integration, and browser commands.

--- a/docs/usage/worker-recovery.rst
+++ b/docs/usage/worker-recovery.rst
@@ -20,25 +20,26 @@ Leaving ``worker_stale_after=None`` disables automatic stale recovery.
 Heartbeats and stale records
 ============================
 
-The worker heartbeat manager updates active records. A distributed worker lock
-allows one worker at a time to run a stale sweep. Eligible stale work is
-requeued while retries remain; otherwise it becomes a terminal stale failure.
-Tasks may disable stale requeue or register ``on_stale_failure`` for cleanup.
+The heartbeat manager updates active records. A shared lock lets only one
+worker at a time check for stale records. A stale task returns to the queue if
+it has retries left. Otherwise, it ends with a stale failure. A task may turn
+off stale requeueing or register ``on_stale_failure`` for cleanup.
 
 Heartbeat pool isolation
 ========================
 
-SQLSpec can route heartbeat-only writes through ``heartbeat_pool_config``.
-Advanced Alchemy can use an adopter-owned ``heartbeat_session_maker``. Both
-must point at the same database as ordinary queue operations. Lifecycle writes
-remain on the main transaction path.
+SQLSpec can send heartbeat-only writes through ``heartbeat_pool_config``.
+Advanced Alchemy can use an app-owned ``heartbeat_session_maker``. Both must
+point to the same database as normal queue operations. Other task-state writes
+continue to use the main transaction path.
 
 Worker identity
 ===============
 
-Workers default to ``worker-{pid}``. Provide an explicit ``worker_id`` when
-process IDs are ambiguous across hosts or prefork processes. The ID appears in
-logs, metrics, and task events; it does not provide mutual exclusion.
+Workers default to ``worker-{pid}``, where ``pid`` is the process ID. Set an
+explicit ``worker_id`` when process IDs may repeat across hosts or preforked
+processes. The ID appears in logs, metrics, and task events. It does not stop
+another worker from running.
 
 Diagnosis
 =========

--- a/docs/usage/worker-recovery.rst
+++ b/docs/usage/worker-recovery.rst
@@ -1,0 +1,49 @@
+===============
+Worker recovery
+===============
+
+Workers heartbeat running tasks and can recover records whose worker stopped:
+
+.. code-block:: python
+
+   from datetime import timedelta
+   from litestar_queues import QueueConfig
+
+   queue_config = QueueConfig(
+       worker_heartbeat_interval=15,
+       worker_stale_after=timedelta(minutes=2),
+       worker_stale_check_interval=30,
+   )
+
+Leaving ``worker_stale_after=None`` disables automatic stale recovery.
+
+Heartbeats and stale records
+============================
+
+The worker heartbeat manager updates active records. A distributed worker lock
+allows one worker at a time to run a stale sweep. Eligible stale work is
+requeued while retries remain; otherwise it becomes a terminal stale failure.
+Tasks may disable stale requeue or register ``on_stale_failure`` for cleanup.
+
+Heartbeat pool isolation
+========================
+
+SQLSpec can route heartbeat-only writes through ``heartbeat_pool_config``.
+Advanced Alchemy can use an adopter-owned ``heartbeat_session_maker``. Both
+must point at the same database as ordinary queue operations. Lifecycle writes
+remain on the main transaction path.
+
+Worker identity
+===============
+
+Workers default to ``worker-{pid}``. Provide an explicit ``worker_id`` when
+process IDs are ambiguous across hosts or prefork processes. The ID appears in
+logs, metrics, and task events; it does not provide mutual exclusion.
+
+Diagnosis
+=========
+
+If work remains ``running`` after a crash, check heartbeat timestamps, stale
+thresholds, backend connectivity, and whether at least one worker has stale
+recovery enabled. Use ``litestar queues status`` for counts and inspect task
+errors after :meth:`~litestar_queues.TaskResult.refresh`.

--- a/docs/usage/worker-wakeups.rst
+++ b/docs/usage/worker-wakeups.rst
@@ -1,0 +1,36 @@
+==============
+Worker wakeups
+==============
+
+When no work is available, a worker asks the queue backend to wait for a
+notification with ``worker_poll_interval`` as the timeout:
+
+.. code-block:: python
+
+   from litestar_queues import QueueConfig
+
+   queue_config = QueueConfig(worker_poll_interval=0.25)
+
+The effective wait ends when a backend notification arrives, the timeout
+expires, or worker shutdown is requested. Backends without notification
+support simply implement the timeout as polling.
+
+Hints, not state
+================
+
+Redis and Valkey use pub/sub hints. SQLSpec can use a configured SQLSpec event
+transport. Advanced Alchemy can use PostgreSQL notification hints when enabled.
+These messages say “check the queue”; they do not contain the authoritative
+task lifecycle.
+
+Notifications can be coalesced, delayed, or dropped. Correctness comes from
+polling and reconciliation against the durable task table or data structure.
+Do not increase the poll interval beyond the recovery latency your service can
+tolerate.
+
+Separate from task events
+=========================
+
+Worker wakeups are not ``QueueEvent`` delivery, browser fan-out, or durable
+event history. A Redis queue backend does not automatically configure Redis
+Channels for SSE or WebSocket consumers. See :doc:`events`.

--- a/docs/usage/worker-wakeups.rst
+++ b/docs/usage/worker-wakeups.rst
@@ -20,13 +20,12 @@ Hints, not state
 
 Redis and Valkey use pub/sub hints. SQLSpec can use a configured SQLSpec event
 transport. Advanced Alchemy can use PostgreSQL notification hints when enabled.
-These messages say “check the queue”; they do not contain the authoritative
-task lifecycle.
+The message only tells the worker to check. The saved task record has the real
+state.
 
-Notifications can be coalesced, delayed, or dropped. Correctness comes from
-polling and reconciliation against the durable task table or data structure.
-Do not increase the poll interval beyond the recovery latency your service can
-tolerate.
+Notifications may arrive late or not at all. The worker stays correct by
+checking the saved task state. Do not set the poll interval higher than the
+delay your service can tolerate.
 
 Separate from task events
 =========================

--- a/docs/usage/workers.rst
+++ b/docs/usage/workers.rst
@@ -16,8 +16,8 @@ deployments.
 Run standalone workers
 ======================
 
-Use a shared persistent queue backend, turn off the web process worker, and run
-the same Litestar application as a worker service:
+Choose a shared, persistent queue backend. Then turn off the worker in the web
+process and run the same Litestar application as a worker service:
 
 .. code-block:: python
 
@@ -40,19 +40,19 @@ Memory persistence cannot coordinate separate processes. Choose a backend in
 What one worker loop does
 =========================
 
-A worker promotes due work, claims up to its available concurrency, schedules
-local executions, heartbeats running records, and reconciles external work.
-``Worker.run_once()`` returns after claims are scheduled; it is not a
-completion barrier. Use :doc:`results` when a caller must observe terminal
-state.
+A worker makes due scheduled tasks ready, claims as many tasks as its
+concurrency limit allows, and starts local execution. It also sends heartbeats
+for running records and checks external work. ``Worker.run_once()`` returns
+after it schedules claimed tasks; it does not wait for them to finish. Use
+:doc:`results` when a caller must observe the final state.
 
 Shutdown
 ========
 
-The first termination signal stops new claims and drains running tasks up to
-the configured graceful timeout. A second signal forces cancellation. The CLI
-returns ``0`` for clean shutdown, ``1`` for a worker error, and ``2`` when
-draining escalates to cancellation.
+The first termination signal stops new claims and gives running tasks time to
+finish. A second signal cancels them. The CLI returns ``0`` for a clean
+shutdown, ``1`` for a worker error, and ``2`` when the graceful timeout ends
+and cancellation begins.
 
 See :doc:`worker-wakeups` for idle waiting and :doc:`worker-recovery` for
 heartbeats and stale work.

--- a/docs/usage/workers.rst
+++ b/docs/usage/workers.rst
@@ -1,127 +1,58 @@
-Workers
-=======
+===========
+Run workers
+===========
 
-The local worker claims due records from the configured queue backend and
-executes them with the configured execution backend.
-
-Plugin Worker
-=============
-
-Set ``in_app_worker=True`` to run an in-app worker with the Litestar
-application:
+The default configuration starts a local worker inside the Litestar process:
 
 .. code-block:: python
 
-   from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+   from litestar_queues import QueueConfig
 
-   config = QueueConfig(
-       queue_backend=SQLSpecBackendConfig(config=...),
-       execution_backend="local",
-       in_app_worker=True,
-       worker_batch_size=20,
-       worker_max_concurrency=4,
-   )
+   queue_config = QueueConfig(in_app_worker=True)
 
-This is useful for tests, local development, and lightweight deployments. For
-heavier production workloads, consider running workers as separate processes so
-web and background capacity can be scaled independently.
+This is the shortest path for development, tests, and small single-process
+deployments.
 
-Manual Worker
-=============
+Run standalone workers
+======================
 
-Use ``Worker`` directly for scripts, process managers, or custom entry points:
+Use a shared persistent queue backend, turn off the web process worker, and run
+the same Litestar application as a worker service:
 
 .. code-block:: python
 
-   from litestar_queues import QueueConfig, QueueService, Worker
+   queue_config = QueueConfig(in_app_worker=False)
 
+.. code-block:: bash
 
-   async with QueueService(QueueConfig(queue_backend="memory", execution_backend="local")) as service:
-       worker = Worker(service, batch_size=10, max_concurrency=2)
-       await worker.start()
+   LITESTAR_APP=app:app litestar queues run --drain-timeout 30
 
-``run_once()`` processes one batch and is useful in tests:
+Process only selected queues or override concurrency:
 
-.. code-block:: python
+.. code-block:: bash
 
-   processed = await worker.run_once()
+   LITESTAR_APP=app:app litestar queues run \
+     --queue reports --queue email --max-concurrency 4
 
-Heartbeats and Stale Records
-============================
+Memory persistence cannot coordinate separate processes. Choose a backend in
+:doc:`backends` before separating the worker.
 
-Workers update heartbeats while a local task is running and clear heartbeat
-values after execution finishes. Backends that support stale recovery can
-requeue running records whose heartbeat is older than ``worker_stale_after``.
-The worker re-checks stale records every ``worker_stale_check_interval``
-seconds (default ``60``) from inside the poll loop, so a worker that survives
-a peer crash will rescue orphaned records without operator intervention. Set
-``worker_stale_after`` to ``None`` (the default) to disable stale recovery
-entirely; the periodic check is skipped in that case.
+What one worker loop does
+=========================
 
-When a stale running task is retried, its priority is demoted to at most ``4``
-and any previous error message is preserved. If no previous error exists, the
-backend stores ``"Task heartbeat stale"``. When stale recovery marks a task
-terminal, it emits ``task.stale_failed`` and invokes the task's
-``on_stale_failure`` callback when one is registered:
+A worker promotes due work, claims up to its available concurrency, schedules
+local executions, heartbeats running records, and reconciles external work.
+``Worker.run_once()`` returns after claims are scheduled; it is not a
+completion barrier. Use :doc:`results` when a caller must observe terminal
+state.
 
-.. code-block:: python
+Shutdown
+========
 
-   from litestar_queues import QueuedTaskRecord, task
+The first termination signal stops new claims and drains running tasks up to
+the configured graceful timeout. A second signal forces cancellation. The CLI
+returns ``0`` for clean shutdown, ``1`` for a worker error, and ``2`` when
+draining escalates to cancellation.
 
-
-   async def notify_operator(record: QueuedTaskRecord) -> None:
-       ...
-
-
-   @task("reports.refresh", requeue_on_stale=False, on_stale_failure=notify_operator)
-   async def refresh_report(report_id: str) -> None:
-       ...
-
-Workers ask the backend for an ``acquire_worker_lock()`` coordination lock
-before running stale-recovery and external-reconciliation sweeps. Backends that
-override that hook can make those sweeps single-owner across a fleet for each
-interval. Backends without lock support return ``True`` and keep the local
-timer behavior.
-
-SQL-backed backends can optionally route heartbeat writes through a dedicated
-connection so they do not contend with task fetch and lifecycle UPDATEs under
-high concurrency. See :ref:`Heartbeat Pool Isolation
-<heartbeat-pool-isolation>` (SQLSpec) and
-:ref:`Heartbeat Session Maker Isolation <aa-heartbeat-session-maker>`
-(Advanced Alchemy).
-
-External Execution
-==================
-
-External execution backends dispatch work outside the local process and store an
-execution reference on the queue record. The worker periodically calls
-``reconcile_external()`` so external backends can move records into terminal
-queue states after the remote execution completes.
-
-Cloud Run uses this flow: local workers dispatch records to Cloud Run Jobs, and
-the Cloud Run worker entry point claims the persisted record inside the remote
-container.
-
-Worker Wakeups
-==============
-
-Queue backends can implement notifications to wake sleeping workers. These
-notifications are only hints. Workers always fall back to polling via
-``worker_poll_interval`` when notifications are unavailable or missed.
-
-Worker Identity
-===============
-
-Each :class:`~litestar_queues.Worker` carries a string ``worker_id`` used to
-tag published ``QueueEvent`` envelopes (the ``workerId`` field on the wire).
-The default is ``"worker-{os.getpid()}"``; operators that run multiple
-workers per host, or that need stable identities across hosts where PIDs
-may collide, should pass an explicit ``worker_id`` to ``Worker(...)``:
-
-.. code-block:: python
-
-   worker = Worker(service, worker_id="orders-worker-3")
-
-The :class:`~litestar_queues.QueuePlugin` startup path uses the PID-based
-default. Standalone worker entry points should pass an explicit ``worker_id``
-per process.
+See :doc:`worker-wakeups` for idle waiting and :doc:`worker-recovery` for
+heartbeats and stale work.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Examples
 
-Standalone example apps live here. Each example owns its app module, templates,
-frontend assets, and README so it can be copied or run without reaching into the
-test suite.
+This directory contains standalone example apps. Each example has its own app
+module, templates, frontend assets, and README. You can copy or run one without
+using files from the test suite.
 
 ## Available Apps
 
@@ -25,23 +25,24 @@ Each transport has the same backend variants:
 - `htmx_realtime_websocket_sqlspec/` and `htmx_realtime_sse_sqlspec/`:
   `SQLSpecBackendConfig` with `AiosqliteConfig`.
 - `htmx_realtime_websocket_advanced_alchemy/` and
-  `htmx_realtime_sse_advanced_alchemy/`: `AdvancedAlchemyBackendConfig` with
+  `htmx_realtime_sse_advanced_alchemy/`: `SQLAlchemyBackendConfig` with
   `sqlite+aiosqlite`.
 - `htmx_realtime_websocket_redis/` and `htmx_realtime_sse_redis/`:
   `RedisBackendConfig`.
 - `htmx_realtime_websocket_valkey/` and `htmx_realtime_sse_valkey/`:
   `ValkeyBackendConfig`.
 
-The backend name describes queue persistence, not browser event fan-out. Every
-shipped copy currently uses `MemoryChannelsBackend` for live Channels delivery,
-so the web app and worker must stay in one process. Redis or Valkey queue
-notifications can wake a worker, but they do not make the browser stream
-shared. A separate worker topology requires an explicit broker-backed Channels
-configuration; do not infer it from selecting a Redis or Valkey queue backend.
+The backend name tells you where queue records are stored. It does not tell you
+how events reach the browser. By default, every example uses
+`MemoryChannelsBackend`, which works in one process only. Redis or Valkey queue
+notifications can wake a worker, but they do not share the browser stream. To
+run the worker in another process, configure a shared Channels backend
+explicitly. Selecting a Redis or Valkey queue backend is not enough.
 
-All demos inherit `QueueConfig`'s in-process worker default. The Redis and
-Valkey copies accept `LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0` only for their
-documented shared web/worker topology.
+All demos use the `QueueConfig` default and run the worker in the web process.
+The Redis and Valkey copies accept
+`LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER=0` only with their documented shared
+web-and-worker setup.
 
 Start with the README in the directory you want to run. Every example uses the
 optional `litestar-queues[examples]` Python extra and local frontend

--- a/examples/htmx_realtime_sse/README.md
+++ b/examples/htmx_realtime_sse/README.md
@@ -1,15 +1,13 @@
 # HTMX Realtime Queue Events - SSE (Memory Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over
-Server-Sent Events. There is one control, a planet-styled **Restart** button
-that (re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over Server-Sent Events
+(SSE) and shown on the page. The **Restart** button starts the demo task again.
 
-This copy is SSE-only. It uses the plugin-owned
-`/queues/events/sse/tasks/{task_id}` endpoint so the transport stays visible in
-the code. It runs in one process with the default memory queue backend, the
-default local worker, and memory Channels delivery. No external service is
-needed.
+This example uses only SSE. Its plugin-owned endpoint is
+`/queues/events/sse/tasks/{task_id}`, so you can see the transport in the code.
+The memory queue backend, local worker, and memory Channels delivery all run in
+one process. You do not need an external service.
 
 ## Run It (dev server, hot reload)
 
@@ -20,7 +18,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_sse.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_sse.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -29,9 +27,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_sse.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -41,7 +37,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -57,38 +53,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx SSE extension owns the connection.** The swapped-in
+- **The htmx SSE extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="sse"` and
   `sse-connect="/queues/events/sse/tasks/{task_id}"`, so htmx opens the
-  `EventSource` declaratively. Because each restart replaces the element, the
-  previous `EventSource` closes automatically: the connection lifecycle equals
-  the swap lifecycle, so a restart is a reconnect. This is the idiomatic
-  pattern and replaces roughly ninety lines of hand-rolled `EventSource` code.
+  `EventSource`. Each restart replaces this element, so htmx closes the old
+  connection and opens a new one. This replaces roughly ninety lines of custom
+  `EventSource` code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:sseBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-sse` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-sse`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_sse/app.py
+++ b/examples/htmx_realtime_sse/app.py
@@ -1,7 +1,5 @@
 import asyncio
-import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -22,41 +20,30 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "memory"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_sse.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -66,13 +53,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -91,17 +78,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
+        context={"task_id": task_id, "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -121,18 +108,12 @@ queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, websocket=False, history=25, heartbeat_interval=15),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],

--- a/examples/htmx_realtime_sse/resources/main.ts
+++ b/examples/htmx_realtime_sse/resources/main.ts
@@ -16,9 +16,9 @@ void import("htmx-ext-sse").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -60,16 +60,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -87,7 +98,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -95,12 +106,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: sse-client-start
@@ -119,7 +136,7 @@ document.body.addEventListener("htmx:sseBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // EventSource closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_sse/resources/styles.css
+++ b/examples/htmx_realtime_sse/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_sse/templates/index.html
+++ b/examples/htmx_realtime_sse/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_sse/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse/templates/partials/stream_mount.html
@@ -14,6 +14,5 @@
   sse-connect="{{ task_sse_url }}"
   sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
   hx-swap="none"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_advanced_alchemy/README.md
+++ b/examples/htmx_realtime_sse_advanced_alchemy/README.md
@@ -1,9 +1,8 @@
 # HTMX Realtime Queue Events - SSE (Advanced Alchemy Aiosqlite Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over
-Server-Sent Events. There is one control, a planet-styled **Restart** button
-that (re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over Server-Sent Events
+(SSE) and shown on the page. The **Restart** button starts the demo task again.
 
 This copy is SSE-only. It uses the plugin-owned
 `/queues/events/sse/tasks/{task_id}` endpoint so the transport stays visible in
@@ -11,12 +10,14 @@ the code. Queue persistence runs through Advanced Alchemy with
 `sqlite+aiosqlite`, and delivery uses memory Channels in the same process, so
 no external service is needed.
 
-This is a one-process topology: the SQLite queue database is persistence only;
-it does not make live Channels delivery available to a separate worker process.
+This setup uses one process. SQLite stores queue records, but it does not send
+live Channels events to a worker in another process.
 
 The queue database defaults to `queue-advanced-alchemy.db` under the example
-directory. The demo enables `create_all=True` and `create_schema=True` so the
-local schema is auto-created for a copyable app.
+directory. The demo passes the queue models' metadata to Advanced Alchemy and
+uses its `create_all=True` option for this local copy. The queue backend does
+not create tables itself. Production applications should use their normal
+metadata and migration workflow.
 
 ## Run It (dev server, hot reload)
 
@@ -27,7 +28,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_sse_advanced_alchemy.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_sse_advanced_alchemy.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -36,9 +37,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_sse_advanced_alchemy.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -48,7 +47,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -64,38 +63,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx SSE extension owns the connection.** The swapped-in
+- **The htmx SSE extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="sse"` and
   `sse-connect="/queues/events/sse/tasks/{task_id}"`, so htmx opens the
-  `EventSource` declaratively. Because each restart replaces the element, the
-  previous `EventSource` closes automatically: the connection lifecycle equals
-  the swap lifecycle, so a restart is a reconnect. This is the idiomatic
-  pattern and replaces roughly ninety lines of hand-rolled `EventSource` code.
+  `EventSource`. Each restart replaces this element, so htmx closes the old
+  connection and opens a new one. This replaces roughly ninety lines of custom
+  `EventSource` code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:sseBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-sse` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-sse`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_sse_advanced_alchemy/app.py
+++ b/examples/htmx_realtime_sse_advanced_alchemy/app.py
@@ -1,9 +1,7 @@
 import asyncio
-import os
 from pathlib import Path
-from uuid import uuid4
 
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.memory import MemoryChannelsBackend
@@ -15,7 +13,7 @@ from litestar.template.config import TemplateConfig
 from litestar_vite import PathConfig, ViteConfig, VitePlugin
 
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
-from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackendConfig
 from litestar_queues.events import (
     EventBufferConfig,
     EventConfig,
@@ -24,44 +22,31 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "advanced-alchemy-aiosqlite"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
-QUEUE_DB_PATH = Path(
-    os.getenv("LITESTAR_QUEUES_EXAMPLE_ADVANCED_ALCHEMY_DB", str(EXAMPLE_ROOT / "queue-advanced-alchemy.db"))
-)
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
+QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-advanced-alchemy.db"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_sse_advanced_alchemy.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -71,13 +56,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -96,17 +81,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
+        context={"task_id": task_id, "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -122,33 +107,30 @@ channels = ChannelsPlugin(
     subscriber_backlog_strategy="dropleft",
 )
 
+alchemy_config = SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{QUEUE_DB_PATH}", create_all=True)
+
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=AdvancedAlchemyBackendConfig(
-        sqlalchemy_config=SQLAlchemyAsyncConfig(
-            connection_string=f"sqlite+aiosqlite:///{QUEUE_DB_PATH}", create_all=True
-        ),
-        create_schema=True,
-    ),
+    queue_backend=SQLAlchemyBackendConfig(sqlalchemy_config=alchemy_config),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, websocket=False, history=25, heartbeat_interval=15),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
-    plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
+    plugins=[
+        HTMXPlugin(),
+        channels,
+        SQLAlchemyPlugin(config=alchemy_config),
+        QueuePlugin(queue_config),
+        VitePlugin(config=vite_config),
+    ],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_sse_advanced_alchemy/resources/main.ts
+++ b/examples/htmx_realtime_sse_advanced_alchemy/resources/main.ts
@@ -16,9 +16,9 @@ void import("htmx-ext-sse").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -60,16 +60,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -87,7 +98,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -95,12 +106,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: sse-client-start
@@ -119,7 +136,7 @@ document.body.addEventListener("htmx:sseBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // EventSource closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_sse_advanced_alchemy/resources/styles.css
+++ b/examples/htmx_realtime_sse_advanced_alchemy/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_sse_advanced_alchemy/templates/index.html
+++ b/examples/htmx_realtime_sse_advanced_alchemy/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_sse_advanced_alchemy/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_advanced_alchemy/templates/partials/stream_mount.html
@@ -14,6 +14,5 @@
   sse-connect="{{ task_sse_url }}"
   sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
   hx-swap="none"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_redis/README.md
+++ b/examples/htmx_realtime_sse_redis/README.md
@@ -1,19 +1,18 @@
 # HTMX Realtime Queue Events - SSE (Redis Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over
-Server-Sent Events. There is one control, a planet-styled **Restart** button
-that (re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over Server-Sent Events
+(SSE) and shown on the page. The **Restart** button starts the demo task again.
 
 This copy is SSE-only. It uses the plugin-owned
 `/queues/events/sse/tasks/{task_id}` endpoint so the transport stays visible in
 the code. Queue persistence runs through Redis, and delivery uses memory
 Channels in the same process, so only Redis is needed as an external service.
 
-The default remains one process: Redis stores queue records and can provide
-worker wakeups, but it does not make the live Channels stream shared. A
-separate `litestar queues run` worker needs an explicit broker-backed Channels
-configuration; selecting `RedisBackendConfig` alone is not enough.
+By default, the example runs in one process. Redis stores queue records and can
+wake workers, but it does not share the live Channels stream. To run
+`litestar queues run` in another process, configure a shared Channels backend.
+`RedisBackendConfig` alone is not enough.
 
 Set `LITESTAR_QUEUES_EXAMPLE_REDIS_URL` when Redis is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
@@ -21,9 +20,9 @@ spinning up a Redis container.
 
 ## Shared Web and Worker Mode
 
-The opt-in shared topology uses Redis Streams for live Channels delivery. It
-keeps the configured event history (`history=25`) and is intentionally separate
-from Redis queue wakeup pub/sub:
+The optional shared setup uses Redis Streams for live Channels delivery. It
+keeps the configured event history (`history=25`) separate from the Redis
+pub/sub messages that wake queue workers:
 
 ```bash
 export LITESTAR_QUEUES_EXAMPLE_REDIS_URL=redis://127.0.0.1:16379/0
@@ -55,7 +54,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_sse_redis.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_sse_redis.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -64,9 +63,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_sse_redis.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -76,7 +73,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -92,38 +89,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx SSE extension owns the connection.** The swapped-in
+- **The htmx SSE extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="sse"` and
   `sse-connect="/queues/events/sse/tasks/{task_id}"`, so htmx opens the
-  `EventSource` declaratively. Because each restart replaces the element, the
-  previous `EventSource` closes automatically: the connection lifecycle equals
-  the swap lifecycle, so a restart is a reconnect. This is the idiomatic
-  pattern and replaces roughly ninety lines of hand-rolled `EventSource` code.
+  `EventSource`. Each restart replaces this element, so htmx closes the old
+  connection and opens a new one. This replaces roughly ninety lines of custom
+  `EventSource` code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:sseBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-sse` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-sse`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_sse_redis/app.py
+++ b/examples/htmx_realtime_sse_redis/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -26,14 +25,14 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "redis"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 REDIS_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_REDIS_URL", "redis://localhost:6379/0")
 REDIS_KEY_PREFIX = os.getenv(
     "LITESTAR_QUEUES_EXAMPLE_REDIS_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_sse_redis"
@@ -44,31 +43,20 @@ CHANNELS_KEY_PREFIX = os.getenv(
 SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_sse_redis.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -78,13 +66,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -103,17 +91,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
+        context={"task_id": task_id, "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -140,19 +128,13 @@ queue_config = QueueConfig(
     worker_graceful_shutdown_timeout=5,
     queue_backend=RedisBackendConfig(url=REDIS_URL, key_prefix=REDIS_KEY_PREFIX),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, websocket=False, history=25, heartbeat_interval=15),
     **standalone_worker_options(),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 
 async def close_shared_channels() -> None:

--- a/examples/htmx_realtime_sse_redis/resources/main.ts
+++ b/examples/htmx_realtime_sse_redis/resources/main.ts
@@ -16,9 +16,9 @@ void import("htmx-ext-sse").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -60,16 +60,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -87,7 +98,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -95,12 +106,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: sse-client-start
@@ -119,7 +136,7 @@ document.body.addEventListener("htmx:sseBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // EventSource closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_sse_redis/resources/styles.css
+++ b/examples/htmx_realtime_sse_redis/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_sse_redis/templates/index.html
+++ b/examples/htmx_realtime_sse_redis/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_sse_redis/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_redis/templates/partials/stream_mount.html
@@ -14,6 +14,5 @@
   sse-connect="{{ task_sse_url }}"
   sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
   hx-swap="none"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_sqlspec/README.md
+++ b/examples/htmx_realtime_sse_sqlspec/README.md
@@ -1,9 +1,8 @@
 # HTMX Realtime Queue Events - SSE (SQLSpec Aiosqlite Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over
-Server-Sent Events. There is one control, a planet-styled **Restart** button
-that (re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over Server-Sent Events
+(SSE) and shown on the page. The **Restart** button starts the demo task again.
 
 This copy is SSE-only. It uses the plugin-owned
 `/queues/events/sse/tasks/{task_id}` endpoint so the transport stays visible in
@@ -11,12 +10,13 @@ the code. Queue persistence runs through SQLSpec with the Aiosqlite driver,
 and delivery uses memory Channels in the same process, so no external service
 is needed.
 
-This is a one-process topology: the SQLite queue database is persistence only;
-it does not make live Channels delivery available to a separate worker process.
+This setup uses one process. SQLite stores queue records, but it does not send
+live Channels events to a worker in another process.
 
 The queue database defaults to `queue-sqlspec.db` under the example directory.
-`SQLSpecBackendConfig` sets `create_schema=False` and `run_migrations=True`, so
-startup calls the SQLSpec migration path for the local queue schema.
+The example registers the queue migration with SQLSpec and runs it during
+startup. Production applications should register it before their normal
+SQLSpec migration command and run migrations during deployment.
 
 ## Run It (dev server, hot reload)
 
@@ -27,7 +27,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_sse_sqlspec.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_sse_sqlspec.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -36,9 +36,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_sse_sqlspec.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -48,7 +46,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -64,38 +62,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx SSE extension owns the connection.** The swapped-in
+- **The htmx SSE extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="sse"` and
   `sse-connect="/queues/events/sse/tasks/{task_id}"`, so htmx opens the
-  `EventSource` declaratively. Because each restart replaces the element, the
-  previous `EventSource` closes automatically: the connection lifecycle equals
-  the swap lifecycle, so a restart is a reconnect. This is the idiomatic
-  pattern and replaces roughly ninety lines of hand-rolled `EventSource` code.
+  `EventSource`. Each restart replaces this element, so htmx closes the old
+  connection and opens a new one. This replaces roughly ninety lines of custom
+  `EventSource` code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:sseBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-sse` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-sse`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_sse_sqlspec/app.py
+++ b/examples/htmx_realtime_sse_sqlspec/app.py
@@ -1,7 +1,5 @@
 import asyncio
-import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -24,43 +22,33 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "sqlspec-aiosqlite"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
-QUEUE_DB_PATH = Path(os.getenv("LITESTAR_QUEUES_EXAMPLE_SQLSPEC_DB", str(EXAMPLE_ROOT / "queue-sqlspec.db")))
-sqlspec_config = AiosqliteConfig(connection_config={"database": str(QUEUE_DB_PATH)})
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
 
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
+QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-sqlspec.db"
+sqlspec_config = AiosqliteConfig(connection_config={"database": str(QUEUE_DB_PATH)})
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_sse_sqlspec.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -70,13 +58,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -95,17 +83,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
+        context={"task_id": task_id, "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -124,25 +112,26 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=SQLSpecBackendConfig(config=sqlspec_config, create_schema=False, run_migrations=True),
+    queue_backend=SQLSpecBackendConfig(config=sqlspec_config),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, websocket=False, history=25, heartbeat_interval=15),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
+
+
+async def bootstrap_queue_schema() -> None:
+    """Run the normal SQLSpec migration path for this local demo."""
+    await sqlspec_config.migrate_up(echo=False)
+
 
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
+    on_startup=[bootstrap_queue_schema],
     plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_sse_sqlspec/resources/main.ts
+++ b/examples/htmx_realtime_sse_sqlspec/resources/main.ts
@@ -16,9 +16,9 @@ void import("htmx-ext-sse").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -60,16 +60,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -87,7 +98,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -95,12 +106,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: sse-client-start
@@ -119,7 +136,7 @@ document.body.addEventListener("htmx:sseBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // EventSource closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_sse_sqlspec/resources/styles.css
+++ b/examples/htmx_realtime_sse_sqlspec/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_sse_sqlspec/templates/index.html
+++ b/examples/htmx_realtime_sse_sqlspec/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_sse_sqlspec/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_sqlspec/templates/partials/stream_mount.html
@@ -14,6 +14,5 @@
   sse-connect="{{ task_sse_url }}"
   sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
   hx-swap="none"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_valkey/README.md
+++ b/examples/htmx_realtime_sse_valkey/README.md
@@ -1,19 +1,18 @@
 # HTMX Realtime Queue Events - SSE (Valkey Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over
-Server-Sent Events. There is one control, a planet-styled **Restart** button
-that (re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over Server-Sent Events
+(SSE) and shown on the page. The **Restart** button starts the demo task again.
 
 This copy is SSE-only. It uses the plugin-owned
 `/queues/events/sse/tasks/{task_id}` endpoint so the transport stays visible in
 the code. Queue persistence runs through Valkey, and delivery uses memory
 Channels in the same process, so only Valkey is needed as an external service.
 
-The default remains one process: Valkey stores queue records and can provide
-worker wakeups, but it does not make the live Channels stream shared. A
-separate `litestar queues run` worker needs an explicit broker-backed Channels
-configuration; selecting `ValkeyBackendConfig` alone is not enough.
+By default, the example runs in one process. Valkey stores queue records and
+can wake workers, but it does not share the live Channels stream. To run
+`litestar queues run` in another process, configure a shared Channels backend.
+`ValkeyBackendConfig` alone is not enough.
 
 Set `LITESTAR_QUEUES_EXAMPLE_VALKEY_URL` when Valkey is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
@@ -21,9 +20,9 @@ spinning up a Valkey container.
 
 ## Shared Web and Worker Mode
 
-The opt-in shared topology uses Litestar's Redis Channels Streams backend with
-the Valkey client. It keeps the configured event history (`history=25`) and is
-intentionally separate from Valkey queue wakeup pub/sub:
+The optional shared setup uses Litestar's Redis Channels Streams backend with
+the Valkey client. It keeps the configured event history (`history=25`) separate
+from the Valkey pub/sub messages that wake queue workers:
 
 ```bash
 export LITESTAR_QUEUES_EXAMPLE_VALKEY_URL=redis://127.0.0.1:16380/0
@@ -56,7 +55,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_sse_valkey.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_sse_valkey.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -65,9 +64,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_sse_valkey.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -77,7 +74,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -93,38 +90,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx SSE extension owns the connection.** The swapped-in
+- **The htmx SSE extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="sse"` and
   `sse-connect="/queues/events/sse/tasks/{task_id}"`, so htmx opens the
-  `EventSource` declaratively. Because each restart replaces the element, the
-  previous `EventSource` closes automatically: the connection lifecycle equals
-  the swap lifecycle, so a restart is a reconnect. This is the idiomatic
-  pattern and replaces roughly ninety lines of hand-rolled `EventSource` code.
+  `EventSource`. Each restart replaces this element, so htmx closes the old
+  connection and opens a new one. This replaces roughly ninety lines of custom
+  `EventSource` code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:sseBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-sse` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-sse`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_sse_valkey/app.py
+++ b/examples/htmx_realtime_sse_valkey/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -26,14 +25,14 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "valkey"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 VALKEY_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_VALKEY_URL", "redis://localhost:6379/0")
 VALKEY_KEY_PREFIX = os.getenv(
     "LITESTAR_QUEUES_EXAMPLE_VALKEY_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_sse_valkey"
@@ -44,31 +43,20 @@ CHANNELS_KEY_PREFIX = os.getenv(
 SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_sse_valkey.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -78,13 +66,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -103,17 +91,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
+        context={"task_id": task_id, "task_sse_url": f"/queues/events/sse/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -140,19 +128,13 @@ queue_config = QueueConfig(
     worker_graceful_shutdown_timeout=5,
     queue_backend=ValkeyBackendConfig(url=VALKEY_URL, key_prefix=VALKEY_KEY_PREFIX),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, websocket=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, websocket=False, history=25, heartbeat_interval=15),
     **standalone_worker_options(),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 
 async def close_shared_channels() -> None:

--- a/examples/htmx_realtime_sse_valkey/resources/main.ts
+++ b/examples/htmx_realtime_sse_valkey/resources/main.ts
@@ -16,9 +16,9 @@ void import("htmx-ext-sse").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -60,16 +60,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -87,7 +98,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -95,12 +106,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: sse-client-start
@@ -119,7 +136,7 @@ document.body.addEventListener("htmx:sseBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // EventSource closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_sse_valkey/resources/styles.css
+++ b/examples/htmx_realtime_sse_valkey/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_sse_valkey/templates/index.html
+++ b/examples/htmx_realtime_sse_valkey/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_sse_valkey/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_valkey/templates/partials/stream_mount.html
@@ -14,6 +14,5 @@
   sse-connect="{{ task_sse_url }}"
   sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
   hx-swap="none"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_websocket/README.md
+++ b/examples/htmx_realtime_websocket/README.md
@@ -1,14 +1,13 @@
 # HTMX Realtime Queue Events - WebSocket (Memory Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over a
-WebSocket. There is one control, a planet-styled **Restart** button that
-(re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over a WebSocket and
+shown on the page. The **Restart** button starts the demo task again.
 
-This copy is WebSocket-only. It uses the plugin-owned
-`/queues/events/tasks/{task_id}` endpoint so the transport stays visible in the
-code. It runs in one process with the default memory queue backend, the default
-local worker, and memory Channels delivery. No external service is needed.
+This example uses only a WebSocket. Its plugin-owned endpoint is
+`/queues/events/tasks/{task_id}`, so you can see the transport in the code. The
+memory queue backend, local worker, and memory Channels delivery all run in one
+process. You do not need an external service.
 
 ## Run It (dev server, hot reload)
 
@@ -19,7 +18,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_websocket.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_websocket.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -28,9 +27,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_websocket.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -40,7 +37,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -56,38 +53,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx WebSocket extension owns the connection.** The swapped-in
+- **The htmx WebSocket extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="ws"` and
   `ws-connect="/queues/events/tasks/{task_id}"`, so htmx opens the socket
-  declaratively. Because each restart replaces the element, the previous socket
-  closes automatically: the connection lifecycle equals the swap lifecycle, so a
-  restart is a reconnect. This is the idiomatic pattern and replaces roughly
-  ninety lines of hand-rolled `WebSocket` code.
+  for you. Each restart replaces this element, so htmx closes the old socket and
+  opens a new one. This replaces roughly ninety lines of custom `WebSocket`
+  code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:wsBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-ws` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-ws`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_websocket/app.py
+++ b/examples/htmx_realtime_websocket/app.py
@@ -1,7 +1,5 @@
 import asyncio
-import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -22,41 +20,30 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "memory"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_websocket.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -66,13 +53,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -91,17 +78,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_ws_url": f"/queues/events/tasks/{result.id}"},
+        context={"task_id": task_id, "task_ws_url": f"/queues/events/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -121,18 +108,12 @@ queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, sse=False, history=25, heartbeat_interval=15),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],

--- a/examples/htmx_realtime_websocket/resources/main.ts
+++ b/examples/htmx_realtime_websocket/resources/main.ts
@@ -17,9 +17,9 @@ void import("htmx-ext-ws").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -61,16 +61,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -88,7 +99,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -96,12 +107,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: websocket-client-start
@@ -120,7 +137,7 @@ document.body.addEventListener("htmx:wsBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // WebSocket closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_websocket/resources/styles.css
+++ b/examples/htmx_realtime_websocket/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_websocket/templates/index.html
+++ b/examples/htmx_realtime_websocket/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_websocket/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_websocket/templates/partials/stream_mount.html
@@ -12,6 +12,5 @@
   aria-hidden="true"
   hx-ext="ws"
   ws-connect="{{ task_ws_url }}"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_websocket_advanced_alchemy/README.md
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/README.md
@@ -1,9 +1,8 @@
 # HTMX Realtime Queue Events - WebSocket (Advanced Alchemy Aiosqlite Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over a
-WebSocket. There is one control, a planet-styled **Restart** button that
-(re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over a WebSocket and
+shown on the page. The **Restart** button starts the demo task again.
 
 This copy is WebSocket-only. It uses the plugin-owned
 `/queues/events/tasks/{task_id}` endpoint so the transport stays visible in the
@@ -11,12 +10,14 @@ code. Queue persistence runs through Advanced Alchemy with `sqlite+aiosqlite`,
 and delivery uses memory Channels in the same process, so no external service
 is needed.
 
-This is a one-process topology: the SQLite queue database is persistence only;
-it does not make live Channels delivery available to a separate worker process.
+This setup uses one process. SQLite stores queue records, but it does not send
+live Channels events to a worker in another process.
 
 The queue database defaults to `queue-advanced-alchemy.db` under the example
-directory. The demo enables `create_all=True` and `create_schema=True` so the
-local schema is auto-created for a copyable app.
+directory. The demo passes the queue models' metadata to Advanced Alchemy and
+uses its `create_all=True` option for this local copy. The queue backend does
+not create tables itself. Production applications should use their normal
+metadata and migration workflow.
 
 ## Run It (dev server, hot reload)
 
@@ -27,7 +28,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_websocket_advanced_alchemy.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_websocket_advanced_alchemy.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -36,9 +37,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_websocket_advanced_alchemy.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -48,7 +47,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -64,38 +63,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx WebSocket extension owns the connection.** The swapped-in
+- **The htmx WebSocket extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="ws"` and
   `ws-connect="/queues/events/tasks/{task_id}"`, so htmx opens the socket
-  declaratively. Because each restart replaces the element, the previous socket
-  closes automatically: the connection lifecycle equals the swap lifecycle, so a
-  restart is a reconnect. This is the idiomatic pattern and replaces roughly
-  ninety lines of hand-rolled `WebSocket` code.
+  for you. Each restart replaces this element, so htmx closes the old socket and
+  opens a new one. This replaces roughly ninety lines of custom `WebSocket`
+  code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:wsBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-ws` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-ws`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_websocket_advanced_alchemy/app.py
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/app.py
@@ -1,9 +1,7 @@
 import asyncio
-import os
 from pathlib import Path
-from uuid import uuid4
 
-from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
 from litestar.channels.backends.memory import MemoryChannelsBackend
@@ -15,7 +13,7 @@ from litestar.template.config import TemplateConfig
 from litestar_vite import PathConfig, ViteConfig, VitePlugin
 
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
-from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackendConfig
 from litestar_queues.events import (
     EventBufferConfig,
     EventConfig,
@@ -24,44 +22,31 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "advanced-alchemy-aiosqlite"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
-QUEUE_DB_PATH = Path(
-    os.getenv("LITESTAR_QUEUES_EXAMPLE_ADVANCED_ALCHEMY_DB", str(EXAMPLE_ROOT / "queue-advanced-alchemy.db"))
-)
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
+QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-advanced-alchemy.db"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_websocket_advanced_alchemy.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -71,13 +56,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -96,17 +81,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_ws_url": f"/queues/events/tasks/{result.id}"},
+        context={"task_id": task_id, "task_ws_url": f"/queues/events/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -122,33 +107,30 @@ channels = ChannelsPlugin(
     subscriber_backlog_strategy="dropleft",
 )
 
+alchemy_config = SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{QUEUE_DB_PATH}", create_all=True)
+
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=AdvancedAlchemyBackendConfig(
-        sqlalchemy_config=SQLAlchemyAsyncConfig(
-            connection_string=f"sqlite+aiosqlite:///{QUEUE_DB_PATH}", create_all=True
-        ),
-        create_schema=True,
-    ),
+    queue_backend=SQLAlchemyBackendConfig(sqlalchemy_config=alchemy_config),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, sse=False, history=25, heartbeat_interval=15),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
-    plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
+    plugins=[
+        HTMXPlugin(),
+        channels,
+        SQLAlchemyPlugin(config=alchemy_config),
+        QueuePlugin(queue_config),
+        VitePlugin(config=vite_config),
+    ],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_websocket_advanced_alchemy/resources/main.ts
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/resources/main.ts
@@ -17,9 +17,9 @@ void import("htmx-ext-ws").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -61,16 +61,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -88,7 +99,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -96,12 +107,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: websocket-client-start
@@ -120,7 +137,7 @@ document.body.addEventListener("htmx:wsBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // WebSocket closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_websocket_advanced_alchemy/resources/styles.css
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_websocket_advanced_alchemy/templates/index.html
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_websocket_advanced_alchemy/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/templates/partials/stream_mount.html
@@ -12,6 +12,5 @@
   aria-hidden="true"
   hx-ext="ws"
   ws-connect="{{ task_ws_url }}"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_websocket_redis/README.md
+++ b/examples/htmx_realtime_websocket_redis/README.md
@@ -1,19 +1,18 @@
 # HTMX Realtime Queue Events - WebSocket (Redis Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over a
-WebSocket. There is one control, a planet-styled **Restart** button that
-(re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over a WebSocket and
+shown on the page. The **Restart** button starts the demo task again.
 
 This copy is WebSocket-only. It uses the plugin-owned
 `/queues/events/tasks/{task_id}` endpoint so the transport stays visible in the
 code. Queue persistence runs through Redis, and delivery uses memory Channels
 in the same process, so only Redis is needed as an external service.
 
-The default remains one process: Redis stores queue records and can provide
-worker wakeups, but it does not make the live Channels stream shared. A
-separate `litestar queues run` worker needs an explicit broker-backed Channels
-configuration; selecting `RedisBackendConfig` alone is not enough.
+By default, the example runs in one process. Redis stores queue records and can
+wake workers, but it does not share the live Channels stream. To run
+`litestar queues run` in another process, configure a shared Channels backend.
+`RedisBackendConfig` alone is not enough.
 
 Set `LITESTAR_QUEUES_EXAMPLE_REDIS_URL` when Redis is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
@@ -21,9 +20,9 @@ spinning up a Redis container.
 
 ## Shared Web and Worker Mode
 
-The opt-in shared topology uses Redis Streams for live Channels delivery. It
-keeps the configured event history (`history=25`) and is intentionally separate
-from Redis queue wakeup pub/sub:
+The optional shared setup uses Redis Streams for live Channels delivery. It
+keeps the configured event history (`history=25`) separate from the Redis
+pub/sub messages that wake queue workers:
 
 ```bash
 export LITESTAR_QUEUES_EXAMPLE_REDIS_URL=redis://127.0.0.1:16379/0
@@ -55,7 +54,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_websocket_redis.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_websocket_redis.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -64,9 +63,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_websocket_redis.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -76,7 +73,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -92,38 +89,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx WebSocket extension owns the connection.** The swapped-in
+- **The htmx WebSocket extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="ws"` and
   `ws-connect="/queues/events/tasks/{task_id}"`, so htmx opens the socket
-  declaratively. Because each restart replaces the element, the previous socket
-  closes automatically: the connection lifecycle equals the swap lifecycle, so a
-  restart is a reconnect. This is the idiomatic pattern and replaces roughly
-  ninety lines of hand-rolled `WebSocket` code.
+  for you. Each restart replaces this element, so htmx closes the old socket and
+  opens a new one. This replaces roughly ninety lines of custom `WebSocket`
+  code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:wsBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-ws` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-ws`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_websocket_redis/app.py
+++ b/examples/htmx_realtime_websocket_redis/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -26,14 +25,14 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "redis"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 REDIS_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_REDIS_URL", "redis://localhost:6379/0")
 REDIS_KEY_PREFIX = os.getenv(
     "LITESTAR_QUEUES_EXAMPLE_REDIS_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_websocket_redis"
@@ -44,31 +43,20 @@ CHANNELS_KEY_PREFIX = os.getenv(
 SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_websocket_redis.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -78,13 +66,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -103,17 +91,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_ws_url": f"/queues/events/tasks/{result.id}"},
+        context={"task_id": task_id, "task_ws_url": f"/queues/events/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -140,19 +128,13 @@ queue_config = QueueConfig(
     worker_graceful_shutdown_timeout=5,
     queue_backend=RedisBackendConfig(url=REDIS_URL, key_prefix=REDIS_KEY_PREFIX),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, sse=False, history=25, heartbeat_interval=15),
     **standalone_worker_options(),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 
 async def close_shared_channels() -> None:

--- a/examples/htmx_realtime_websocket_redis/resources/main.ts
+++ b/examples/htmx_realtime_websocket_redis/resources/main.ts
@@ -17,9 +17,9 @@ void import("htmx-ext-ws").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -61,16 +61,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -88,7 +99,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -96,12 +107,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: websocket-client-start
@@ -120,7 +137,7 @@ document.body.addEventListener("htmx:wsBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // WebSocket closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_websocket_redis/resources/styles.css
+++ b/examples/htmx_realtime_websocket_redis/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_websocket_redis/templates/index.html
+++ b/examples/htmx_realtime_websocket_redis/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_websocket_redis/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_websocket_redis/templates/partials/stream_mount.html
@@ -12,6 +12,5 @@
   aria-hidden="true"
   hx-ext="ws"
   ws-connect="{{ task_ws_url }}"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_websocket_sqlspec/README.md
+++ b/examples/htmx_realtime_websocket_sqlspec/README.md
@@ -1,9 +1,8 @@
 # HTMX Realtime Queue Events - WebSocket (SQLSpec Aiosqlite Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over a
-WebSocket. There is one control, a planet-styled **Restart** button that
-(re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over a WebSocket and
+shown on the page. The **Restart** button starts the demo task again.
 
 This copy is WebSocket-only. It uses the plugin-owned
 `/queues/events/tasks/{task_id}` endpoint so the transport stays visible in the
@@ -11,12 +10,13 @@ code. Queue persistence runs through SQLSpec with the Aiosqlite driver, and
 delivery uses memory Channels in the same process, so no external service is
 needed.
 
-This is a one-process topology: the SQLite queue database is persistence only;
-it does not make live Channels delivery available to a separate worker process.
+This setup uses one process. SQLite stores queue records, but it does not send
+live Channels events to a worker in another process.
 
 The queue database defaults to `queue-sqlspec.db` under the example directory.
-`SQLSpecBackendConfig` sets `create_schema=False` and `run_migrations=True`, so
-startup calls the SQLSpec migration path for the local queue schema.
+The example registers the queue migration with SQLSpec and runs it during
+startup. Production applications should register it before their normal
+SQLSpec migration command and run migrations during deployment.
 
 ## Run It (dev server, hot reload)
 
@@ -27,7 +27,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_websocket_sqlspec.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_websocket_sqlspec.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -36,9 +36,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_websocket_sqlspec.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -48,7 +46,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -64,38 +62,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx WebSocket extension owns the connection.** The swapped-in
+- **The htmx WebSocket extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="ws"` and
   `ws-connect="/queues/events/tasks/{task_id}"`, so htmx opens the socket
-  declaratively. Because each restart replaces the element, the previous socket
-  closes automatically: the connection lifecycle equals the swap lifecycle, so a
-  restart is a reconnect. This is the idiomatic pattern and replaces roughly
-  ninety lines of hand-rolled `WebSocket` code.
+  for you. Each restart replaces this element, so htmx closes the old socket and
+  opens a new one. This replaces roughly ninety lines of custom `WebSocket`
+  code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:wsBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-ws` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-ws`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_websocket_sqlspec/app.py
+++ b/examples/htmx_realtime_websocket_sqlspec/app.py
@@ -1,7 +1,5 @@
 import asyncio
-import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -24,43 +22,33 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "sqlspec-aiosqlite"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
-QUEUE_DB_PATH = Path(os.getenv("LITESTAR_QUEUES_EXAMPLE_SQLSPEC_DB", str(EXAMPLE_ROOT / "queue-sqlspec.db")))
-sqlspec_config = AiosqliteConfig(connection_config={"database": str(QUEUE_DB_PATH)})
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
 
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
+QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-sqlspec.db"
+sqlspec_config = AiosqliteConfig(connection_config={"database": str(QUEUE_DB_PATH)})
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_websocket_sqlspec.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -70,13 +58,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -95,17 +83,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_ws_url": f"/queues/events/tasks/{result.id}"},
+        context={"task_id": task_id, "task_ws_url": f"/queues/events/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -124,25 +112,26 @@ channels = ChannelsPlugin(
 queue_config = QueueConfig(
     # Demo apps exit fast on Ctrl+C instead of draining the minute-long job.
     worker_graceful_shutdown_timeout=5,
-    queue_backend=SQLSpecBackendConfig(config=sqlspec_config, create_schema=False, run_migrations=True),
+    queue_backend=SQLSpecBackendConfig(config=sqlspec_config),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, sse=False, history=25, heartbeat_interval=15),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
+
+
+async def bootstrap_queue_schema() -> None:
+    """Run the normal SQLSpec migration path for this local demo."""
+    await sqlspec_config.migrate_up(echo=False)
+
 
 app = Litestar(
     route_handlers=[index, status_json, restart_demo],
     template_config=TemplateConfig(directory=EXAMPLE_ROOT / "templates", engine=JinjaTemplateEngine),
     signature_namespace={"NamedDependency": NamedDependency},
+    on_startup=[bootstrap_queue_schema],
     plugins=[HTMXPlugin(), channels, QueuePlugin(queue_config), VitePlugin(config=vite_config)],
 )
 # -- docs-app-config-end --

--- a/examples/htmx_realtime_websocket_sqlspec/resources/main.ts
+++ b/examples/htmx_realtime_websocket_sqlspec/resources/main.ts
@@ -17,9 +17,9 @@ void import("htmx-ext-ws").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -61,16 +61,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -88,7 +99,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -96,12 +107,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: websocket-client-start
@@ -120,7 +137,7 @@ document.body.addEventListener("htmx:wsBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // WebSocket closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_websocket_sqlspec/resources/styles.css
+++ b/examples/htmx_realtime_websocket_sqlspec/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_websocket_sqlspec/templates/index.html
+++ b/examples/htmx_realtime_websocket_sqlspec/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_websocket_sqlspec/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_websocket_sqlspec/templates/partials/stream_mount.html
@@ -12,6 +12,5 @@
   aria-hidden="true"
   hx-ext="ws"
   ws-connect="{{ task_ws_url }}"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_websocket_valkey/README.md
+++ b/examples/htmx_realtime_websocket_valkey/README.md
@@ -1,19 +1,18 @@
 # HTMX Realtime Queue Events - WebSocket (Valkey Backend)
 
-A cinematic, full-screen "space opera" page: an animated opening crawl of text
-receding into an animated galaxy starfield, fed live by queue task events over a
-WebSocket. There is one control, a planet-styled **Restart** button that
-(re)enqueues the roughly one-minute demo job and restarts the crawl.
+This is a small app that shows realtime messages moving from a queue task to
+the frontend. Each update is pushed from the backend over a WebSocket and
+shown on the page. The **Restart** button starts the demo task again.
 
 This copy is WebSocket-only. It uses the plugin-owned
 `/queues/events/tasks/{task_id}` endpoint so the transport stays visible in the
 code. Queue persistence runs through Valkey, and delivery uses memory Channels
 in the same process, so only Valkey is needed as an external service.
 
-The default remains one process: Valkey stores queue records and can provide
-worker wakeups, but it does not make the live Channels stream shared. A
-separate `litestar queues run` worker needs an explicit broker-backed Channels
-configuration; selecting `ValkeyBackendConfig` alone is not enough.
+By default, the example runs in one process. Valkey stores queue records and
+can wake workers, but it does not share the live Channels stream. To run
+`litestar queues run` in another process, configure a shared Channels backend.
+`ValkeyBackendConfig` alone is not enough.
 
 Set `LITESTAR_QUEUES_EXAMPLE_VALKEY_URL` when Valkey is not available at
 `redis://localhost:6379/0`. See the repository's local infra helpers for
@@ -21,9 +20,9 @@ spinning up a Valkey container.
 
 ## Shared Web and Worker Mode
 
-The opt-in shared topology uses Litestar's Redis Channels Streams backend with
-the Valkey client. It keeps the configured event history (`history=25`) and is
-intentionally separate from Valkey queue wakeup pub/sub:
+The optional shared setup uses Litestar's Redis Channels Streams backend with
+the Valkey client. It keeps the configured event history (`history=25`) separate
+from the Valkey pub/sub messages that wake queue workers:
 
 ```bash
 export LITESTAR_QUEUES_EXAMPLE_VALKEY_URL=redis://127.0.0.1:16380/0
@@ -56,7 +55,7 @@ uv sync --extra examples --group dev
 LITESTAR_APP=examples.htmx_realtime_websocket_valkey.app:app \
 uv run litestar assets install
 LITESTAR_APP=examples.htmx_realtime_websocket_valkey.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -65,9 +64,7 @@ For a faster local run:
 
 ```bash
 LITESTAR_APP=examples.htmx_realtime_websocket_valkey.app:app \
-LITESTAR_QUEUES_EXAMPLE_VITE_DEV=1 \
-LITESTAR_QUEUES_EXAMPLE_STEPS=4 \
-LITESTAR_QUEUES_EXAMPLE_STEP_DELAY=0.5 \
+VITE_DEV_MODE=1 \
 LITESTAR_PORT=8000 \
 uv run litestar run --reload
 ```
@@ -77,7 +74,7 @@ Restart.
 
 ## Run It (without the dev server)
 
-`LITESTAR_QUEUES_EXAMPLE_VITE_DEV` defaults to off. Without it, the page loads
+`VITE_DEV_MODE` defaults to off. Without it, the page loads
 built assets from the manifest, so `GET /` returns 500 until you build them
 once. Build, then run:
 
@@ -93,38 +90,47 @@ uv run litestar run
 
 ## How It Works
 
+### Repeated clicks
+
+The demo enqueues the task with `key="demo:current"`. If you click
+**Restart** while that task is pending or running, the queue returns the
+same task instead of starting a second copy. The page shows that the task is
+already running. After the task finishes, the next click creates a new task.
+Remove the key, or use a different key for each job, when concurrent runs are
+what your application needs.
+
 - **One button, no forms.** `hx-post="/demo/restart"` lives directly on the
   planet `<button>`. Clicking it enqueues the demo job and swaps the returned
   `partials/stream_mount.html` into `#stream-mount`.
-- **The htmx WebSocket extension owns the connection.** The swapped-in
+- **The htmx WebSocket extension manages the connection.** The swapped-in
   `#stream-mount` element carries `hx-ext="ws"` and
   `ws-connect="/queues/events/tasks/{task_id}"`, so htmx opens the socket
-  declaratively. Because each restart replaces the element, the previous socket
-  closes automatically: the connection lifecycle equals the swap lifecycle, so a
-  restart is a reconnect. This is the idiomatic pattern and replaces roughly
-  ninety lines of hand-rolled `WebSocket` code.
+  for you. Each restart replaces this element, so htmx closes the old socket and
+  opens a new one. This replaces roughly ninety lines of custom `WebSocket`
+  code.
 - **One small JS adapter.** Queue events are JSON, so the extension cannot swap
   them as HTML. `resources/main.ts` listens for `htmx:wsBeforeMessage`, parses
-  the frame, ignores `{"type":"ping"}` heartbeats, appends a line to the crawl,
-  flips the readout to gold on `task.completed`, and calls `preventDefault()` so
-  htmx never attempts an HTML swap. On the `queue-demo:started` trigger event
-  (fired by `HTMXTemplate` after the swap) it clears the crawl for the new run.
+  the frame, ignores `{"type":"ping"}` heartbeats, appends the event to the page,
+  turns the readout gold on `task.completed`, and calls `preventDefault()` so
+  htmx does not treat the JSON as HTML. After `HTMXTemplate` swaps the element,
+  its `queue-demo:started` event resets the display for the task returned by
+  the backend.
 - **htmx wiring.** `resources/main.ts` imports htmx, publishes it as
-  `window.htmx`, calls `registerHtmxExtension()`, then dynamically imports
-  `htmx-ext-ws` so the extension sees the global. htmx 2's ESM build does not
-  attach itself to `window`, so this ordering is required.
+  `window.htmx`, calls `registerHtmxExtension()`, and then imports
+  `htmx-ext-ws`. This order is required because the htmx 2 ESM build does not
+  add itself to `window`.
 - **Litestar Vite JSON template.** A muted corner caption uses
   `hx-ext="litestar"` with `hx-swap="json"` and `<template ls-if>` to render the
   backend name from `GET /demo/status`.
 
-The `QueueConfig` enables buffered events and the task event stream only
-(`EventStreamConfig(scopes={"task"})`). Its `channel_authorizer` allows every
-channel; this is a demo-only shortcut that suppresses the missing-auth warning
-for a local single-process app. Real deployments must authorize stream access.
+`QueueConfig` buffers events and enables only the task event stream
+(`EventStreamConfig(scopes={"task"})`). This local demo does not add
+authentication to its stream. Real deployments must protect the stream route
+and check who may access each task.
 
 ## External Publisher
 
-`scripts/external_publisher.py` shows the shape for non-Litestar publishers via
-`create_event_producer`. The script deliberately raises until you replace the
-placeholder config with a shared Redis or SQLSpec Channels backend. The memory
-Channels backend cannot bridge two separate processes.
+`scripts/external_publisher.py` shows how code outside Litestar can publish with
+`create_event_producer`. It raises an error until you replace its placeholder
+with a shared Redis or SQLSpec Channels backend. The memory Channels backend
+cannot connect separate processes.

--- a/examples/htmx_realtime_websocket_valkey/app.py
+++ b/examples/htmx_realtime_websocket_valkey/app.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 from pathlib import Path
-from uuid import uuid4
 
 from litestar import Litestar, get, post
 from litestar.channels import ChannelsPlugin
@@ -26,14 +25,14 @@ from litestar_queues.events import (
     publish_task_log,
 )
 
-__all__ = ("allow_demo_channel", "index", "restart_demo", "run_crawl", "status_json")
+__all__ = ("index", "restart_demo", "run_crawl", "status_json")
 
 
 EXAMPLE_ROOT = Path(__file__).parent
 BACKEND_NAME = "valkey"
-DEMO_STEPS = int(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEPS", "6"))
-DEMO_STEP_DELAY = float(os.getenv("LITESTAR_QUEUES_EXAMPLE_STEP_DELAY", "5"))
-VITE_DEV_MODE = os.getenv("LITESTAR_QUEUES_EXAMPLE_VITE_DEV", "0") == "1"
+DEMO_STEPS = 6
+DEMO_STEP_DELAY = 1
+DEMO_KEY = "demo:current"
 VALKEY_URL = os.getenv("LITESTAR_QUEUES_EXAMPLE_VALKEY_URL", "redis://localhost:6379/0")
 VALKEY_KEY_PREFIX = os.getenv(
     "LITESTAR_QUEUES_EXAMPLE_VALKEY_KEY_PREFIX", "litestar_queues:examples:htmx_realtime_websocket_valkey"
@@ -44,31 +43,20 @@ CHANNELS_KEY_PREFIX = os.getenv(
 SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "1"
 
 CRAWL_LINES = (
-    "You clicked restart, so the app queued a background job.",
-    "A worker picked up the job and started running it.",
-    'ctx.event("here") - the job sent this line from inside itself.',
-    "Every update streams live to this page.",
-    "The browser just listens - no polling, no refresh.",
-    "When the job finishes, a final event marks it complete.",
+    "The task started.",
+    "The task sent an event from the backend.",
+    "The task is sleeping before the next event.",
+    "The task sent another event.",
+    "The page received the event.",
+    "The task finished.",
 )
-
-
-def allow_demo_channel(*_: object) -> bool:
-    """Allow every stream channel in this local demo app.
-
-    Returns:
-        Always ``True`` for the demo-only stream authorizer.
-    """
-    return True
 
 
 # -- docs-task-start --
 @task("examples.htmx_realtime_websocket_valkey.crawl", queue="demo", retries=0, timeout=90)
-async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict[str, str]:
+async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     ctx = _task_context
-    await publish_task_log(
-        "Job started - everything below comes from the job", payload={"job_id": job_id}, immediate=True
-    )
+    await publish_task_log("The task started", payload={"task_id": ctx.task_id}, immediate=True)
 
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
@@ -78,13 +66,13 @@ async def run_crawl(job_id: str, *, _task_context: TaskExecutionContext) -> dict
         await ctx.event(
             "task.event",
             message=message,
-            payload={"job_id": job_id, "line": message, "step": step},
+            payload={"task_id": ctx.task_id, "line": message, "step": step},
             immediate=step == DEMO_STEPS,
         )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("Job finished", payload={"job_id": job_id}, immediate=True)
-    return {"job_id": job_id, "status": "complete"}
+    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
+    return {"task_id": ctx.task_id, "status": "complete"}
 
 
 # -- docs-task-end --
@@ -103,17 +91,17 @@ async def status_json() -> dict[str, str]:
 
 @post("/demo/restart")
 async def restart_demo(queue_service: NamedDependency[QueueService]) -> Template:
-    job_id = uuid4().hex[:8]
-    result = await queue_service.enqueue(
-        run_crawl, job_id, key=f"demo:{job_id}", description="Run the HTMX realtime queue event demo"
-    )
+    existing = await queue_service.get_queue_backend().get_task_by_key(DEMO_KEY)
+    result = await queue_service.enqueue(run_crawl, key=DEMO_KEY, description="Run the HTMX realtime queue event demo")
+    task_id = str(result.id)
+    reused = existing is not None and not existing.is_terminal and existing.id == result.id
     return HTMXTemplate(
         template_name="partials/stream_mount.html",
-        context={"job_id": job_id, "task_id": str(result.id), "task_ws_url": f"/queues/events/tasks/{result.id}"},
+        context={"task_id": task_id, "task_ws_url": f"/queues/events/tasks/{result.id}"},
         push_url=False,
         re_target="#stream-mount",
         trigger_event="queue-demo:started",
-        params={"jobId": job_id, "taskId": str(result.id)},
+        params={"taskId": task_id, "reused": reused},
         after="swap",
     )
 
@@ -140,19 +128,13 @@ queue_config = QueueConfig(
     worker_graceful_shutdown_timeout=5,
     queue_backend=ValkeyBackendConfig(url=VALKEY_URL, key_prefix=VALKEY_KEY_PREFIX),
     event=EventConfig(channels_backend=channels, buffer=EventBufferConfig(buffer_size=8, flush_interval=0.2)),
-    # A demo-only allow-all authorizer: it suppresses the missing-auth warning
-    # for this local single-process example. Real deployments must authorize.
-    # Each demo registers only its own transport so a stale tab from the other
+    # The demo registers only its own transport so a stale tab from another
     # example cannot silently reconnect to this app's routes.
-    event_stream=EventStreamConfig(
-        scopes={"task"}, sse=False, history=25, heartbeat_interval=15, channel_authorizer=allow_demo_channel
-    ),
+    event_stream=EventStreamConfig(scopes={"task"}, sse=False, history=25, heartbeat_interval=15),
     **standalone_worker_options(),
 )
 
-vite_config = ViteConfig(
-    mode="htmx", dev_mode=VITE_DEV_MODE, paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources")
-)
+vite_config = ViteConfig(mode="htmx", paths=PathConfig(root=EXAMPLE_ROOT, resource_dir="resources"))
 
 
 async def close_shared_channels() -> None:

--- a/examples/htmx_realtime_websocket_valkey/resources/main.ts
+++ b/examples/htmx_realtime_websocket_valkey/resources/main.ts
@@ -17,9 +17,9 @@ void import("htmx-ext-ws").then(() => htmx.process(document.body))
 
 const MAX_LINES = 40
 // After the final event, wait for the last lines to drift out of view, then
-// return to the idle hint unless another mission starts first.
+// return to the idle hint unless another task starts first.
 const IDLE_DELAY_MS = 45_000
-const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to queue a background job."
+const IDLE_TEXT = document.querySelector<HTMLElement>("#crawl-lines p")?.textContent ?? "Press restart to send a background task."
 let idleTimer: ReturnType<typeof setTimeout> | null = null
 
 type QueueEvent = {
@@ -61,16 +61,27 @@ function appendCrawlLine(event: QueueEvent): void {
   while (target.children.length > MAX_LINES) target.firstElementChild?.remove()
 }
 
+function markBackendMessage(event: QueueEvent): void {
+  const status = document.querySelector<HTMLElement>("#delivery-status")
+  const label = document.querySelector<HTMLElement>("#delivery-label")
+  if (!status || !label) return
+  label.textContent = `Backend message received · ${event.type}`
+  status.classList.remove("received")
+  void status.offsetHeight
+  status.classList.add("received")
+}
+
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
 // cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
 // back-to-back duplicates (progress and custom events share a message), and
-// append a crawl line. The terminal event only flips the readout — the task's
+// append the event line. The terminal event only flips the readout — the task's
 // own closing log line is the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return
+  markBackendMessage(event)
   if (event.type === "task.completed") {
-    setReadout("Mission complete", true)
+    setReadout("Task complete", true)
     if (idleTimer) clearTimeout(idleTimer)
     idleTimer = setTimeout(goIdle, IDLE_DELAY_MS)
     return
@@ -88,7 +99,7 @@ function goIdle(): void {
   setReadout("Awaiting launch")
 }
 
-function resetCrawl(jobId?: string): void {
+function resetCrawl(taskId?: string, reused = false): void {
   if (idleTimer) clearTimeout(idleTimer)
   idleTimer = null
   const plane = document.querySelector<HTMLElement>("#crawl-lines")
@@ -96,12 +107,18 @@ function resetCrawl(jobId?: string): void {
     plane.classList.remove("idle")
     plane.replaceChildren()
     // The crawl keyframe is one-shot and time-based; restart it so every
-    // mission's lines enter from the bottom instead of mid-flight.
+    // task's lines enter from the bottom instead of mid-flight.
     plane.style.animation = "none"
     void plane.offsetHeight
     plane.style.animation = ""
   }
-  setReadout(jobId ? `Mission ${jobId} underway` : "Mission underway")
+  setReadout(
+    taskId
+      ? reused
+        ? `Task ${taskId} is already running`
+        : `Task ${taskId} queued`
+      : "Task queued",
+  )
 }
 
 // docs: websocket-client-start
@@ -120,7 +137,7 @@ document.body.addEventListener("htmx:wsBeforeMessage", (event) => {
 // replaces #stream-mount. Swapping the element reconnects the stream (the old
 // WebSocket closes with the removed element); reset the crawl to match.
 document.body.addEventListener("queue-demo:started", (event) => {
-  const detail = (event as CustomEvent<{ jobId?: string }>).detail
-  resetCrawl(detail?.jobId)
+  const detail = (event as CustomEvent<{ taskId?: string; reused?: boolean }>).detail
+  resetCrawl(detail?.taskId, detail?.reused === true)
 })
 // docs: stream-adapter-end

--- a/examples/htmx_realtime_websocket_valkey/resources/styles.css
+++ b/examples/htmx_realtime_websocket_valkey/resources/styles.css
@@ -38,7 +38,7 @@ button {
     var(--bg);
 }
 
-/* --- Galaxy starfield: three parallax layers of hard-coded box-shadow dots. --- */
+/* --- Decorative background with three parallax layers. --- */
 .starfield {
   position: absolute;
   inset: 0;
@@ -196,6 +196,40 @@ button {
 @keyframes telemetry-pulse {
   0%, 100% { opacity: 0.35; }
   50% { opacity: 1; }
+}
+
+/* A short pulse makes each backend-delivered message visible even when its
+   text is already familiar. */
+.delivery-status {
+  position: absolute;
+  left: 2rem;
+  bottom: 4.25rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.delivery-pulse {
+  display: inline-block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 0 0 rgb(237 182 65 / 75%);
+}
+
+.delivery-status.received .delivery-pulse {
+  animation: message-pulse 700ms ease-out;
+}
+
+@keyframes message-pulse {
+  0% { box-shadow: 0 0 0 0 rgb(237 182 65 / 75%); transform: scale(0.8); }
+  55% { box-shadow: 0 0 0 0.85rem rgb(237 182 65 / 0%); transform: scale(1.15); }
+  100% { box-shadow: 0 0 0 0 rgb(237 182 65 / 0%); transform: scale(1); }
 }
 
 /* --- Brand mark: whisper-quiet, top-left. --- */
@@ -366,7 +400,8 @@ button {
   .nebula,
   .planet-orbit,
   .planet-launching,
-  .telemetry-dot {
+  .telemetry-dot,
+  .delivery-status.received .delivery-pulse {
     animation: none;
   }
 

--- a/examples/htmx_realtime_websocket_valkey/templates/index.html
+++ b/examples/htmx_realtime_websocket_valkey/templates/index.html
@@ -33,13 +33,18 @@
     <template ls-else><span>{{ backend_name }}</span></template>
   </div>
 
-  <div class="crawl-perspective" aria-live="polite" aria-label="Task event crawl">
+  <div class="crawl-perspective" aria-live="polite" aria-label="Task events">
     <div id="crawl-lines" class="crawl-plane idle">
-      <p>Press restart to queue a background job and watch it report back.</p>
+      <p>Press restart to send a background task and watch its messages arrive.</p>
     </div>
   </div>
 
-  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live telemetry · every line is published by the running job</p>
+  <p class="telemetry-caption"><span class="telemetry-dot" aria-hidden="true"></span>Live messages · each update is pushed from the backend job</p>
+
+  <div id="delivery-status" class="delivery-status" role="status" aria-live="polite">
+    <span class="delivery-pulse" aria-hidden="true"></span>
+    <span id="delivery-label">Waiting for a backend message</span>
+  </div>
 
   <p id="job-readout" class="readout">Awaiting launch</p>
 
@@ -52,7 +57,7 @@
     hx-indicator="this"
     hx-disabled-elt="this"
     hx-sync="this:replace"
-    aria-label="Restart the demo queue job and crawl"
+    aria-label="Restart the demo queue task"
   >
     <span class="planet-orbit" aria-hidden="true"><span class="planet-satellite"></span></span>
     <span class="planet-label">Restart</span>

--- a/examples/htmx_realtime_websocket_valkey/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_websocket_valkey/templates/partials/stream_mount.html
@@ -12,6 +12,5 @@
   aria-hidden="true"
   hx-ext="ws"
   ws-connect="{{ task_ws_url }}"
-  data-job-id="{{ job_id }}"
   data-task-id="{{ task_id }}"
 ></div>

--- a/src/litestar_queues/backends/advanced_alchemy/__init__.py
+++ b/src/litestar_queues/backends/advanced_alchemy/__init__.py
@@ -2,7 +2,14 @@
 
 from litestar_queues.backends.advanced_alchemy.backend import AdvancedAlchemyQueueBackend
 from litestar_queues.backends.advanced_alchemy.config import AdvancedAlchemyBackendConfig
-from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
-from litestar_queues.backends.advanced_alchemy.models import QueueTaskModel
+from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
+from litestar_queues.backends.advanced_alchemy.models import QueueEventLogModel, QueueTaskModel
 
-__all__ = ("AdvancedAlchemyBackendConfig", "AdvancedAlchemyQueueBackend", "QueueTaskModel", "QueueTaskModelMixin")
+__all__ = (
+    "AdvancedAlchemyBackendConfig",
+    "AdvancedAlchemyQueueBackend",
+    "QueueEventLogModel",
+    "QueueEventLogModelMixin",
+    "QueueTaskModel",
+    "QueueTaskModelMixin",
+)

--- a/src/litestar_queues/backends/advanced_alchemy/__init__.py
+++ b/src/litestar_queues/backends/advanced_alchemy/__init__.py
@@ -1,15 +1,15 @@
 """Advanced Alchemy queue backend public exports."""
 
-from litestar_queues.backends.advanced_alchemy.backend import AdvancedAlchemyQueueBackend
-from litestar_queues.backends.advanced_alchemy.config import AdvancedAlchemyBackendConfig
+from litestar_queues.backends.advanced_alchemy.backend import SQLAlchemyBackend
+from litestar_queues.backends.advanced_alchemy.config import SQLAlchemyBackendConfig
 from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 from litestar_queues.backends.advanced_alchemy.models import QueueEventLogModel, QueueTaskModel
 
 __all__ = (
-    "AdvancedAlchemyBackendConfig",
-    "AdvancedAlchemyQueueBackend",
     "QueueEventLogModel",
     "QueueEventLogModelMixin",
     "QueueTaskModel",
     "QueueTaskModelMixin",
+    "SQLAlchemyBackend",
+    "SQLAlchemyBackendConfig",
 )

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -11,7 +11,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError as SQLAlchemyIntegrityError
 
-from litestar_queues.backends.advanced_alchemy.config import AdvancedAlchemyBackendConfig
+from litestar_queues.backends.advanced_alchemy.config import SQLAlchemyBackendConfig
 from litestar_queues.backends.advanced_alchemy.event_log import AdvancedAlchemyQueueEventLog
 from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 from litestar_queues.backends.advanced_alchemy.service import QueueEventLogService, QueueTaskService
@@ -37,14 +37,14 @@ if TYPE_CHECKING:
     )
     from litestar_queues.observability import QueueObservabilityRuntimeProtocol
 
-__all__ = ("AdvancedAlchemyQueueBackend",)
+__all__ = ("SQLAlchemyBackend",)
 
 _POSTGRES_NOTIFY_BACKEND = "postgres-listen-notify"
 _POSTGRES_NOTIFY_PAYLOAD = "tasks"
 
 
-class AdvancedAlchemyQueueBackend(BaseQueueBackend):
-    """Advanced Alchemy-backed queue backend."""
+class SQLAlchemyBackend(BaseQueueBackend):
+    """SQLAlchemy queue backend using Advanced Alchemy services."""
 
     _model_class: "type[QueueTaskModelMixin]"
     _service_class: 'type["QueueTaskService"]'
@@ -52,7 +52,6 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
     _event_log_service_class: 'type["QueueEventLogService"]'
 
     __slots__ = (
-        "_create_schema",
         "_event_log",
         "_event_log_model_class",
         "_event_log_service_class",
@@ -69,17 +68,16 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
     )
 
     def __init__(
-        self, config: "QueueConfig | None" = None, *, backend_config: "AdvancedAlchemyBackendConfig | None" = None
+        self, config: "QueueConfig | None" = None, *, backend_config: "SQLAlchemyBackendConfig | None" = None
     ) -> "None":
         super().__init__(config=config)
-        backend_config = backend_config or AdvancedAlchemyBackendConfig()
+        backend_config = backend_config or SQLAlchemyBackendConfig()
         self._sqlalchemy_config = backend_config.sqlalchemy_config
         self._heartbeat_session_maker = backend_config.heartbeat_session_maker
         self._model_class, self._service_class = self._resolve_model_classes(backend_config.model_class)
         self._event_log_model_class, self._event_log_service_class = self._resolve_event_log_model_classes(
             backend_config.event_log_model_class
         )
-        self._create_schema = backend_config.create_schema
         self._notifications = backend_config.notifications
         self._notification_channel = backend_config.notification_channel
         self._event_poll_interval = backend_config.event_poll_interval
@@ -108,8 +106,6 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         if self._opened:
             return True
         self._ensure_configured()
-        if self._create_schema:
-            await self.create_schema()
         self._opened = True
         return True
 
@@ -121,21 +117,6 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         if self._event_log is not None:
             await self._event_log.flush_events()
         self._opened = False
-
-    async def create_schema(self) -> "None":
-        """Create the queue task table and enabled event-history table."""
-        self._ensure_configured()
-        sqlalchemy_config = self._sqlalchemy_config
-        if sqlalchemy_config is None:
-            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config."
-            raise QueueConfigurationError(msg)
-        engine = sqlalchemy_config.get_engine()
-        table = self._model_class.__dict__["__table__"]
-        async with engine.begin() as connection:
-            await connection.run_sync(table.create, checkfirst=True)
-            if self._event_log_enabled():
-                event_log_table = self._event_log_model_class.__dict__["__table__"]
-                await connection.run_sync(event_log_table.create, checkfirst=True)
 
     def get_event_log(self, config: "EventLogConfig") -> "QueueEventLog | None":
         """Return Advanced Alchemy-managed queue event history when enabled."""
@@ -365,12 +346,12 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
 
     def _ensure_configured(self) -> "None":
         if self._sqlalchemy_config is None:
-            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config."
+            msg = "SQLAlchemyBackend requires sqlalchemy_config."
             raise QueueConfigurationError(msg)
 
     def _ensure_opened(self) -> "None":
         if not self._opened:
-            msg = "AdvancedAlchemyQueueBackend.open() must be called before using the backend."
+            msg = "SQLAlchemyBackend.open() must be called before using the backend."
             raise RuntimeError(msg)
 
     def _driver_name(self) -> "str | None":
@@ -390,7 +371,7 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
     def _create_notification_listener(self) -> "Any":
         sqlalchemy_config = self._sqlalchemy_config
         if sqlalchemy_config is None or sqlalchemy_config.connection_string is None:
-            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config for PostgreSQL notifications."
+            msg = "SQLAlchemyBackend requires sqlalchemy_config for PostgreSQL notifications."
             raise QueueConfigurationError(msg)
         url = make_url(sqlalchemy_config.connection_string).set(drivername="postgresql")
         return _AsyncpgNotificationListener(
@@ -400,7 +381,7 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
     async def _send_notification_marker(self) -> "None":
         sqlalchemy_config = self._sqlalchemy_config
         if sqlalchemy_config is None:
-            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config for PostgreSQL notifications."
+            msg = "SQLAlchemyBackend requires sqlalchemy_config for PostgreSQL notifications."
             raise QueueConfigurationError(msg)
         engine = sqlalchemy_config.get_engine()
         async with engine.begin() as connection:
@@ -430,17 +411,17 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         self, model_class: "type[object] | None"
     ) -> 'tuple[type[QueueTaskModelMixin], type["QueueTaskService"]]':
         if model_class is None:
-            msg = "AdvancedAlchemyBackendConfig.model_class must inherit QueueTaskModelMixin."
+            msg = "SQLAlchemyBackendConfig.model_class must inherit QueueTaskModelMixin."
             raise QueueConfigurationError(msg)
         try:
             valid_model = issubclass(model_class, QueueTaskModelMixin)
         except TypeError:
             valid_model = False
         if not valid_model:
-            msg = "AdvancedAlchemyBackendConfig.model_class must inherit QueueTaskModelMixin."
+            msg = "SQLAlchemyBackendConfig.model_class must inherit QueueTaskModelMixin."
             raise QueueConfigurationError(msg)
         if "__tablename__" not in model_class.__dict__:
-            msg = "AdvancedAlchemyBackendConfig.model_class must declare __tablename__."
+            msg = "SQLAlchemyBackendConfig.model_class must declare __tablename__."
             raise QueueConfigurationError(msg)
         typed_model = cast("type[QueueTaskModelMixin]", model_class)
         mapper = cast("Any", sqlalchemy_inspect(typed_model))
@@ -469,7 +450,7 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         } - {property_.key for property_ in mapper.column_attrs}
         if missing_columns:
             columns = ", ".join(sorted(missing_columns))
-            msg = f"AdvancedAlchemyBackendConfig.model_class is missing queue columns: {columns}."
+            msg = f"SQLAlchemyBackendConfig.model_class is missing queue columns: {columns}."
             raise QueueConfigurationError(msg)
         return typed_model, QueueTaskService.for_model(typed_model)
 
@@ -477,17 +458,17 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         self, model_class: "type[object] | None"
     ) -> 'tuple[type[QueueEventLogModelMixin], type["QueueEventLogService"]]':
         if model_class is None:
-            msg = "AdvancedAlchemyBackendConfig.event_log_model_class must inherit QueueEventLogModelMixin."
+            msg = "SQLAlchemyBackendConfig.event_log_model_class must inherit QueueEventLogModelMixin."
             raise QueueConfigurationError(msg)
         try:
             valid_model = issubclass(model_class, QueueEventLogModelMixin)
         except TypeError:
             valid_model = False
         if not valid_model:
-            msg = "AdvancedAlchemyBackendConfig.event_log_model_class must inherit QueueEventLogModelMixin."
+            msg = "SQLAlchemyBackendConfig.event_log_model_class must inherit QueueEventLogModelMixin."
             raise QueueConfigurationError(msg)
         if "__tablename__" not in model_class.__dict__:
-            msg = "AdvancedAlchemyBackendConfig.event_log_model_class must declare __tablename__."
+            msg = "SQLAlchemyBackendConfig.event_log_model_class must declare __tablename__."
             raise QueueConfigurationError(msg)
         typed_model = cast("type[QueueEventLogModelMixin]", model_class)
         mapper = cast("Any", sqlalchemy_inspect(typed_model))
@@ -512,7 +493,7 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         } - {property_.key for property_ in mapper.column_attrs}
         if missing_columns:
             columns = ", ".join(sorted(missing_columns))
-            msg = f"AdvancedAlchemyBackendConfig.event_log_model_class is missing event-log columns: {columns}."
+            msg = f"SQLAlchemyBackendConfig.event_log_model_class is missing event-log columns: {columns}."
             raise QueueConfigurationError(msg)
         return typed_model, QueueEventLogService.for_model(typed_model)
 
@@ -525,7 +506,7 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         self._ensure_configured()
         sqlalchemy_config = self._sqlalchemy_config
         if sqlalchemy_config is None:
-            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config."
+            msg = "SQLAlchemyBackend requires sqlalchemy_config."
             raise QueueConfigurationError(msg)
         session_maker = sqlalchemy_config.create_session_maker()
         async with session_maker() as session:
@@ -621,7 +602,7 @@ class _AsyncpgNotificationListener:
         try:
             asyncpg = import_module("asyncpg")
         except ImportError as exc:
-            msg = "AdvancedAlchemyBackendConfig.notifications=True for postgresql+asyncpg requires asyncpg."
+            msg = "SQLAlchemyBackendConfig.notifications=True for postgresql+asyncpg requires asyncpg."
             raise QueueConfigurationError(msg) from exc
         return await cast("Any", asyncpg).connect(dsn=self._dsn)
 

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from litestar_queues.config import QueueConfig
+    from litestar_queues.events import EventLogConfig, QueueEventLog
     from litestar_queues.models import (
         EnqueueSpec,
         HeartbeatTouch,
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
         StaleTaskRecoveryResult,
     )
     from litestar_queues.observability import QueueObservabilityRuntimeProtocol
-    from litestar_queues.events import EventLogConfig, QueueEventLog
 
 __all__ = ("AdvancedAlchemyQueueBackend",)
 
@@ -53,10 +53,10 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
 
     __slots__ = (
         "_create_schema",
-        "_event_poll_interval",
         "_event_log",
         "_event_log_model_class",
         "_event_log_service_class",
+        "_event_poll_interval",
         "_heartbeat_session_maker",
         "_model_class",
         "_notification_channel",
@@ -343,7 +343,7 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         notified = await listener.wait(wait_timeout)
         if notified:
             self._increment_queue_metric("listener_wakeup")
-        return notified
+        return bool(notified)
 
     async def list_running_external(self, *, limit: "int | None" = None) -> "list[QueuedTaskRecord]":
         async with self._service() as service:

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -12,8 +12,9 @@ from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError as SQLAlchemyIntegrityError
 
 from litestar_queues.backends.advanced_alchemy.config import AdvancedAlchemyBackendConfig
-from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
-from litestar_queues.backends.advanced_alchemy.service import QueueTaskService
+from litestar_queues.backends.advanced_alchemy.event_log import AdvancedAlchemyQueueEventLog
+from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
+from litestar_queues.backends.advanced_alchemy.service import QueueEventLogService, QueueTaskService
 from litestar_queues.backends.base import BaseQueueBackend
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import HeartbeatTouchResult, QueueBackendCapabilities
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
         StaleTaskRecoveryResult,
     )
     from litestar_queues.observability import QueueObservabilityRuntimeProtocol
+    from litestar_queues.events import EventLogConfig, QueueEventLog
 
 __all__ = ("AdvancedAlchemyQueueBackend",)
 
@@ -46,10 +48,15 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
 
     _model_class: "type[QueueTaskModelMixin]"
     _service_class: 'type["QueueTaskService"]'
+    _event_log_model_class: "type[QueueEventLogModelMixin]"
+    _event_log_service_class: 'type["QueueEventLogService"]'
 
     __slots__ = (
         "_create_schema",
         "_event_poll_interval",
+        "_event_log",
+        "_event_log_model_class",
+        "_event_log_service_class",
         "_heartbeat_session_maker",
         "_model_class",
         "_notification_channel",
@@ -69,12 +76,16 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         self._sqlalchemy_config = backend_config.sqlalchemy_config
         self._heartbeat_session_maker = backend_config.heartbeat_session_maker
         self._model_class, self._service_class = self._resolve_model_classes(backend_config.model_class)
+        self._event_log_model_class, self._event_log_service_class = self._resolve_event_log_model_classes(
+            backend_config.event_log_model_class
+        )
         self._create_schema = backend_config.create_schema
         self._notifications = backend_config.notifications
         self._notification_channel = backend_config.notification_channel
         self._event_poll_interval = backend_config.event_poll_interval
         self._notification_listener: "Any | None" = None
         self._observability_runtime: "QueueObservabilityRuntimeProtocol | None" = None
+        self._event_log: "AdvancedAlchemyQueueEventLog | None" = None
         self._opened = False
 
     @property
@@ -107,10 +118,12 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         if self._notification_listener is not None:
             await self._notification_listener.close()
             self._notification_listener = None
+        if self._event_log is not None:
+            await self._event_log.flush_events()
         self._opened = False
 
     async def create_schema(self) -> "None":
-        """Create the queue task table and indexes."""
+        """Create the queue task table and enabled event-history table."""
         self._ensure_configured()
         sqlalchemy_config = self._sqlalchemy_config
         if sqlalchemy_config is None:
@@ -120,6 +133,19 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         table = self._model_class.__dict__["__table__"]
         async with engine.begin() as connection:
             await connection.run_sync(table.create, checkfirst=True)
+            if self._event_log_enabled():
+                event_log_table = self._event_log_model_class.__dict__["__table__"]
+                await connection.run_sync(event_log_table.create, checkfirst=True)
+
+    def get_event_log(self, config: "EventLogConfig") -> "QueueEventLog | None":
+        """Return Advanced Alchemy-managed queue event history when enabled."""
+        if not config.enabled:
+            return None
+        if self._event_log is None:
+            self._event_log = AdvancedAlchemyQueueEventLog(
+                config=config, service_factory=self._event_log_service, transaction_factory=self._event_log_operation
+            )
+        return self._event_log
 
     async def enqueue(
         self,
@@ -447,6 +473,53 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
             raise QueueConfigurationError(msg)
         return typed_model, QueueTaskService.for_model(typed_model)
 
+    def _resolve_event_log_model_classes(
+        self, model_class: "type[object] | None"
+    ) -> 'tuple[type[QueueEventLogModelMixin], type["QueueEventLogService"]]':
+        if model_class is None:
+            msg = "AdvancedAlchemyBackendConfig.event_log_model_class must inherit QueueEventLogModelMixin."
+            raise QueueConfigurationError(msg)
+        try:
+            valid_model = issubclass(model_class, QueueEventLogModelMixin)
+        except TypeError:
+            valid_model = False
+        if not valid_model:
+            msg = "AdvancedAlchemyBackendConfig.event_log_model_class must inherit QueueEventLogModelMixin."
+            raise QueueConfigurationError(msg)
+        if "__tablename__" not in model_class.__dict__:
+            msg = "AdvancedAlchemyBackendConfig.event_log_model_class must declare __tablename__."
+            raise QueueConfigurationError(msg)
+        typed_model = cast("type[QueueEventLogModelMixin]", model_class)
+        mapper = cast("Any", sqlalchemy_inspect(typed_model))
+        missing_columns = {
+            "created_at",
+            "event_id",
+            "event_type",
+            "task_id",
+            "task_name",
+            "queue",
+            "worker_id",
+            "execution_backend",
+            "execution_profile",
+            "level",
+            "message",
+            "detail_json",
+            "progress_current",
+            "progress_total",
+            "progress_percent",
+            "sequence",
+            "occurred_at",
+        } - {property_.key for property_ in mapper.column_attrs}
+        if missing_columns:
+            columns = ", ".join(sorted(missing_columns))
+            msg = f"AdvancedAlchemyBackendConfig.event_log_model_class is missing event-log columns: {columns}."
+            raise QueueConfigurationError(msg)
+        return typed_model, QueueEventLogService.for_model(typed_model)
+
+    def _event_log_enabled(self) -> "bool":
+        event_log_config = self.config.event_log if self.config is not None else None
+        return event_log_config is not None and event_log_config.enabled
+
     @asynccontextmanager
     async def _session(self) -> "AsyncIterator[AsyncSession]":
         self._ensure_configured()
@@ -469,6 +542,18 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         self._ensure_opened()
         async with self._session() as session, session.begin():
             yield self._service_class(session=session)
+
+    @asynccontextmanager
+    async def _event_log_service(self) -> 'AsyncIterator["QueueEventLogService"]':
+        self._ensure_opened()
+        async with self._session() as session:
+            yield self._event_log_service_class(session=session)
+
+    @asynccontextmanager
+    async def _event_log_operation(self) -> 'AsyncIterator["QueueEventLogService"]':
+        self._ensure_opened()
+        async with self._session() as session, session.begin():
+            yield self._event_log_service_class(session=session)
 
     @asynccontextmanager
     async def _heartbeat_operation(self) -> 'AsyncIterator["QueueTaskService"]':

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -1,10 +1,14 @@
 """Advanced Alchemy queue backend."""
 
-from contextlib import asynccontextmanager
+import asyncio
+from contextlib import asynccontextmanager, suppress
+from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 
 from advanced_alchemy.exceptions import DuplicateKeyError
 from sqlalchemy import inspect as sqlalchemy_inspect
+from sqlalchemy import text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError as SQLAlchemyIntegrityError
 
 from litestar_queues.backends.advanced_alchemy.config import AdvancedAlchemyBackendConfig
@@ -12,7 +16,7 @@ from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
 from litestar_queues.backends.advanced_alchemy.service import QueueTaskService
 from litestar_queues.backends.base import BaseQueueBackend
 from litestar_queues.exceptions import QueueConfigurationError
-from litestar_queues.models import HeartbeatTouchResult
+from litestar_queues.models import HeartbeatTouchResult, QueueBackendCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping, Sequence
@@ -22,9 +26,19 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from litestar_queues.config import QueueConfig
-    from litestar_queues.models import HeartbeatTouch, QueuedTaskRecord, QueueStatistics, StaleTaskRecoveryResult
+    from litestar_queues.models import (
+        EnqueueSpec,
+        HeartbeatTouch,
+        QueuedTaskRecord,
+        QueueStatistics,
+        StaleTaskRecoveryResult,
+    )
+    from litestar_queues.observability import QueueObservabilityRuntimeProtocol
 
 __all__ = ("AdvancedAlchemyQueueBackend",)
+
+_POSTGRES_NOTIFY_BACKEND = "postgres-listen-notify"
+_POSTGRES_NOTIFY_PAYLOAD = "tasks"
 
 
 class AdvancedAlchemyQueueBackend(BaseQueueBackend):
@@ -35,8 +49,13 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
 
     __slots__ = (
         "_create_schema",
+        "_event_poll_interval",
         "_heartbeat_session_maker",
         "_model_class",
+        "_notification_channel",
+        "_notification_listener",
+        "_notifications",
+        "_observability_runtime",
         "_opened",
         "_service_class",
         "_sqlalchemy_config",
@@ -51,7 +70,23 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         self._heartbeat_session_maker = backend_config.heartbeat_session_maker
         self._model_class, self._service_class = self._resolve_model_classes(backend_config.model_class)
         self._create_schema = backend_config.create_schema
+        self._notifications = backend_config.notifications
+        self._notification_channel = backend_config.notification_channel
+        self._event_poll_interval = backend_config.event_poll_interval
+        self._notification_listener: "Any | None" = None
+        self._observability_runtime: "QueueObservabilityRuntimeProtocol | None" = None
         self._opened = False
+
+    @property
+    def capabilities(self) -> "QueueBackendCapabilities":
+        """Backend behavior capabilities."""
+        notifications_enabled = self._notifications_supported()
+        return QueueBackendCapabilities(
+            supports_notifications=notifications_enabled,
+            notification_backend=_POSTGRES_NOTIFY_BACKEND if notifications_enabled else None,
+            notifications_durable=False,
+            supports_batch_claim=_supports_batch_claim_driver(self._driver_name()),
+        )
 
     async def open(self) -> "bool":
         """Open Advanced Alchemy resources.
@@ -69,6 +104,9 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
 
     async def close(self) -> "None":
         """Close backend-owned resources."""
+        if self._notification_listener is not None:
+            await self._notification_listener.close()
+            self._notification_listener = None
         self._opened = False
 
     async def create_schema(self) -> "None":
@@ -124,6 +162,20 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         await self.notify_new_task(record)
         return record
 
+    async def enqueue_many(self, specs: "Sequence[EnqueueSpec]") -> "list[QueuedTaskRecord]":
+        """Persist multiple queued tasks in one Advanced Alchemy operation.
+
+        Returns:
+            Queue task records in input order.
+        """
+        if not specs:
+            return []
+        async with self._operation() as service:
+            records = await service.enqueue_many(specs)
+        self._increment_queue_metric("enqueue", float(len(records)))
+        await self.notify_new_tasks(records)
+        return records
+
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
         async with self._service() as service:
             return await service.get_task(task_id)
@@ -147,6 +199,21 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
     ) -> "QueuedTaskRecord | None":
         async with self._operation() as service:
             return await service.claim_next(queue=queue, execution_backend=execution_backend)
+
+    async def claim_many(
+        self, *, limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "list[QueuedTaskRecord]":
+        """Claim up to ``limit`` due tasks.
+
+        Returns:
+            Claimed task records.
+        """
+        if limit <= 0:
+            return []
+        async with self._operation() as service:
+            records = await service.claim_many(limit=limit, queue=queue, execution_backend=execution_backend)
+        self._increment_queue_metric("claim", float(len(records)))
+        return records
 
     async def complete_task(
         self, task_id: "UUID", *, result: "Any" = None, expected_retry_count: "int | None" = None
@@ -211,6 +278,47 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
             await self.notify_new_task(record)
         return record
 
+    async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
+        """Publish a PostgreSQL worker wakeup marker when enabled.
+
+        Returns:
+            None.
+        """
+        if not self._notifications_supported() or record.status not in {"pending", "scheduled"} or not record.is_due:
+            return
+        await self._send_notification_marker()
+        self._increment_queue_metric("notify")
+
+    async def notify_new_tasks(self, records: "Sequence[QueuedTaskRecord]") -> "None":
+        """Coalesce a batch of task records into at most one wakeup marker.
+
+        Returns:
+            None.
+        """
+        for record in records:
+            if record.status in {"pending", "scheduled"} and record.is_due:
+                await self.notify_new_task(record)
+                return
+
+    async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
+        """Wait for a PostgreSQL worker wakeup marker when configured.
+
+        Returns:
+            True when a wakeup marker or due-row reconciliation is observed.
+        """
+        if not self._notifications_supported():
+            return await super().wait_for_notifications(timeout=timeout)
+        listener = self._get_notification_listener()
+        await listener.start()
+        if await self._has_due_tasks():
+            self._increment_queue_metric("poll_fallback")
+            return True
+        wait_timeout = self._event_poll_interval if self._event_poll_interval is not None else timeout
+        notified = await listener.wait(wait_timeout)
+        if notified:
+            self._increment_queue_metric("listener_wakeup")
+        return notified
+
     async def list_running_external(self, *, limit: "int | None" = None) -> "list[QueuedTaskRecord]":
         async with self._service() as service:
             return await service.list_running_external(limit=limit)
@@ -238,6 +346,59 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         if not self._opened:
             msg = "AdvancedAlchemyQueueBackend.open() must be called before using the backend."
             raise RuntimeError(msg)
+
+    def _driver_name(self) -> "str | None":
+        sqlalchemy_config = self._sqlalchemy_config
+        if sqlalchemy_config is None or sqlalchemy_config.connection_string is None:
+            return None
+        return make_url(sqlalchemy_config.connection_string).drivername
+
+    def _notifications_supported(self) -> "bool":
+        return self._notifications and self._driver_name() == "postgresql+asyncpg"
+
+    def _get_notification_listener(self) -> "Any":
+        if self._notification_listener is None:
+            self._notification_listener = self._create_notification_listener()
+        return self._notification_listener
+
+    def _create_notification_listener(self) -> "Any":
+        sqlalchemy_config = self._sqlalchemy_config
+        if sqlalchemy_config is None or sqlalchemy_config.connection_string is None:
+            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config for PostgreSQL notifications."
+            raise QueueConfigurationError(msg)
+        url = make_url(sqlalchemy_config.connection_string).set(drivername="postgresql")
+        return _AsyncpgNotificationListener(
+            dsn=url.render_as_string(hide_password=False), channel=self._notification_channel
+        )
+
+    async def _send_notification_marker(self) -> "None":
+        sqlalchemy_config = self._sqlalchemy_config
+        if sqlalchemy_config is None:
+            msg = "AdvancedAlchemyQueueBackend requires sqlalchemy_config for PostgreSQL notifications."
+            raise QueueConfigurationError(msg)
+        engine = sqlalchemy_config.get_engine()
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("SELECT pg_notify(:channel, :payload)"),
+                {"channel": self._notification_channel, "payload": _POSTGRES_NOTIFY_PAYLOAD},
+            )
+
+    async def _has_due_tasks(self) -> "bool":
+        async with self._service() as service:
+            return bool(await service.list_pending(limit=1, queue=None, execution_backend=None))
+
+    def _increment_queue_metric(self, name: "str", amount: "float" = 1.0) -> "None":
+        if amount == 0 or self.config is None or self.config.observability is None:
+            return
+        if self._observability_runtime is None:
+            from litestar_queues.observability import create_observability_runtime
+
+            self._observability_runtime = create_observability_runtime(self.config.observability)
+        self._observability_runtime.record_counter(
+            f"litestar_queues.queue.{name}",
+            int(amount),
+            attributes={"messaging.system": "litestar_queues", "backend": "advanced-alchemy"},
+        )
 
     def _resolve_model_classes(
         self, model_class: "type[object] | None"
@@ -327,3 +488,61 @@ class AdvancedAlchemyQueueBackend(BaseQueueBackend):
         else:
             async with self._heartbeat_session_maker() as session, session.begin():
                 yield self._service_class(session=session)
+
+
+class _AsyncpgNotificationListener:
+    """Dedicated asyncpg LISTEN connection for Advanced Alchemy wakeups."""
+
+    __slots__ = ("_channel", "_connection", "_dsn", "_event")
+
+    def __init__(self, *, dsn: "str", channel: "str") -> "None":
+        self._dsn = dsn
+        self._channel = channel
+        self._event = asyncio.Event()
+        self._connection: "Any | None" = None
+
+    async def start(self) -> "None":
+        connection = self._connection
+        if connection is not None and not connection.is_closed():
+            return
+        await self.close()
+        connection = await self._connect()
+        await connection.add_listener(self._channel, self._handle_notification)
+        self._connection = connection
+
+    async def wait(self, timeout: "float | None") -> "bool":
+        await self.start()
+        if self._event.is_set():
+            self._event.clear()
+            return True
+        try:
+            await asyncio.wait_for(self._event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        self._event.clear()
+        return True
+
+    async def close(self) -> "None":
+        connection = self._connection
+        self._connection = None
+        if connection is None:
+            return
+        with suppress(Exception):
+            await connection.remove_listener(self._channel, self._handle_notification)
+        with suppress(Exception):
+            await connection.close()
+
+    async def _connect(self) -> "Any":
+        try:
+            asyncpg = import_module("asyncpg")
+        except ImportError as exc:
+            msg = "AdvancedAlchemyBackendConfig.notifications=True for postgresql+asyncpg requires asyncpg."
+            raise QueueConfigurationError(msg) from exc
+        return await cast("Any", asyncpg).connect(dsn=self._dsn)
+
+    def _handle_notification(self, _connection: "Any", _pid: "int", _channel: "str", _payload: "str") -> "None":
+        self._event.set()
+
+
+def _supports_batch_claim_driver(driver_name: "str | None") -> "bool":
+    return driver_name == "postgresql+asyncpg"

--- a/src/litestar_queues/backends/advanced_alchemy/config.py
+++ b/src/litestar_queues/backends/advanced_alchemy/config.py
@@ -16,6 +16,12 @@ def _default_model_class() -> "type[object]":
     return QueueTaskModel
 
 
+def _default_event_log_model_class() -> "type[object]":
+    from litestar_queues.backends.advanced_alchemy.models import QueueEventLogModel
+
+    return QueueEventLogModel
+
+
 @dataclass(slots=True)
 class AdvancedAlchemyBackendConfig:
     """Configuration values for the Advanced Alchemy queue backend."""
@@ -24,6 +30,7 @@ class AdvancedAlchemyBackendConfig:
     sqlalchemy_config: "SQLAlchemyAsyncConfig | None" = None
     heartbeat_session_maker: "async_sessionmaker[AsyncSession] | None" = None
     model_class: "type[object] | None" = field(default_factory=_default_model_class)
+    event_log_model_class: "type[object] | None" = field(default_factory=_default_event_log_model_class)
     create_schema: "bool" = False
     notifications: "bool" = False
     notification_channel: "str" = "litestar_queues_tasks"

--- a/src/litestar_queues/backends/advanced_alchemy/config.py
+++ b/src/litestar_queues/backends/advanced_alchemy/config.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from advanced_alchemy.config.asyncio import SQLAlchemyAsyncConfig
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-__all__ = ("AdvancedAlchemyBackendConfig",)
+__all__ = ("SQLAlchemyBackendConfig",)
 
 
 def _default_model_class() -> "type[object]":
@@ -23,15 +23,14 @@ def _default_event_log_model_class() -> "type[object]":
 
 
 @dataclass(slots=True)
-class AdvancedAlchemyBackendConfig:
-    """Configuration values for the Advanced Alchemy queue backend."""
+class SQLAlchemyBackendConfig:
+    """Configuration values for the SQLAlchemy queue backend."""
 
     backend_name: "ClassVar[str]" = "advanced-alchemy"
     sqlalchemy_config: "SQLAlchemyAsyncConfig | None" = None
     heartbeat_session_maker: "async_sessionmaker[AsyncSession] | None" = None
     model_class: "type[object] | None" = field(default_factory=_default_model_class)
     event_log_model_class: "type[object] | None" = field(default_factory=_default_event_log_model_class)
-    create_schema: "bool" = False
     notifications: "bool" = False
     notification_channel: "str" = "litestar_queues_tasks"
     event_poll_interval: "float | None" = None

--- a/src/litestar_queues/backends/advanced_alchemy/config.py
+++ b/src/litestar_queues/backends/advanced_alchemy/config.py
@@ -25,3 +25,6 @@ class AdvancedAlchemyBackendConfig:
     heartbeat_session_maker: "async_sessionmaker[AsyncSession] | None" = None
     model_class: "type[object] | None" = field(default_factory=_default_model_class)
     create_schema: "bool" = False
+    notifications: "bool" = False
+    notification_channel: "str" = "litestar_queues_tasks"
+    event_poll_interval: "float | None" = None

--- a/src/litestar_queues/backends/advanced_alchemy/event_log.py
+++ b/src/litestar_queues/backends/advanced_alchemy/event_log.py
@@ -1,0 +1,96 @@
+"""Advanced Alchemy-backed queue event history."""
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from litestar_queues.events._log_records import event_log_record_from_event
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from contextlib import AbstractAsyncContextManager
+    from datetime import datetime
+
+    from litestar_queues.backends.advanced_alchemy.service import QueueEventLogService
+    from litestar_queues.events import EventLogConfig, QueueEvent, QueueEventLogRecord, QueueEventStageSummary
+
+__all__ = ("AdvancedAlchemyQueueEventLog",)
+
+logger = logging.getLogger(__name__)
+
+
+class AdvancedAlchemyQueueEventLog:
+    """Buffered Advanced Alchemy event-history writer and query interface."""
+
+    __slots__ = ("_config", "_flush_lock", "_last_flush", "_pending", "_service_factory", "_transaction_factory")
+
+    def __init__(
+        self,
+        *,
+        config: "EventLogConfig",
+        service_factory: 'Callable[[], AbstractAsyncContextManager["QueueEventLogService"]]',
+        transaction_factory: 'Callable[[], AbstractAsyncContextManager["QueueEventLogService"]]',
+    ) -> "None":
+        self._config = config
+        self._service_factory = service_factory
+        self._transaction_factory = transaction_factory
+        self._pending: "list[QueueEventLogRecord]" = []
+        self._last_flush = time.monotonic()
+        self._flush_lock = asyncio.Lock()
+
+    async def publish_event(self, event: "QueueEvent") -> "None":
+        """Buffer a queue event and flush when configured thresholds are reached."""
+        should_flush = False
+        async with self._flush_lock:
+            self._pending.append(event_log_record_from_event(event))
+            should_flush = len(self._pending) >= max(1, self._config.buffer_size) or self._flush_interval_elapsed()
+        if should_flush:
+            await self.flush_events()
+
+    async def flush_events(self) -> "None":
+        """Flush buffered queue events through an Advanced Alchemy session.
+
+        Returns:
+            None.
+        """
+        async with self._flush_lock:
+            if not self._pending:
+                return
+            batch = list(self._pending)
+            try:
+                async with self._transaction_factory() as service:
+                    await service.add_records(batch)
+            except Exception:
+                if self._config.strict:
+                    raise
+                logger.warning("Advanced Alchemy queue event history flush failed", exc_info=True)
+                return
+            del self._pending[: len(batch)]
+            self._last_flush = time.monotonic()
+
+    async def list_events(
+        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+    ) -> "list[QueueEventLogRecord]":
+        """Return durable event history records."""
+        await self.flush_events()
+        async with self._service_factory() as service:
+            return await service.list_events(task_id=task_id, task_name=task_name, limit=limit)
+
+    async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":
+        """Return no aggregate summaries for the Advanced Alchemy event log."""
+        del task_name
+        return []
+
+    async def cleanup_before(self, before: "datetime") -> "int":
+        """Delete event history older than ``before``.
+
+        Returns:
+            Number of deleted event-history rows.
+        """
+        await self.flush_events()
+        async with self._transaction_factory() as service:
+            return await service.cleanup_before(before)
+
+    def _flush_interval_elapsed(self) -> "bool":
+        return self._config.flush_interval <= 0 or time.monotonic() - self._last_flush >= self._config.flush_interval

--- a/src/litestar_queues/backends/advanced_alchemy/mixins.py
+++ b/src/litestar_queues/backends/advanced_alchemy/mixins.py
@@ -4,10 +4,10 @@ from datetime import datetime  # noqa: TC003
 from typing import Any, Protocol, TypeAlias, cast
 
 from advanced_alchemy.types import JsonB
-from sqlalchemy import DateTime, Index, Integer, String, Text
+from sqlalchemy import DateTime, Float, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, declarative_mixin, declared_attr, mapped_column
 
-__all__ = ("QueueTaskModelMixin",)
+__all__ = ("QueueEventLogModelMixin", "QueueTaskModelMixin")
 
 JSONValue: TypeAlias = dict[str, Any] | list[Any] | str | int | float | bool | None
 
@@ -106,6 +106,87 @@ class QueueTaskModelMixin:
     @declared_attr
     def metadata_json(cls) -> "Mapped[dict[str, Any]]":
         return mapped_column("metadata", JsonB, default=dict, nullable=False)
+
+
+@declarative_mixin
+class QueueEventLogModelMixin:
+    """Declarative mixin carrying generic queue event-history columns and indexes."""
+
+    __abstract__ = True
+
+    @declared_attr.directive
+    def __table_args__(cls) -> "tuple[Any, ...]":
+        table = str(cast("_NamedTable", cls).__tablename__)
+        return (
+            Index(f"ix_{table}_task_id", "task_id", "sequence", "occurred_at"),
+            Index(f"ix_{table}_task_name", "task_name", "occurred_at"),
+            Index(f"ix_{table}_event_type", "event_type", "occurred_at"),
+            Index(f"ix_{table}_occurred_at", "occurred_at"),
+        )
+
+    @declared_attr
+    def event_id(cls) -> "Mapped[str]":
+        return mapped_column(String(length=64), unique=True, nullable=False)
+
+    @declared_attr
+    def event_type(cls) -> "Mapped[str]":
+        return mapped_column(String(length=255), nullable=False)
+
+    @declared_attr
+    def task_id(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=64), default=None)
+
+    @declared_attr
+    def task_name(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=500), default=None)
+
+    @declared_attr
+    def queue(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=255), default=None)
+
+    @declared_attr
+    def worker_id(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=255), default=None)
+
+    @declared_attr
+    def execution_backend(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=255), default=None)
+
+    @declared_attr
+    def execution_profile(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=255), default=None)
+
+    @declared_attr
+    def level(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=32), default=None)
+
+    @declared_attr
+    def message(cls) -> "Mapped[str | None]":
+        return mapped_column(Text(), default=None)
+
+    @declared_attr
+    def detail_json(cls) -> "Mapped[dict[str, Any]]":
+        return mapped_column(JsonB, default=dict, nullable=False)
+
+    @declared_attr
+    def progress_current(cls) -> "Mapped[float | None]":
+        return mapped_column(Float(), default=None)
+
+    @declared_attr
+    def progress_total(cls) -> "Mapped[float | None]":
+        return mapped_column(Float(), default=None)
+
+    @declared_attr
+    def progress_percent(cls) -> "Mapped[float | None]":
+        return mapped_column(Float(), default=None)
+
+    @declared_attr
+    def sequence(cls) -> "Mapped[int | None]":
+        return mapped_column(Integer(), default=None)
+
+    @declared_attr
+    def occurred_at(cls) -> "Mapped[datetime]":
+        return mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class _NamedTable(Protocol):

--- a/src/litestar_queues/backends/advanced_alchemy/models.py
+++ b/src/litestar_queues/backends/advanced_alchemy/models.py
@@ -2,12 +2,18 @@
 
 from advanced_alchemy.base import UUIDAuditBase
 
-from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
+from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 
-__all__ = ("QueueTaskModel",)
+__all__ = ("QueueEventLogModel", "QueueTaskModel")
 
 
 class QueueTaskModel(UUIDAuditBase, QueueTaskModelMixin):
     """Default queue task model for the Advanced Alchemy backend."""
 
     __tablename__ = "litestar_queue_task"
+
+
+class QueueEventLogModel(UUIDAuditBase, QueueEventLogModelMixin):
+    """Default queue event-history model for the Advanced Alchemy backend."""
+
+    __tablename__ = "litestar_queue_task_event_log"

--- a/src/litestar_queues/backends/advanced_alchemy/repository.py
+++ b/src/litestar_queues/backends/advanced_alchemy/repository.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING, Any, cast
 from advanced_alchemy.repository import SQLAlchemyAsyncRepository
 
 if TYPE_CHECKING:
-    from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
+    from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 
-__all__ = ("QueueTaskRepository",)
+__all__ = ("QueueEventLogRepository", "QueueTaskRepository")
 
 
 class QueueTaskRepository(SQLAlchemyAsyncRepository[Any]):
@@ -19,4 +19,16 @@ class QueueTaskRepository(SQLAlchemyAsyncRepository[Any]):
         return cast(
             "type[QueueTaskRepository]",
             type(f"QueueTaskRepositoryFor{model_class.__name__}", (cls,), {"model_type": model_class}),
+        )
+
+
+class QueueEventLogRepository(SQLAlchemyAsyncRepository[Any]):
+    """Repository for queue event-history records."""
+
+    @classmethod
+    def for_model(cls, model_class: "type[QueueEventLogModelMixin]") -> 'type["QueueEventLogRepository"]':
+        """Return a repository subclass bound to ``model_class``."""
+        return cast(
+            "type[QueueEventLogRepository]",
+            type(f"QueueEventLogRepositoryFor{model_class.__name__}", (cls,), {"model_type": model_class}),
         )

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -12,7 +12,7 @@ from sqlalchemy import and_, case, delete, desc, func, literal, or_, select, upd
 from sqlalchemy import inspect as sqlalchemy_inspect
 from sqlalchemy.orm.exc import UnmappedColumnError
 
-from litestar_queues.backends.advanced_alchemy.repository import QueueTaskRepository
+from litestar_queues.backends.advanced_alchemy.repository import QueueEventLogRepository, QueueTaskRepository
 from litestar_queues.backends.base import (
     STALE_HEARTBEAT_ERROR,
     record_matches_filters,
@@ -30,10 +30,11 @@ from litestar_queues.models import (
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-    from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
+    from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
+    from litestar_queues.events import QueueEventLogRecord
     from litestar_queues.models import EnqueueSpec, HeartbeatTouch
 
-__all__ = ("QueueTaskService",)
+__all__ = ("QueueEventLogService", "QueueTaskService")
 
 _DUE_STATUSES = ("pending", "scheduled")
 _TERMINAL_STATUSES = ("completed", "failed", "cancelled")
@@ -41,6 +42,114 @@ _SKIP_LOCKED_CLAIM_DIALECTS = frozenset({"oracle", "postgresql"})
 _NATIVE_KEYED_ENQUEUE_DIALECTS = frozenset({"mariadb", "mysql", "oracle", "postgresql"})
 _ORACLE_CLAIM_CANDIDATE_LIMIT = 10
 _CAS_CLAIM_BATCH_SIZE = 10
+
+
+class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
+    """Persistence operations for Advanced Alchemy queue event-history records."""
+
+    @classmethod
+    def for_model(cls, model_class: "type[QueueEventLogModelMixin]") -> 'type["QueueEventLogService"]':
+        """Return a service subclass bound to ``model_class``."""
+        repository_type = QueueEventLogRepository.for_model(model_class)
+        return cast(
+            "type[QueueEventLogService]",
+            type(f"QueueEventLogServiceFor{model_class.__name__}", (cls,), {"repository_type": repository_type}),
+        )
+
+    async def add_records(self, records: "Sequence[QueueEventLogRecord]") -> "None":
+        """Persist event-history records."""
+        self.repository.session.add_all([self.model_from_record(record) for record in records])
+
+    async def list_events(
+        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+    ) -> "list[QueueEventLogRecord]":
+        """Return matching event-history records in ascending event order."""
+        model_type = self.model_type
+        criteria: "list[Any]" = []
+        if task_id is not None:
+            criteria.append(model_type.task_id == task_id)
+        if task_name is not None:
+            criteria.append(model_type.task_name == task_name)
+        statement = select(model_type)
+        if criteria:
+            statement = statement.where(*criteria)
+        statement = statement.order_by(model_type.occurred_at, model_type.sequence, model_type.event_id)
+        if limit is not None:
+            statement = statement.limit(limit)
+        models = await self.get_many(statement=statement)
+        return [self.record_from_model(model) for model in models]
+
+    async def cleanup_before(self, before: "datetime") -> "int":
+        """Delete event-history records older than ``before``.
+
+        Returns:
+            Number of deleted event-history rows.
+        """
+        result = await self.repository.session.execute(
+            delete(self.model_type).where(self.model_type.occurred_at < before)
+        )
+        return int(result.rowcount or 0)
+
+    def model_from_record(self, record: "QueueEventLogRecord") -> "Any":
+        """Convert a backend-neutral event-history record into an ORM model.
+
+        Returns:
+            Advanced Alchemy event-history model.
+        """
+        return self.model_type(
+            event_id=record.event_id,
+            event_type=record.event_type,
+            task_id=record.task_id,
+            task_name=record.task_name,
+            queue=record.queue,
+            worker_id=record.worker_id,
+            execution_backend=record.execution_backend,
+            execution_profile=record.execution_profile,
+            level=record.level,
+            message=record.message,
+            detail_json=_serialize_json(record.detail),
+            progress_current=record.progress_current,
+            progress_total=record.progress_total,
+            progress_percent=record.progress_percent,
+            sequence=record.sequence,
+            occurred_at=record.occurred_at,
+            created_at=record.created_at,
+        )
+
+    @staticmethod
+    def record_from_model(model: "Any") -> "QueueEventLogRecord":
+        """Convert an ORM model into a backend-neutral event-history record.
+
+        Returns:
+            Backend-neutral event-history record.
+        """
+        from litestar_queues.events._log_records import optional_float, optional_str
+        from litestar_queues.events.log import QueueEventLogRecord
+
+        detail = _deserialize_json(model.detail_json)
+        if not isinstance(detail, dict):
+            detail = {}
+        return QueueEventLogRecord(
+            event_id=str(model.event_id),
+            event_type=str(model.event_type),
+            task_id=cast("str | None", model.task_id),
+            task_name=cast("str | None", model.task_name),
+            queue=cast("str | None", model.queue),
+            worker_id=cast("str | None", model.worker_id),
+            execution_backend=cast("str | None", model.execution_backend),
+            execution_profile=cast("str | None", model.execution_profile),
+            stage=optional_str(detail.get("stage")),
+            level=cast("str | None", model.level),
+            message=cast("str | None", model.message),
+            detail=detail,
+            progress_current=optional_float(model.progress_current),
+            progress_total=optional_float(model.progress_total),
+            progress_percent=optional_float(model.progress_percent),
+            duration_ms=optional_float(detail.get("duration_ms")),
+            sequence=int(model.sequence) if model.sequence is not None else None,
+            occurred_at=cast("datetime", _coerce_datetime(model.occurred_at)),
+            created_at=cast("datetime", _coerce_datetime(model.created_at)),
+        )
 
 
 class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
     from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
-    from litestar_queues.models import HeartbeatTouch
+    from litestar_queues.models import EnqueueSpec, HeartbeatTouch
 
 __all__ = ("QueueTaskService",)
 
@@ -96,6 +96,31 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         )
         return await self._insert_task_record(record, key=key)
 
+    async def enqueue_many(self, specs: "Sequence[EnqueueSpec]") -> "list[QueuedTaskRecord]":
+        """Persist many enqueue specs in the current repository transaction.
+
+        Returns:
+            Queue task records in input order.
+        """
+        records: "list[QueuedTaskRecord]" = []
+        for spec in specs:
+            records.append(
+                await self.enqueue(
+                    spec.task_name,
+                    args=spec.args,
+                    kwargs=dict(spec.kwargs or {}),
+                    queue=spec.queue,
+                    priority=spec.priority,
+                    max_retries=spec.max_retries,
+                    scheduled_at=spec.scheduled_at,
+                    key=spec.key,
+                    execution_backend=spec.execution_backend,
+                    execution_profile=spec.execution_profile,
+                    metadata=dict(spec.metadata or {}),
+                )
+            )
+        return records
+
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
         model = await self._select_task(task_id)
         return self.record_from_model(model) if model is not None else None
@@ -148,6 +173,27 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
                 return None
             pending_limit += _CAS_CLAIM_BATCH_SIZE
 
+    async def claim_many(
+        self, *, limit: "int", queue: "str | None", execution_backend: "str | None"
+    ) -> "list[QueuedTaskRecord]":
+        """Claim up to ``limit`` records in the current repository transaction.
+
+        Returns:
+            Claimed task records.
+        """
+        if limit <= 0:
+            return []
+        if _supports_batch_claim(self._dialect_name()):
+            return await self._claim_many_skip_locked(limit=limit, queue=queue, execution_backend=execution_backend)
+
+        records: "list[QueuedTaskRecord]" = []
+        for _ in range(limit):
+            claimed = await self.claim_next(queue=queue, execution_backend=execution_backend)
+            if claimed is None:
+                break
+            records.append(claimed)
+        return records
+
     async def _claim_next_skip_locked(
         self, *, queue: "str | None", execution_backend: "str | None"
     ) -> "QueuedTaskRecord | None":
@@ -178,6 +224,41 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         if row is None:
             return None
         return await self.claim_task(UUID(str(row.id)))
+
+    async def _claim_many_skip_locked(
+        self, *, limit: "int", queue: "str | None", execution_backend: "str | None"
+    ) -> "list[QueuedTaskRecord]":
+        now = _utc_now()
+        model_type = self.model_type
+        statement = _build_claim_candidate_statement(
+            model_type, queue=queue, execution_backend=execution_backend, now=now, limit=limit, skip_locked=True
+        )
+        candidates = (await self.repository.session.execute(statement)).scalars().all()
+        task_ids = [UUID(str(candidate.id)) for candidate in candidates]
+        if not task_ids:
+            return []
+
+        await self.repository.session.execute(
+            update(model_type)
+            .where(
+                model_type.id.in_(task_ids),
+                model_type.status.in_(_DUE_STATUSES),
+                or_(model_type.scheduled_at.is_(None), model_type.scheduled_at <= now),
+            )
+            .values(_update_values(model_type, {"status": "running", "started_at": now, "heartbeat_at": now}, now=now))
+            .execution_options(synchronize_session=False)
+        )
+        models = (
+            (
+                await self.repository.session.execute(
+                    select(model_type).where(model_type.id.in_(task_ids)).execution_options(populate_existing=True)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_id = {UUID(str(model.id)): self.record_from_model(model) for model in models}
+        return [by_id[task_id] for task_id in task_ids if task_id in by_id and by_id[task_id].status == "running"]
 
     async def complete_task(
         self, task_id: "UUID", *, result: "Any" = None, expected_retry_count: "int | None" = None
@@ -720,6 +801,10 @@ def _supports_skip_locked_claim(dialect_name: "str | None") -> "bool":
 
 def _supports_native_keyed_enqueue(dialect_name: "str | None") -> "bool":
     return dialect_name in _NATIVE_KEYED_ENQUEUE_DIALECTS
+
+
+def _supports_batch_claim(dialect_name: "str | None") -> "bool":
+    return dialect_name == "postgresql"
 
 
 def _build_claim_candidate_statement(

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -132,6 +132,27 @@ class BaseQueueBackend:
             return None
         return await self.claim_task(records[0].id)
 
+    async def claim_many(
+        self, *, limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "list[QueuedTaskRecord]":
+        """Claim up to ``limit`` due tasks.
+
+        Backends that advertise ``supports_batch_claim`` should override this
+        with a native batch path. The fallback preserves existing
+        :meth:`claim_next` semantics for backends with only a single-record
+        primitive.
+
+        Returns:
+            Claimed task records.
+        """
+        records: "list[QueuedTaskRecord]" = []
+        for _ in range(max(0, limit)):
+            claimed = await self.claim_next(queue=queue, execution_backend=execution_backend)
+            if claimed is None:
+                break
+            records.append(claimed)
+        return records
+
     async def complete_task(
         self, task_id: "UUID", *, result: "Any" = None, expected_retry_count: "int | None" = None
     ) -> "QueuedTaskRecord | None":
@@ -286,6 +307,12 @@ class BaseQueueBackend:
 
     async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
         """Notify waiters that a new task is available."""
+
+    async def notify_new_tasks(self, records: "Sequence[QueuedTaskRecord]") -> "None":
+        """Notify waiters that new tasks are available."""
+        for record in records:
+            if record.status in {"pending", "scheduled"} and record.is_due:
+                await self.notify_new_task(record)
 
     async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
         """Wait until backend notification arrives.

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -84,7 +84,7 @@ class BaseQueueBackend:
         Returns:
             Queue task records in the same order as ``specs``.
         """
-        return [
+        records = [
             await self.enqueue(
                 spec.task_name,
                 args=spec.args,
@@ -100,6 +100,8 @@ class BaseQueueBackend:
             )
             for spec in specs
         ]
+        await self.notify_new_tasks(records)
+        return records
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
         """Return a queued task by ID."""
@@ -309,10 +311,10 @@ class BaseQueueBackend:
         """Notify waiters that a new task is available."""
 
     async def notify_new_tasks(self, records: "Sequence[QueuedTaskRecord]") -> "None":
-        """Notify waiters that new tasks are available."""
-        for record in records:
-            if record.status in {"pending", "scheduled"} and record.is_due:
-                await self.notify_new_task(record)
+        """Emit one worker-wakeup hint for a batch of newly available tasks."""
+        due = tuple(record for record in records if record.status in {"pending", "scheduled"} and record.is_due)
+        if due:
+            await self.notify_new_task(due[0])
 
     async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
         """Wait until backend notification arrives.

--- a/src/litestar_queues/backends/factory.py
+++ b/src/litestar_queues/backends/factory.py
@@ -16,7 +16,7 @@ __all__ = ("get_queue_backend", "get_queue_backend_class", "list_queue_backends"
 _queue_backend_registry: "dict[str, type[BaseQueueBackend]]" = {}
 
 _BUILTIN_BACKENDS: "dict[str, str]" = {
-    "advanced-alchemy": "litestar_queues.backends.advanced_alchemy:AdvancedAlchemyQueueBackend",
+    "advanced-alchemy": "litestar_queues.backends.advanced_alchemy:SQLAlchemyBackend",
     "memory": "litestar_queues.backends.memory:InMemoryQueueBackend",
     "redis": "litestar_queues.backends.redis:RedisQueueBackend",
     "sqlspec": "litestar_queues.backends.sqlspec:SQLSpecQueueBackend",

--- a/src/litestar_queues/backends/memory/__init__.py
+++ b/src/litestar_queues/backends/memory/__init__.py
@@ -1,5 +1,6 @@
 """In-memory queue backend."""
 
 from litestar_queues.backends.memory.backend import InMemoryQueueBackend
+from litestar_queues.backends.memory.event_log import InMemoryQueueEventLog
 
-__all__ = ("InMemoryQueueBackend",)
+__all__ = ("InMemoryQueueBackend", "InMemoryQueueEventLog")

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     from litestar_queues.config import QueueConfig
     from litestar_queues.events import EventLogConfig, QueueEventLog
-    from litestar_queues.models import HeartbeatTouch
+    from litestar_queues.models import EnqueueSpec, HeartbeatTouch
 
 __all__ = ("InMemoryQueueBackend",)
 
@@ -100,6 +100,49 @@ class InMemoryQueueBackend(BaseQueueBackend):
                 self._keys[key] = record.id
         await self.notify_new_task(record)
         return record
+
+    async def enqueue_many(self, specs: "Sequence[EnqueueSpec]") -> "list[QueuedTaskRecord]":
+        """Persist multiple in-memory tasks while signaling waiters once.
+
+        Returns:
+            Queue task records in the same order as ``specs``.
+        """
+        if not specs:
+            return []
+
+        records: "list[QueuedTaskRecord]" = []
+        now = _utc_now()
+        async with self._lock:
+            for spec in specs:
+                if spec.key is not None:
+                    existing_id = self._keys.get(spec.key)
+                    if existing_id is not None:
+                        existing = self._records.get(existing_id)
+                        if existing is not None and not existing.is_terminal:
+                            records.append(existing)
+                            continue
+
+                record = QueuedTaskRecord(
+                    task_name=spec.task_name,
+                    args=spec.args,
+                    kwargs=dict(spec.kwargs or {}),
+                    queue=spec.queue,
+                    execution_backend=spec.execution_backend,
+                    execution_profile=spec.execution_profile,
+                    status="scheduled" if spec.scheduled_at is not None and spec.scheduled_at > now else "pending",
+                    priority=spec.priority,
+                    max_retries=spec.max_retries,
+                    scheduled_at=spec.scheduled_at,
+                    key=spec.key,
+                    metadata=dict(spec.metadata or {}),
+                )
+                self._records[record.id] = record
+                if spec.key is not None:
+                    self._keys[spec.key] = record.id
+                records.append(record)
+
+        await self.notify_new_tasks(records)
+        return records
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
         return self._records.get(task_id)
@@ -342,7 +385,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
         return removed
 
     async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
-        if record.status in {"pending", "scheduled"}:
+        if record.status in {"pending", "scheduled"} and record.is_due:
             self._notification_event.set()
 
     async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from litestar_queues.config import QueueConfig
+    from litestar_queues.events import EventLogConfig, QueueEventLog
     from litestar_queues.models import HeartbeatTouch
 
 __all__ = ("InMemoryQueueBackend",)
@@ -30,7 +31,7 @@ __all__ = ("InMemoryQueueBackend",)
 class InMemoryQueueBackend(BaseQueueBackend):
     """In-process queue backend for tests, local development, and examples."""
 
-    __slots__ = ("_keys", "_lock", "_notification_event", "_records")
+    __slots__ = ("_event_log", "_keys", "_lock", "_notification_event", "_records")
 
     def __init__(self, config: "QueueConfig | None" = None) -> "None":
         super().__init__(config=config)
@@ -38,6 +39,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
         self._keys: "dict[str, UUID]" = {}
         self._lock = asyncio.Lock()
         self._notification_event = asyncio.Event()
+        self._event_log: "QueueEventLog | None" = None
 
     @property
     def capabilities(self) -> "QueueBackendCapabilities":
@@ -45,6 +47,16 @@ class InMemoryQueueBackend(BaseQueueBackend):
         return QueueBackendCapabilities(
             supports_notifications=True, notification_backend="asyncio-event", notifications_durable=False
         )
+
+    def get_event_log(self, config: "EventLogConfig") -> "QueueEventLog | None":
+        """Return bounded, process-local queue event history when enabled."""
+        if not config.enabled:
+            return None
+        if self._event_log is None:
+            from litestar_queues.backends.memory.event_log import InMemoryQueueEventLog
+
+            self._event_log = InMemoryQueueEventLog(config)
+        return self._event_log
 
     async def enqueue(
         self,
@@ -350,6 +362,10 @@ class InMemoryQueueBackend(BaseQueueBackend):
             self._records.clear()
             self._keys.clear()
             self._notification_event.clear()
+        if self._event_log is not None:
+            clear = getattr(self._event_log, "clear", None)
+            if clear is not None:
+                await clear()
 
 
 def _utc_now() -> "datetime":

--- a/src/litestar_queues/backends/memory/event_log.py
+++ b/src/litestar_queues/backends/memory/event_log.py
@@ -1,0 +1,74 @@
+"""In-memory queue event history."""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from litestar_queues.events._log_records import event_log_record_from_event, event_log_record_sort_key
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from litestar_queues.events import EventLogConfig, QueueEvent, QueueEventLogRecord, QueueEventStageSummary
+
+__all__ = ("InMemoryQueueEventLog",)
+
+
+class InMemoryQueueEventLog:
+    """Process-local, bounded queue event history for tests and local usage."""
+
+    __slots__ = ("_config", "_lock", "_records")
+
+    def __init__(self, config: "EventLogConfig") -> "None":
+        self._config = config
+        self._records: "list[QueueEventLogRecord]" = []
+        self._lock = asyncio.Lock()
+
+    async def publish_event(self, event: "QueueEvent") -> "None":
+        """Append an event history record and prune the oldest records."""
+        record = event_log_record_from_event(event)
+        async with self._lock:
+            self._records.append(record)
+            overflow = len(self._records) - self._config.max_records
+            if overflow > 0:
+                del self._records[:overflow]
+
+    async def flush_events(self) -> "None":
+        """Flush buffered events.
+
+        The memory event log writes immediately, so this is intentionally a no-op.
+        """
+
+    async def list_events(
+        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+    ) -> "list[QueueEventLogRecord]":
+        """Return matching event history records in ascending event order."""
+        async with self._lock:
+            records = [
+                record
+                for record in self._records
+                if (task_id is None or record.task_id == task_id)
+                and (task_name is None or record.task_name == task_name)
+            ]
+        records.sort(key=event_log_record_sort_key)
+        return records[:limit] if limit is not None else records
+
+    async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":
+        """Return no aggregate summaries for the memory event log."""
+        del task_name
+        return []
+
+    async def cleanup_before(self, before: "datetime") -> "int":
+        """Delete records older than ``before``.
+
+        Returns:
+            Number of deleted records.
+        """
+        async with self._lock:
+            original_count = len(self._records)
+            self._records = [record for record in self._records if record.occurred_at >= before]
+            return original_count - len(self._records)
+
+    async def clear(self) -> "None":
+        """Clear all memory event-history records."""
+        async with self._lock:
+            self._records.clear()

--- a/src/litestar_queues/backends/redis/__init__.py
+++ b/src/litestar_queues/backends/redis/__init__.py
@@ -2,5 +2,6 @@
 
 from litestar_queues.backends.redis.backend import RedisQueueBackend
 from litestar_queues.backends.redis.config import RedisBackendConfig
+from litestar_queues.backends.redis.event_log import RedisQueueEventLog
 
-__all__ = ("RedisBackendConfig", "RedisQueueBackend")
+__all__ = ("RedisBackendConfig", "RedisQueueBackend", "RedisQueueEventLog")

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from litestar_queues.backends.redis._typing import RedisClientLike, RedisPipelineLike, RedisPubSubLike
     from litestar_queues.config import QueueConfig
     from litestar_queues.events import EventLogConfig, QueueEventLog
-    from litestar_queues.models import HeartbeatTouch
+    from litestar_queues.models import EnqueueSpec, HeartbeatTouch
 
 __all__ = ("RedisQueueBackend",)
 
@@ -229,6 +229,65 @@ class RedisQueueBackend(BaseQueueBackend):
             await self._save_record(record)
         await self.notify_new_task(record)
         return record
+
+    async def enqueue_many(self, specs: "Sequence[EnqueueSpec]") -> "list[QueuedTaskRecord]":
+        """Persist a batch of Redis-backed tasks and coalesce worker wakeups.
+
+        Returns:
+            Queue task records in the same order as ``specs``.
+        """
+        if not specs:
+            return []
+
+        results: "list[QueuedTaskRecord]" = []
+        unkeyed_records: "list[QueuedTaskRecord]" = []
+        for spec in specs:
+            if spec.key is not None:
+                async with self._lock(f"key:{spec.key}", wait=True):
+                    existing = await self.get_task_by_key(spec.key)
+                    if existing is not None and not existing.is_terminal:
+                        results.append(existing)
+                        continue
+                    if existing is not None:
+                        await self._clear_key(existing)
+                    record = self._create_record(
+                        spec.task_name,
+                        args=spec.args,
+                        kwargs=spec.kwargs,
+                        queue=spec.queue,
+                        priority=spec.priority,
+                        max_retries=spec.max_retries,
+                        scheduled_at=spec.scheduled_at,
+                        key=spec.key,
+                        execution_backend=spec.execution_backend,
+                        execution_profile=spec.execution_profile,
+                        metadata=spec.metadata,
+                    )
+                    await self._save_record(record)
+                    await self._client_hset(self._keys_key, spec.key, str(record.id))
+                    results.append(record)
+                continue
+
+            record = self._create_record(
+                spec.task_name,
+                args=spec.args,
+                kwargs=spec.kwargs,
+                queue=spec.queue,
+                priority=spec.priority,
+                max_retries=spec.max_retries,
+                scheduled_at=spec.scheduled_at,
+                key=None,
+                execution_backend=spec.execution_backend,
+                execution_profile=spec.execution_profile,
+                metadata=spec.metadata,
+            )
+            unkeyed_records.append(record)
+            results.append(record)
+
+        if unkeyed_records:
+            await self._save_records(unkeyed_records)
+        await self.notify_new_tasks(results)
+        return results
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
         """Return a queued task by ID."""
@@ -607,13 +666,8 @@ class RedisQueueBackend(BaseQueueBackend):
 
     async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
         """Publish a Redis-protocol pub/sub message when work is available."""
-        if self._notifications and record.status in _DUE_STATUSES:
-            payload = _json_dumps({
-                "task_id": str(record.id),
-                "task_name": record.task_name,
-                "queue": record.queue,
-                "execution_backend": record.execution_backend,
-            })
+        if self._notifications and record.status in _DUE_STATUSES and record.is_due:
+            payload = _json_dumps({"event": "task_available"})
             client = await self._get_client()
             await client.publish(self._notification_channel, payload)
 
@@ -709,31 +763,42 @@ class RedisQueueBackend(BaseQueueBackend):
         )
 
     async def _save_record(self, record: "QueuedTaskRecord") -> "None":
+        await self._save_records([record])
+
+    async def _save_records(self, records: "Sequence[QueuedTaskRecord]") -> "None":
+        if not records:
+            return
         client = await self._get_client()
-        record_id = str(record.id)
         pipeline = _create_pipeline(client)
         if pipeline is not None:
-            pipeline.hset(self._task_key(record.id), mapping=self._record_to_mapping(record))
-            pipeline.sadd(self._tasks_key, record_id)
-            for status in _STATUS_VALUES:
-                pipeline.srem(self._status_key(status), record_id)
-            pipeline.sadd(self._status_key(record.status), record_id)
-            if record.status in _DUE_STATUSES:
-                pipeline.zadd(self._pending_key, {record_id: _score_datetime(record.scheduled_at)})
-            else:
-                pipeline.zrem(self._pending_key, record_id)
+            for record in records:
+                self._queue_save_record(pipeline, record)
             await _execute_pipeline(pipeline)
             return
 
-        await client.hset(self._task_key(record.id), mapping=self._record_to_mapping(record))
-        await client.sadd(self._tasks_key, record_id)
+        for record in records:
+            record_id = str(record.id)
+            await client.hset(self._task_key(record.id), mapping=self._record_to_mapping(record))
+            await client.sadd(self._tasks_key, record_id)
+            for status in _STATUS_VALUES:
+                await client.srem(self._status_key(status), record_id)
+            await client.sadd(self._status_key(record.status), record_id)
+            if record.status in _DUE_STATUSES:
+                await client.zadd(self._pending_key, {record_id: _score_datetime(record.scheduled_at)})
+            else:
+                await client.zrem(self._pending_key, record_id)
+
+    def _queue_save_record(self, pipeline: "RedisPipelineLike", record: "QueuedTaskRecord") -> "None":
+        record_id = str(record.id)
+        pipeline.hset(self._task_key(record.id), mapping=self._record_to_mapping(record))
+        pipeline.sadd(self._tasks_key, record_id)
         for status in _STATUS_VALUES:
-            await client.srem(self._status_key(status), record_id)
-        await client.sadd(self._status_key(record.status), record_id)
+            pipeline.srem(self._status_key(status), record_id)
+        pipeline.sadd(self._status_key(record.status), record_id)
         if record.status in _DUE_STATUSES:
-            await client.zadd(self._pending_key, {record_id: _score_datetime(record.scheduled_at)})
+            pipeline.zadd(self._pending_key, {record_id: _score_datetime(record.scheduled_at)})
         else:
-            await client.zrem(self._pending_key, record_id)
+            pipeline.zrem(self._pending_key, record_id)
 
     async def _delete_record(self, record: "QueuedTaskRecord") -> "None":
         client = await self._get_client()

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -22,6 +22,7 @@ from litestar_queues.backends.base import (
     stale_requeue_priority,
 )
 from litestar_queues.backends.redis.config import RedisBackendConfig as _RedisBackendConfig
+from litestar_queues.backends.redis.event_log import RedisQueueEventLog, hashed_index_value
 from litestar_queues.exceptions import QueueError
 from litestar_queues.models import (
     HeartbeatTouchResult,
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
 
     from litestar_queues.backends.redis._typing import RedisClientLike, RedisPipelineLike, RedisPubSubLike
     from litestar_queues.config import QueueConfig
+    from litestar_queues.events import EventLogConfig, QueueEventLog
     from litestar_queues.models import HeartbeatTouch
 
 __all__ = ("RedisQueueBackend",)
@@ -98,6 +100,7 @@ class RedisQueueBackend(BaseQueueBackend):
 
     __slots__ = (
         "_client",
+        "_event_log",
         "_key_prefix",
         "_lock_timeout",
         "_notification_channel",
@@ -122,6 +125,7 @@ class RedisQueueBackend(BaseQueueBackend):
         self._pubsub: "RedisPubSubLike | None" = None
         self._lock_timeout = backend_config.lock_timeout
         self._poll_interval = backend_config.poll_interval
+        self._event_log: "RedisQueueEventLog | None" = None
 
     @property
     def capabilities(self) -> "QueueBackendCapabilities":
@@ -145,6 +149,8 @@ class RedisQueueBackend(BaseQueueBackend):
 
     async def close(self) -> "None":
         """Close owned Redis-protocol client resources."""
+        if self._event_log is not None:
+            await self._event_log.flush_events()
         if self._pubsub is not None:
             await _close_pubsub(self._pubsub, self._notification_channel)
             self._pubsub = None
@@ -155,6 +161,14 @@ class RedisQueueBackend(BaseQueueBackend):
                 if inspect.isawaitable(result):
                     await result
             self._client = None
+
+    def get_event_log(self, config: "EventLogConfig") -> "QueueEventLog | None":
+        """Return Redis-protocol queue event history when enabled."""
+        if not config.enabled:
+            return None
+        if self._event_log is None:
+            self._event_log = RedisQueueEventLog(backend=self, config=config)
+        return self._event_log
 
     async def enqueue(
         self,
@@ -802,6 +816,21 @@ class RedisQueueBackend(BaseQueueBackend):
 
     def _lock_key(self, lock_name: "str") -> "str":
         return f"{self._key_prefix}:locks:{lock_name}"
+
+    def _event_log_global_key(self) -> "str":
+        return f"{self._key_prefix}:events"
+
+    def _event_log_event_key(self, event_id: "str") -> "str":
+        return f"{self._key_prefix}:events:record:{event_id}"
+
+    def _event_log_task_key(self, task_id: "str") -> "str":
+        return f"{self._key_prefix}:events:task:{hashed_index_value(task_id)}"
+
+    def _event_log_task_name_key(self, task_name: "str") -> "str":
+        return f"{self._key_prefix}:events:task_name:{hashed_index_value(task_name)}"
+
+    def _event_log_event_type_key(self, event_type: "str") -> "str":
+        return f"{self._key_prefix}:events:event_type:{hashed_index_value(event_type)}"
 
     def _record_to_mapping(self, record: "QueuedTaskRecord") -> "dict[str, str]":
         return {

--- a/src/litestar_queues/backends/redis/event_log.py
+++ b/src/litestar_queues/backends/redis/event_log.py
@@ -1,0 +1,302 @@
+"""Redis-protocol queue event history."""
+
+# ruff: noqa: SLF001
+
+import asyncio
+import hashlib
+import inspect
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
+
+from litestar_queues.events._log_records import (
+    event_log_record_from_event,
+    event_log_record_sort_key,
+    optional_float,
+    optional_int,
+    optional_str,
+    parse_datetime,
+)
+from litestar_queues.events.log import QueueEventLogRecord
+
+if TYPE_CHECKING:
+    from litestar_queues.backends.redis._typing import RedisClientLike, RedisPipelineLike
+    from litestar_queues.backends.redis.backend import RedisQueueBackend
+    from litestar_queues.events import EventLogConfig, QueueEvent, QueueEventStageSummary
+
+__all__ = ("RedisQueueEventLog",)
+
+logger = logging.getLogger(__name__)
+
+
+class RedisQueueEventLog:
+    """Buffered Redis-protocol event-history writer and query interface."""
+
+    __slots__ = ("_backend", "_config", "_flush_lock", "_last_flush", "_pending")
+
+    def __init__(self, *, backend: "RedisQueueBackend", config: "EventLogConfig") -> "None":
+        self._backend = backend
+        self._config = config
+        self._pending: "list[dict[str, str]]" = []
+        self._last_flush = time.monotonic()
+        self._flush_lock = asyncio.Lock()
+
+    async def publish_event(self, event: "QueueEvent") -> "None":
+        """Buffer a queue event and flush when configured thresholds are reached."""
+        should_flush = False
+        async with self._flush_lock:
+            self._pending.append(self._mapping_from_record(event_log_record_from_event(event)))
+            should_flush = len(self._pending) >= max(1, self._config.buffer_size) or self._flush_interval_elapsed()
+        if should_flush:
+            await self.flush_events()
+
+    async def flush_events(self) -> "None":
+        """Flush buffered queue events through a Redis pipeline.
+
+        Returns:
+            None.
+        """
+        async with self._flush_lock:
+            if not self._pending:
+                return
+            batch = list(self._pending)
+            try:
+                client = await self._backend._get_client()
+                await self._write_batch(client, batch)
+            except Exception:
+                if self._config.strict:
+                    raise
+                logger.warning("Redis queue event history flush failed", exc_info=True)
+                return
+            del self._pending[: len(batch)]
+            self._last_flush = time.monotonic()
+
+    async def list_events(
+        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+    ) -> "list[QueueEventLogRecord]":
+        """Return durable event history records."""
+        await self.flush_events()
+        client = await self._backend._get_client()
+        index_key = self._select_index_key(task_id=task_id, task_name=task_name)
+        event_ids = await client.zrangebyscore(index_key, "-inf", "+inf")
+        records = await self._records_from_ids(client, event_ids)
+        records = [
+            record
+            for record in records
+            if (task_id is None or record.task_id == task_id) and (task_name is None or record.task_name == task_name)
+        ]
+        records.sort(key=event_log_record_sort_key)
+        return records[:limit] if limit is not None else records
+
+    async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":
+        """Return no aggregate summaries for the Redis-protocol event log."""
+        del task_name
+        return []
+
+    async def cleanup_before(self, before: "datetime") -> "int":
+        """Delete event history older than ``before``.
+
+        Returns:
+            Number of removed event-history records.
+        """
+        await self.flush_events()
+        client = await self._backend._get_client()
+        event_ids = await client.zrangebyscore(
+            self._backend._event_log_global_key(), "-inf", f"({_score_datetime(before)}"
+        )
+        mappings = await self._mappings_from_ids(client, event_ids)
+        removed = 0
+        pipeline = _create_pipeline(client)
+        for event_id, mapping in zip(event_ids, mappings, strict=True):
+            decoded_event_id = str(_decode(event_id))
+            if not mapping:
+                if pipeline is not None:
+                    pipeline.zrem(self._backend._event_log_global_key(), decoded_event_id)
+                else:
+                    await client.zrem(self._backend._event_log_global_key(), decoded_event_id)
+                continue
+            record = _record_from_mapping(mapping)
+            if record.occurred_at >= before:
+                continue
+            index_keys = _json_loads(mapping.get("index_keys"), [])
+            event_key = self._backend._event_log_event_key(record.event_id)
+            if pipeline is not None:
+                pipeline.delete(event_key)
+                for index_key in index_keys:
+                    pipeline.zrem(str(index_key), record.event_id)
+            else:
+                await client.delete(event_key)
+                for index_key in index_keys:
+                    await client.zrem(str(index_key), record.event_id)
+            removed += 1
+        if pipeline is not None:
+            await _execute_pipeline(pipeline)
+        return removed
+
+    async def _write_batch(self, client: "RedisClientLike", batch: "list[dict[str, str]]") -> "None":
+        pipeline = _create_pipeline(client)
+        if pipeline is not None:
+            for mapping in batch:
+                self._queue_write(pipeline, mapping)
+            await _execute_pipeline(pipeline)
+            return
+        for mapping in batch:
+            event_id = mapping["event_id"]
+            await client.hset(self._backend._event_log_event_key(event_id), mapping=mapping)
+            score = _score_datetime(parse_datetime(mapping["occurred_at"]))
+            for index_key in _json_loads(mapping["index_keys"], []):
+                await client.zadd(str(index_key), {event_id: score})
+
+    def _queue_write(self, pipeline: "RedisPipelineLike", mapping: "dict[str, str]") -> "None":
+        event_id = mapping["event_id"]
+        pipeline.hset(self._backend._event_log_event_key(event_id), mapping=mapping)
+        score = _score_datetime(parse_datetime(mapping["occurred_at"]))
+        for index_key in _json_loads(mapping["index_keys"], []):
+            pipeline.zadd(str(index_key), {event_id: score})
+
+    def _mapping_from_record(self, record: "QueueEventLogRecord") -> "dict[str, str]":
+        index_keys = [self._backend._event_log_global_key(), self._backend._event_log_event_type_key(record.event_type)]
+        if record.task_id is not None:
+            index_keys.append(self._backend._event_log_task_key(record.task_id))
+        if record.task_name is not None:
+            index_keys.append(self._backend._event_log_task_name_key(record.task_name))
+        return {
+            "event_id": record.event_id,
+            "event_type": record.event_type,
+            "task_id": record.task_id or "",
+            "task_name": record.task_name or "",
+            "queue": record.queue or "",
+            "worker_id": record.worker_id or "",
+            "execution_backend": record.execution_backend or "",
+            "execution_profile": record.execution_profile or "",
+            "level": record.level or "",
+            "message": record.message or "",
+            "detail": _json_dumps(record.detail),
+            "progress_current": _optional_number(record.progress_current),
+            "progress_total": _optional_number(record.progress_total),
+            "progress_percent": _optional_number(record.progress_percent),
+            "sequence": "" if record.sequence is None else str(record.sequence),
+            "occurred_at": _serialize_datetime(record.occurred_at),
+            "created_at": _serialize_datetime(record.created_at),
+            "index_keys": _json_dumps(index_keys),
+        }
+
+    async def _records_from_ids(self, client: "RedisClientLike", event_ids: "list[Any]") -> "list[QueueEventLogRecord]":
+        return [
+            _record_from_mapping(mapping) for mapping in await self._mappings_from_ids(client, event_ids) if mapping
+        ]
+
+    async def _mappings_from_ids(self, client: "RedisClientLike", event_ids: "list[Any]") -> "list[dict[str, Any]]":
+        event_keys = [self._backend._event_log_event_key(str(_decode(event_id))) for event_id in event_ids]
+        if not event_keys:
+            return []
+        pipeline = _create_pipeline(client)
+        if pipeline is None:
+            return [_decode_mapping(await client.hgetall(key)) for key in event_keys]
+        for key in event_keys:
+            pipeline.hgetall(key)
+        return [_decode_mapping(cast("dict[Any, Any]", result)) for result in await _execute_pipeline(pipeline)]
+
+    def _select_index_key(self, *, task_id: "str | None", task_name: "str | None") -> "str":
+        if task_id is not None:
+            return self._backend._event_log_task_key(task_id)
+        if task_name is not None:
+            return self._backend._event_log_task_name_key(task_name)
+        return self._backend._event_log_global_key()
+
+    def _flush_interval_elapsed(self) -> "bool":
+        return self._config.flush_interval <= 0 or time.monotonic() - self._last_flush >= self._config.flush_interval
+
+
+def _record_from_mapping(mapping: "dict[str, Any]") -> "QueueEventLogRecord":
+    detail = _json_loads(mapping.get("detail"), {})
+    if not isinstance(detail, dict):
+        detail = {}
+    return QueueEventLogRecord(
+        event_id=str(mapping["event_id"]),
+        event_type=str(mapping["event_type"]),
+        task_id=_optional_mapping_str(mapping.get("task_id")),
+        task_name=_optional_mapping_str(mapping.get("task_name")),
+        queue=_optional_mapping_str(mapping.get("queue")),
+        worker_id=_optional_mapping_str(mapping.get("worker_id")),
+        execution_backend=_optional_mapping_str(mapping.get("execution_backend")),
+        execution_profile=_optional_mapping_str(mapping.get("execution_profile")),
+        stage=optional_str(detail.get("stage")),
+        level=_optional_mapping_str(mapping.get("level")),
+        message=_optional_mapping_str(mapping.get("message")),
+        detail=detail,
+        progress_current=optional_float(_json_loads(mapping.get("progress_current"), None)),
+        progress_total=optional_float(_json_loads(mapping.get("progress_total"), None)),
+        progress_percent=optional_float(_json_loads(mapping.get("progress_percent"), None)),
+        duration_ms=optional_float(detail.get("duration_ms")),
+        sequence=optional_int(mapping.get("sequence") or None),
+        occurred_at=parse_datetime(mapping["occurred_at"]),
+        created_at=parse_datetime(mapping["created_at"]),
+    )
+
+
+def _optional_number(value: "float | None") -> "str":
+    return "" if value is None else _json_dumps(value)
+
+
+def _optional_mapping_str(value: "Any") -> "str | None":
+    if value in {None, ""}:
+        return None
+    return optional_str(value)
+
+
+def _serialize_datetime(value: "datetime") -> "str":
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _score_datetime(value: "datetime") -> "float":
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).timestamp()
+
+
+def _json_dumps(value: "Any") -> "str":
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def _json_loads(value: "Any", default: "Any") -> "Any":
+    value = _decode(value)
+    if value in {None, ""}:
+        return default
+    return json.loads(str(value))
+
+
+def _decode(value: "Any") -> "Any":
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
+
+def _decode_mapping(mapping: "dict[Any, Any]") -> "dict[str, Any]":
+    return {str(_decode(key)): _decode(value) for key, value in mapping.items()}
+
+
+def _create_pipeline(client: "RedisClientLike") -> "RedisPipelineLike | None":
+    pipeline_factory = getattr(client, "pipeline", None)
+    if pipeline_factory is None:
+        return None
+    try:
+        return cast("RedisPipelineLike", pipeline_factory(transaction=False))
+    except TypeError:
+        return cast("RedisPipelineLike", pipeline_factory())
+
+
+async def _execute_pipeline(pipeline: "RedisPipelineLike") -> "list[Any]":
+    result = pipeline.execute()
+    if inspect.isawaitable(result):
+        return list(await result)
+    return list(cast("list[Any]", result))
+
+
+def hashed_index_value(value: "str") -> "str":
+    """Return a stable Redis-key-safe index value."""
+    return hashlib.sha256(value.encode()).hexdigest()

--- a/src/litestar_queues/backends/sqlspec/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/__init__.py
@@ -2,5 +2,6 @@
 
 from litestar_queues.backends.sqlspec.backend import SQLSpecQueueBackend
 from litestar_queues.backends.sqlspec.config import SQLSpecBackendConfig
+from litestar_queues.backends.sqlspec.extension import configure_queue_migration_extension
 
-__all__ = ("SQLSpecBackendConfig", "SQLSpecQueueBackend")
+__all__ = ("SQLSpecBackendConfig", "SQLSpecQueueBackend", "configure_queue_migration_extension")

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -3,7 +3,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
-from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable
 from logging import getLogger
@@ -28,7 +27,7 @@ from litestar_queues.backends.sqlspec.event_log import (
     create_event_log_store,
     resolve_event_log_table_name,
 )
-from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME, configure_queue_migration_extension
+from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.backends.sqlspec.schema import (
     DEFAULT_TABLE_NAME,
     resolve_column_map,
@@ -168,7 +167,6 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
     __slots__ = (
         "_column_map",
-        "_create_schema",
         "_event_backend",
         "_event_channel",
         "_event_log",
@@ -191,11 +189,10 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         "_owns_event_channel",
         "_owns_sqlspec",
         "_queue_observability",
-        "_run_migrations",
+        "_queue_table_name",
         "_sqlspec",
         "_sqlspec_config",
         "_store",
-        "_table_name",
     )
 
     def __init__(
@@ -212,11 +209,11 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         self._heartbeat_pool_enabled = self._heartbeat_pool_config is not None
         self._heartbeat_pool_registered = False
         self._owns_sqlspec = self._sqlspec is None
-        self._table_name = (
-            validate_table_name(backend_config.table_name) if backend_config.table_name is not None else None
+        self._queue_table_name = (
+            validate_table_name(backend_config.queue_table_name)
+            if backend_config.queue_table_name is not None
+            else None
         )
-        self._create_schema = backend_config.create_schema
-        self._run_migrations = backend_config.run_migrations
         self._event_channel = backend_config.event_channel
         self._owns_event_channel = self._event_channel is None
         self._notifications_requested = backend_config.notifications
@@ -251,14 +248,10 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             return True
 
         self._get_or_create_sqlspec()
-        self._resolve_table_name()
+        self._resolve_queue_table_name()
         self._configure_notifications()
         self._register_heartbeat_pool()
         self._opened = True
-        if self._resolve_run_migrations():
-            await self.run_migrations()
-        if self._resolve_create_schema():
-            await self.create_schema()
         return True
 
     async def close(self) -> "None":
@@ -322,19 +315,6 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 for statement in statements:
                     await driver.execute_script(statement)
                 await driver.commit()
-
-    async def run_migrations(self) -> "None":
-        """Apply packaged SQLSpec migrations."""
-        if self._manage_schema:
-            sqlspec_config = self._get_sqlspec_config()
-            event_log_enabled = self._event_log_enabled()
-            with _temporary_queue_migration_extension(
-                sqlspec_config,
-                table_name=self._resolve_table_name(),
-                event_log_enabled=event_log_enabled,
-                event_log_table_name=self._resolve_event_log_table_name() if event_log_enabled else None,
-            ):
-                await sqlspec_config.migrate_up(echo=False)
 
     async def enqueue(
         self,
@@ -1087,26 +1067,12 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
         return cast("SQLSpecConfig", AiosqliteConfig())
 
-    def _resolve_table_name(self) -> "str":
-        if self._table_name is None:
+    def _resolve_queue_table_name(self) -> "str":
+        if self._queue_table_name is None:
             queue_settings = _queue_extension_settings(self._sqlspec_config)
             configured_table_name = _setting(queue_settings, "table_name") or DEFAULT_TABLE_NAME
-            self._table_name = validate_table_name(str(configured_table_name))
-        return self._table_name
-
-    def _resolve_create_schema(self) -> "bool":
-        if not self._manage_schema:
-            return False
-        return _resolve_bool(
-            self._create_schema, _queue_extension_settings(self._sqlspec_config), "create_schema", True
-        )
-
-    def _resolve_run_migrations(self) -> "bool":
-        if not self._manage_schema:
-            return False
-        return _resolve_bool(
-            self._run_migrations, _queue_extension_settings(self._sqlspec_config), "run_migrations", False
-        )
+            self._queue_table_name = validate_table_name(str(configured_table_name))
+        return self._queue_table_name
 
     def _resolve_notification_channel(self) -> "str":
         if self._notification_channel is not None:
@@ -1276,7 +1242,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         if self._store is None:
             self._store = create_queue_store(
                 self._get_sqlspec_config(),
-                table_name=self._resolve_table_name(),
+                table_name=self._resolve_queue_table_name(),
                 column_map=self._column_map,
                 native_json_columns=self._native_json_columns,
                 manage_schema=self._manage_schema,
@@ -1287,7 +1253,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         if self._event_log_store is None:
             store = create_event_log_store(
                 self._get_sqlspec_config(),
-                queue_table_name=self._resolve_table_name(),
+                queue_table_name=self._resolve_queue_table_name(),
                 event_log_table_name=self._event_log_table_name,
                 manage_schema=self._manage_schema,
             )
@@ -1303,7 +1269,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
     def _resolve_event_log_table_name(self) -> "str":
         if self._event_log_table_name is None:
-            self._event_log_table_name = resolve_event_log_table_name(self._resolve_table_name())
+            self._event_log_table_name = resolve_event_log_table_name(self._resolve_queue_table_name())
         return self._event_log_table_name
 
     @asynccontextmanager
@@ -1889,42 +1855,6 @@ def _queue_extension_settings(sqlspec_config: "SQLSpecStoreConfig | None") -> "d
     return dict(extension_config.get(QUEUE_EXTENSION_NAME, {}) or {})
 
 
-@contextmanager
-def _temporary_queue_migration_extension(
-    sqlspec_config: "SQLSpecConfig",
-    *,
-    table_name: "str",
-    event_log_enabled: "bool" = False,
-    event_log_table_name: "str | None" = None,
-) -> "Iterator[None]":
-    original_extension_config = deepcopy(sqlspec_config.extension_config or {})
-    original_migration_config = deepcopy(sqlspec_config.migration_config or {})
-
-    extension_config = deepcopy(original_extension_config)
-    queue_settings = dict(extension_config.get(QUEUE_EXTENSION_NAME, {}) or {})
-    queue_settings["table_name"] = validate_table_name(table_name)
-    if event_log_enabled:
-        queue_settings["event_log_enabled"] = True
-        queue_settings["event_log_table_name"] = resolve_event_log_table_name(
-            table_name, event_log_table_name=event_log_table_name
-        )
-    extension_config[QUEUE_EXTENSION_NAME] = queue_settings
-
-    sqlspec_config.extension_config = extension_config
-    sqlspec_config.set_migration_config(deepcopy(original_migration_config))
-    configure_queue_migration_extension(
-        sqlspec_config,
-        table_name=table_name,
-        event_log_enabled=event_log_enabled,
-        event_log_table_name=event_log_table_name,
-    )
-    try:
-        yield
-    finally:
-        sqlspec_config.extension_config = original_extension_config
-        sqlspec_config.set_migration_config(original_migration_config)
-
-
 async def _create_schema_statements(store: "SQLSpecQueueStore", driver: "SQLSpecDriver") -> "list[str]":
     create_for_driver = getattr(store, "create_statements_for_driver", None)
     if callable(create_for_driver):
@@ -1947,14 +1877,6 @@ def _setting(queue_settings: "dict[str, Any]", *names: "str") -> "Any":
         if name in queue_settings:
             return queue_settings[name]
     return None
-
-
-def _resolve_bool(value: "bool | None", queue_settings: "dict[str, Any]", key: "str", default: "bool") -> "bool":
-    if value is not None:
-        return value
-    if key in queue_settings:
-        return bool(queue_settings[key])
-    return default
 
 
 def _normalize_notification_channel(channel: "str") -> "str":

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -65,11 +65,32 @@ if TYPE_CHECKING:
 __all__ = ("SQLSpecQueueBackend",)
 
 _DUE_STATUSES = ("pending", "scheduled")
-_DURABLE_NOTIFICATION_BACKENDS = frozenset({"aq", "listen_notify_durable", "table_queue", "txeventq"})
+_DURABLE_NOTIFICATION_BACKENDS = frozenset({"aq", "notify_queue", "poll_queue", "txeventq"})
 _EVENT_EXTENSION_NAME = "events"
 _QUEUE_SETTING_EVENT_SETTINGS = ("event_settings", "events")
 
 _NOTIFY_TRANSPORT_POLLING = "polling"
+_CANONICAL_NOTIFY_TRANSPORTS = frozenset({"aq", "notify", "notify_queue", "poll_queue", "polling", "txeventq"})
+_LEGACY_NOTIFY_TRANSPORTS = frozenset({"listen_notify", "listen_notify_durable", "table_queue"})
+_SQLSPEC_EVENT_BACKENDS = {
+    "aq": "aq",
+    "notify": "listen_notify",
+    "notify_queue": "listen_notify_durable",
+    "poll_queue": "table_queue",
+    "polling": "polling",
+    "txeventq": "txeventq",
+}
+_CANONICAL_EVENT_BACKENDS = {
+    "aq": "aq",
+    "listen_notify": "notify",
+    "listen_notify_durable": "notify_queue",
+    "notify": "notify",
+    "notify_queue": "notify_queue",
+    "poll_queue": "poll_queue",
+    "polling": "polling",
+    "table_queue": "poll_queue",
+    "txeventq": "txeventq",
+}
 # Adapter families that can push worker wakeups. Postgres-over-asyncpg ships the
 # durable LISTEN/NOTIFY hybrid; psycopg/psqlpy fall back to the durable table
 # queue until their LISTEN/NOTIFY path lands upstream. Everything else polls.
@@ -96,14 +117,38 @@ def _adapter_notify_transport(adapter_name: "str | None") -> "str":
     advertise push wakeups where the driver can deliver them.
 
     Returns:
-        ``"listen_notify_durable"`` for asyncpg, ``"table_queue"`` for
-        psycopg/psqlpy, otherwise ``"polling"``.
+        ``"notify_queue"`` for asyncpg, ``"poll_queue"`` for psycopg/psqlpy,
+        otherwise ``"polling"``.
     """
     if adapter_name in _NOTIFY_DURABLE_ADAPTERS:
-        return "listen_notify_durable"
+        return "notify_queue"
     if adapter_name in _NOTIFY_TABLE_QUEUE_ADAPTERS:
-        return "table_queue"
+        return "poll_queue"
     return _NOTIFY_TRANSPORT_POLLING
+
+
+def _canonical_notify_transport(backend_name: "str | None") -> "str | None":
+    """Map a SQLSpec event backend name to the queue transport vocabulary."""
+    if backend_name is None:
+        return None
+    return _CANONICAL_EVENT_BACKENDS.get(backend_name, backend_name)
+
+
+def _sqlspec_event_backend(transport: "str") -> "str":
+    """Map a canonical queue transport to the SQLSpec Events backend name."""
+    return _SQLSPEC_EVENT_BACKENDS.get(transport, transport)
+
+
+def _validate_queue_notify_transport(transport: "str") -> "str":
+    """Validate explicit queue transport configuration from extension settings."""
+    if transport in _CANONICAL_NOTIFY_TRANSPORTS:
+        return transport
+    valid = ", ".join(sorted(_CANONICAL_NOTIFY_TRANSPORTS))
+    if transport in _LEGACY_NOTIFY_TRANSPORTS:
+        msg = f"Invalid notify_transport {transport!r}; use canonical queue transport names: {valid}."
+    else:
+        msg = f"Invalid notify_transport {transport!r}; expected one of: {valid}."
+    raise QueueConfigurationError(msg)
 
 
 class SQLSpecQueueBackend(BaseQueueBackend):
@@ -177,7 +222,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         self._queue_observability = backend_config.queue_observability and not _package_queue_observability_enabled(
             config
         )
-        self._notification_backend: "str | None" = getattr(self._event_channel, "_backend_name", None)
+        self._notification_backend = _canonical_notify_transport(getattr(self._event_channel, "_backend_name", None))
         self._notifications_enabled = self._event_channel is not None
         self._event_log_store: "Any | None" = None
         self._event_log: "SQLSpecQueueEventLog | None" = None
@@ -1089,7 +1134,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             # An injected channel already owns its backend; still resolve the
             # configured poll interval so wait_for_notifications honors it.
             self._resolve_event_poll_interval(queue_settings, events_settings)
-        self._notification_backend = cast("str | None", getattr(self._event_channel, "_backend_name", None))
+        self._notification_backend = _canonical_notify_transport(
+            cast("str | None", getattr(self._event_channel, "_backend_name", None))
+        )
 
     def _resolve_notifications_requested(self, queue_settings: "dict[str, Any]") -> "bool | None":
         notifications_requested = self._notifications_requested
@@ -1107,17 +1154,20 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         capability gate.
 
         Returns:
-            A wakeup transport name (``listen_notify``, ``listen_notify_durable``,
-            ``table_queue``, or ``polling``), or an events backend name carried
-            over from existing ``event_backend`` configuration.
+            A canonical wakeup transport name (``notify``, ``notify_queue``,
+            ``poll_queue``, ``polling``, ``aq``, or ``txeventq``).
         """
-        explicit = self._notify_transport or _setting(queue_settings, "notify_transport")
-        if explicit is None:
-            explicit = (
-                self._event_backend or _setting(queue_settings, "event_backend") or events_settings.get("backend")
-            )
+        explicit = self._notify_transport
         if explicit is not None:
-            return str(explicit)
+            return explicit
+        configured_transport = _setting(queue_settings, "notify_transport")
+        if configured_transport is not None:
+            return _validate_queue_notify_transport(str(configured_transport))
+        configured_backend = self._event_backend or _setting(queue_settings, "event_backend") or events_settings.get(
+            "backend"
+        )
+        if configured_backend is not None:
+            return _canonical_notify_transport(str(configured_backend)) or _NOTIFY_TRANSPORT_POLLING
         return _adapter_notify_transport(resolve_adapter_name(sqlspec_config))
 
     def _notifications_should_enable(
@@ -1178,7 +1228,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             if isinstance(configured_events, dict):
                 merged_event_settings.update(configured_events)
         merged_event_settings.update(self._event_settings)
-        merged_event_settings["backend"] = transport
+        merged_event_settings["backend"] = _sqlspec_event_backend(transport)
 
         configured_queue_table = self._event_queue_table or _setting(queue_settings, "event_queue_table")
         if configured_queue_table is not None:

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1058,7 +1058,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
         stream = self._event_channel.iter_events(
             self._resolve_notification_channel(),
-            poll_interval=self._event_poll_interval if self._event_poll_interval is not None else timeout,
+            poll_interval=self._event_poll_interval,
         )
         try:
             if timeout is None:

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -128,19 +128,31 @@ def _adapter_notify_transport(adapter_name: "str | None") -> "str":
 
 
 def _canonical_notify_transport(backend_name: "str | None") -> "str | None":
-    """Map a SQLSpec event backend name to the queue transport vocabulary."""
+    """Map a SQLSpec event backend name to the queue transport vocabulary.
+
+    Returns:
+        The canonical queue transport name, if one can be resolved.
+    """
     if backend_name is None:
         return None
     return _CANONICAL_EVENT_BACKENDS.get(backend_name, backend_name)
 
 
 def _sqlspec_event_backend(transport: "str") -> "str":
-    """Map a canonical queue transport to the SQLSpec Events backend name."""
+    """Map a canonical queue transport to the SQLSpec Events backend name.
+
+    Returns:
+        The SQLSpec Events backend name.
+    """
     return _SQLSPEC_EVENT_BACKENDS.get(transport, transport)
 
 
 def _validate_queue_notify_transport(transport: "str") -> "str":
-    """Validate explicit queue transport configuration from extension settings."""
+    """Validate explicit queue transport configuration from extension settings.
+
+    Returns:
+        The validated canonical queue transport name.
+    """
     if transport in _CANONICAL_NOTIFY_TRANSPORTS:
         return transport
     valid = ", ".join(sorted(_CANONICAL_NOTIFY_TRANSPORTS))
@@ -418,10 +430,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                     raise
 
         self._increment_queue_metric("enqueue", float(len(to_insert)))
-        for record in to_insert:
-            if record.status not in _DUE_STATUSES or not record.is_due:
-                continue
-            await self.notify_new_task(record)
+        await self.notify_new_tasks(to_insert)
         return results
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -1033,16 +1042,16 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
     async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
         """Publish a SQLSpec event when configured queue work becomes available."""
-        if self._notifications_enabled and self._event_channel is not None and record.status in _DUE_STATUSES:
-            with self._observe_queue_operation("notify", task_id=str(record.id), queue=record.queue):
+        if (
+            self._notifications_enabled
+            and self._event_channel is not None
+            and record.status in _DUE_STATUSES
+            and record.is_due
+        ):
+            with self._observe_queue_operation("notify", queue=record.queue):
                 await self._event_channel.publish(
                     self._resolve_notification_channel(),
-                    {
-                        "task_id": str(record.id),
-                        "task_name": record.task_name,
-                        "queue": record.queue,
-                        "execution_backend": record.execution_backend,
-                    },
+                    {"event": "task_available"},
                     {"event_type": "litestar_queues.task_available"},
                 )
             self._increment_queue_metric("notify")
@@ -1057,8 +1066,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             return await super().wait_for_notifications(timeout=timeout)
 
         stream = self._event_channel.iter_events(
-            self._resolve_notification_channel(),
-            poll_interval=self._event_poll_interval,
+            self._resolve_notification_channel(), poll_interval=self._event_poll_interval
         )
         try:
             if timeout is None:
@@ -1163,8 +1171,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         configured_transport = _setting(queue_settings, "notify_transport")
         if configured_transport is not None:
             return _validate_queue_notify_transport(str(configured_transport))
-        configured_backend = self._event_backend or _setting(queue_settings, "event_backend") or events_settings.get(
-            "backend"
+        configured_backend = (
+            self._event_backend or _setting(queue_settings, "event_backend") or events_settings.get("backend")
         )
         if configured_backend is not None:
             return _canonical_notify_transport(str(configured_backend)) or _NOTIFY_TRANSPORT_POLLING

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -40,9 +40,7 @@ class SQLSpecBackendConfig:
     sqlspec: "SQLSpec | None" = None
     config: "SQLSpecStoreConfig | None" = None
     heartbeat_pool_config: "SQLSpecStoreConfig | None" = None
-    table_name: "str | None" = None
-    create_schema: "bool | None" = None
-    run_migrations: "bool | None" = None
+    queue_table_name: "str | None" = None
     event_channel: "AsyncEventChannel | None" = None
     notifications: "bool | None" = None
     notification_channel: "str | None" = None
@@ -59,8 +57,8 @@ class SQLSpecBackendConfig:
 
     def __post_init__(self) -> "None":
         """Validate adopter-owned table and wakeup-transport configuration."""
-        if self.table_name is not None:
-            self.table_name = validate_table_name(self.table_name)
+        if self.queue_table_name is not None:
+            self.queue_table_name = validate_table_name(self.queue_table_name)
         if self.event_log_table_name is not None:
             self.event_log_table_name = validate_table_name(self.event_log_table_name)
         self.column_map = resolve_column_map(self.column_map)

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -22,14 +22,7 @@ __all__ = ("DEFAULT_NOTIFICATION_CHANNEL", "NOTIFY_TRANSPORTS", "SQLSpecBackendC
 
 DEFAULT_NOTIFICATION_CHANNEL = "litestar_queues_tasks"
 
-NOTIFY_TRANSPORTS: "frozenset[str]" = frozenset({
-    "aq",
-    "notify",
-    "notify_queue",
-    "poll_queue",
-    "polling",
-    "txeventq",
-})
+NOTIFY_TRANSPORTS: "frozenset[str]" = frozenset({"aq", "notify", "notify_queue", "poll_queue", "polling", "txeventq"})
 """Valid worker-wakeup transports for :attr:`SQLSpecBackendConfig.notify_transport`.
 
 ``notify`` uses native push wakeups, ``notify_queue`` uses native push wakeups

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -24,18 +24,18 @@ DEFAULT_NOTIFICATION_CHANNEL = "litestar_queues_tasks"
 
 NOTIFY_TRANSPORTS: "frozenset[str]" = frozenset({
     "aq",
-    "listen_notify",
-    "listen_notify_durable",
+    "notify",
+    "notify_queue",
+    "poll_queue",
     "polling",
-    "table_queue",
     "txeventq",
 })
 """Valid worker-wakeup transports for :attr:`SQLSpecBackendConfig.notify_transport`.
 
-``listen_notify``/``listen_notify_durable`` push wakeups through native
-LISTEN/NOTIFY, ``table_queue`` uses the durable events table, ``aq`` and
-``txeventq`` use Oracle Advanced Queuing backends, and ``polling`` disables
-push wakeups so workers fall back to interval polling.
+``notify`` uses native push wakeups, ``notify_queue`` uses native push wakeups
+with a durable queue fallback, ``poll_queue`` uses the durable events table,
+``aq`` and ``txeventq`` use Oracle Advanced Queuing backends, and ``polling``
+disables push wakeups so workers fall back to interval polling.
 """
 
 

--- a/src/litestar_queues/backends/sqlspec/extension.py
+++ b/src/litestar_queues/backends/sqlspec/extension.py
@@ -27,14 +27,14 @@ def queue_migration_directory() -> "Path":
 def configure_queue_migration_extension(
     sqlspec_config: "SQLSpecConfig",
     *,
-    table_name: "str" = DEFAULT_TABLE_NAME,
+    queue_table_name: "str" = DEFAULT_TABLE_NAME,
     event_log_enabled: "bool" = False,
     event_log_table_name: "str | None" = None,
 ) -> "None":
     """Register the packaged queue migration with SQLSpec's extension runner."""
     queue_settings = _configure_extension_settings(
         sqlspec_config,
-        table_name=table_name,
+        queue_table_name=queue_table_name,
         event_log_enabled=event_log_enabled,
         event_log_table_name=event_log_table_name,
     )
@@ -52,16 +52,16 @@ def configure_queue_migration_extension(
 def _configure_extension_settings(
     sqlspec_config: "SQLSpecConfig",
     *,
-    table_name: "str",
+    queue_table_name: "str",
     event_log_enabled: "bool" = False,
     event_log_table_name: "str | None" = None,
 ) -> "dict[str, Any]":
     extension_config = dict(sqlspec_config.extension_config or {})
     queue_settings = dict(extension_config.get(QUEUE_EXTENSION_NAME, {}) or {})
-    queue_settings["table_name"] = validate_table_name(table_name)
+    queue_settings["table_name"] = validate_table_name(queue_table_name)
     if event_log_enabled:
         queue_settings["event_log_enabled"] = True
         queue_settings["event_log_table_name"] = validate_table_name(
-            event_log_table_name or event_log_table_name_for(table_name)
+            event_log_table_name or event_log_table_name_for(queue_table_name)
         )
     return queue_settings

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -267,9 +267,9 @@ class QueueConfig:
             "non_retryable": non_retryable,
         }
         with suppress(ImportError):
-            from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyQueueBackend
+            from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend
 
-            namespace["AdvancedAlchemyQueueBackend"] = AdvancedAlchemyQueueBackend
+            namespace["SQLAlchemyBackend"] = SQLAlchemyBackend
         with suppress(ImportError):
             from litestar_queues.backends.sqlspec import SQLSpecQueueBackend
 

--- a/src/litestar_queues/events/_log_records.py
+++ b/src/litestar_queues/events/_log_records.py
@@ -1,0 +1,93 @@
+"""Internal helpers for backend-managed queue event history records."""
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
+
+from litestar_queues.events.log import QueueEventLogRecord
+
+if TYPE_CHECKING:
+    from litestar_queues.events.models import QueueEvent
+
+__all__ = (
+    "event_log_record_from_event",
+    "event_log_record_sort_key",
+    "optional_float",
+    "optional_int",
+    "optional_str",
+    "parse_datetime",
+    "utc_now",
+)
+
+
+def event_log_record_from_event(event: "QueueEvent", *, created_at: "datetime | None" = None) -> "QueueEventLogRecord":
+    """Convert a queue event envelope into a backend-neutral history record.
+
+    Returns:
+        Backend-neutral event-history record.
+    """
+    detail = dict(event.payload)
+    return QueueEventLogRecord(
+        event_id=event.id,
+        event_type=event.type,
+        task_id=event.task_id,
+        task_name=event.task_name,
+        queue=event.queue,
+        worker_id=event.worker_id,
+        execution_backend=event.execution_backend,
+        execution_profile=event.execution_profile,
+        stage=optional_str(detail.get("stage")),
+        level=event.level,
+        message=event.message,
+        detail=detail,
+        progress_current=optional_float(event.progress_current),
+        progress_total=optional_float(event.progress_total),
+        progress_percent=optional_float(event.progress_percent),
+        duration_ms=optional_float(detail.get("duration_ms")),
+        sequence=event.sequence,
+        occurred_at=parse_datetime(event.occurred_at),
+        created_at=created_at or utc_now(),
+    )
+
+
+def event_log_record_sort_key(record: "QueueEventLogRecord") -> "tuple[datetime, int, str]":
+    """Return SQLSpec-compatible ascending event-history sort key."""
+    return (record.occurred_at, record.sequence if record.sequence is not None else 0, record.event_id)
+
+
+def parse_datetime(value: "Any") -> "datetime":
+    """Return a timezone-aware UTC datetime."""
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        if isinstance(value, bytes | bytearray):
+            value = bytes(value).decode()
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def utc_now() -> "datetime":
+    """Return the current UTC timestamp."""
+    return datetime.now(timezone.utc)
+
+
+def optional_str(value: "Any") -> "str | None":
+    """Return string values only."""
+    return value if isinstance(value, str) else None
+
+
+def optional_float(value: "Any") -> "float | None":
+    """Return numeric values as floats, excluding booleans."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def optional_int(value: "Any") -> "int | None":
+    """Return optional integer values."""
+    if value is None:
+        return None
+    return int(cast("int", value))

--- a/src/litestar_queues/events/log.py
+++ b/src/litestar_queues/events/log.py
@@ -19,6 +19,13 @@ class EventLogConfig:
     buffer_size: "int" = 20
     flush_interval: "float" = 1.0
     strict: "bool" = False
+    max_records: "int" = 1000
+
+    def __post_init__(self) -> "None":
+        """Validate event-history configuration."""
+        if self.max_records <= 0:
+            msg = "EventLogConfig.max_records must be greater than 0."
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/litestar_queues/events/producer.py
+++ b/src/litestar_queues/events/producer.py
@@ -4,8 +4,9 @@ import inspect
 from typing import TYPE_CHECKING, Any, Literal
 
 from litestar_queues.events.models import QueueEvent
-from litestar_queues.events.publisher import QueueEventPublisher
+from litestar_queues.events.publisher import EventConfig, QueueEventPublisher
 from litestar_queues.events.sinks import NoopQueueEventSink, QueueEventSink
+from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
     from litestar_queues.config import QueueConfig
 
 __all__ = ("QueueEventProducer", "create_event_producer")
+
+EventProducerTransport = Literal["configured", "sqlspec"]
 
 
 class QueueEventProducer:
@@ -40,23 +43,29 @@ class QueueEventProducer:
         return _ScopeEventHandle(self._publisher, "custom", scope_key)
 
 
-def create_event_producer(config: "QueueConfig") -> "_ExternalProducer":
+def create_event_producer(
+    config: "QueueConfig", *, transport: "EventProducerTransport" = "configured"
+) -> "_ExternalProducer":
     """Return an external producer context manager for queue event publishing."""
-    return _ExternalProducer(config)
+    return _ExternalProducer(config, transport=transport)
 
 
 class _ExternalProducer:
-    __slots__ = ("_config", "_producer", "_resource")
+    __slots__ = ("_config", "_producer", "_publisher", "_resource", "_transport")
 
-    def __init__(self, config: "QueueConfig") -> "None":
+    def __init__(self, config: "QueueConfig", *, transport: "EventProducerTransport") -> "None":
         self._config = config
+        self._transport = transport
         self._producer: "QueueEventProducer | None" = None
+        self._publisher: "QueueEventPublisher | None" = None
         self._resource: "object | None" = None
 
     async def __aenter__(self) -> "QueueEventProducer":
         sink, resource, publisher = self._build_publisher()
         self._resource = resource if resource is not None else sink
         await _call_optional_lifecycle(self._resource, "open", "on_startup")
+        publisher.start_buffer()
+        self._publisher = publisher
         self._producer = QueueEventProducer(publisher)
         return self._producer
 
@@ -70,10 +79,16 @@ class _ExternalProducer:
 
     async def aclose(self) -> "None":
         """Close the external producer transport if it is open."""
+        publisher = self._publisher
         resource = self._resource
         self._producer = None
+        self._publisher = None
         self._resource = None
-        await _call_optional_lifecycle(resource, "close", "on_shutdown")
+        try:
+            if publisher is not None:
+                await publisher.stop_buffer()
+        finally:
+            await _call_optional_lifecycle(resource, "close", "on_shutdown")
 
     async def close(self) -> "None":
         """Close the external producer transport if it is open."""
@@ -81,6 +96,8 @@ class _ExternalProducer:
 
     def _build_publisher(self) -> "tuple[QueueEventSink, object | None, QueueEventPublisher]":
         event_config = self._config.event
+        if event_config is None and self._transport == "sqlspec":
+            event_config = EventConfig()
         resource: "object | None" = None
         if event_config is None:
             sink: "QueueEventSink" = NoopQueueEventSink()
@@ -88,6 +105,13 @@ class _ExternalProducer:
             return sink, resource, publisher
         if not event_config.enabled:
             sink = NoopQueueEventSink()
+        elif self._transport == "sqlspec":
+            sink = _build_sqlspec_sink(
+                self._config,
+                max_payload_bytes=event_config.max_payload_bytes,
+                payload_size_estimator=event_config.payload_size_estimator,
+            )
+            resource = sink
         elif event_config.sink is not None:
             sink = event_config.sink
             resource = sink
@@ -104,6 +128,7 @@ class _ExternalProducer:
             sink = NoopQueueEventSink()
         publisher = QueueEventPublisher(
             sink,
+            buffer_config=event_config.buffer,
             strict=event_config.strict,
             publish_task_channel=event_config.publish_task_channel,
             publish_queue_channel=event_config.publish_queue_channel,
@@ -266,3 +291,19 @@ async def _call_optional_lifecycle(resource: "object | None", primary: "str", fa
     result = method()
     if inspect.isawaitable(result):
         await result
+
+
+def _build_sqlspec_sink(
+    config: "QueueConfig", *, max_payload_bytes: "int | None", payload_size_estimator: "Any"
+) -> "QueueEventSink":
+    queue_backend = config.queue_backend
+    backend_name = queue_backend if isinstance(queue_backend, str) else getattr(queue_backend, "backend_name", None)
+    if backend_name != "sqlspec" or isinstance(queue_backend, str):
+        msg = "transport='sqlspec' requires QueueConfig.queue_backend to be a SQLSpecBackendConfig-like object."
+        raise QueueConfigurationError(msg)
+
+    from litestar_queues.events.sqlspec import SQLSpecQueueEventSink
+
+    return SQLSpecQueueEventSink(
+        queue_backend, max_payload_bytes=max_payload_bytes, payload_size_estimator=payload_size_estimator
+    )

--- a/src/litestar_queues/events/sqlspec.py
+++ b/src/litestar_queues/events/sqlspec.py
@@ -1,0 +1,167 @@
+"""SQLSpec event-channel sink for external queue event producers."""
+
+import inspect
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from litestar_queues.events.chunking import QueueEventSizeEstimator
+    from litestar_queues.events.models import QueueEvent
+
+__all__ = ("SQLSpecQueueEventSink",)
+
+_EVENT_EXTENSION_NAME = "events"
+_POLLING_TRANSPORT = "polling"
+
+
+class SQLSpecQueueEventSink:
+    """Publish queue events through a SQLSpec ``AsyncEventChannel``."""
+
+    __slots__ = (
+        "_backend_config",
+        "_channel",
+        "_max_payload_bytes",
+        "_owns_channel",
+        "_owns_sqlspec",
+        "_payload_size_estimator",
+        "_sqlspec",
+        "_sqlspec_config",
+    )
+
+    def __init__(
+        self,
+        backend_config: "object",
+        *,
+        max_payload_bytes: "int | None" = None,
+        payload_size_estimator: "QueueEventSizeEstimator | None" = None,
+    ) -> "None":
+        self._backend_config = backend_config
+        self._channel = getattr(backend_config, "event_channel", None)
+        self._owns_channel = self._channel is None
+        self._sqlspec = getattr(backend_config, "sqlspec", None)
+        self._owns_sqlspec = self._sqlspec is None
+        self._sqlspec_config = getattr(backend_config, "config", None)
+        self._max_payload_bytes = max_payload_bytes
+        self._payload_size_estimator = payload_size_estimator
+
+    async def open(self) -> "None":
+        """Lifecycle hook kept for external producer symmetry."""
+
+    async def close(self) -> "None":
+        """Close only SQLSpec resources owned by this sink."""
+        if self._owns_channel and self._channel is not None:
+            result = self._channel.shutdown()
+            if inspect.isawaitable(result):
+                await result
+            self._channel = None
+        if self._owns_sqlspec and self._sqlspec is not None:
+            result = self._sqlspec.close_all_pools()
+            if inspect.isawaitable(result):
+                await result
+            self._sqlspec = None
+
+    async def publish(self, event: "QueueEvent", *, channels: "Sequence[str]") -> "None":
+        """Publish one event to each requested SQLSpec channel."""
+        for event_chunk in self._event_chunks(event):
+            for channel in channels:
+                await self._publish_one(event_chunk, channel=channel)
+
+    async def publish_many(self, batch: "Sequence[tuple[QueueEvent, Sequence[str]]]") -> "None":
+        """Publish a producer batch without introducing a second event envelope."""
+        grouped: "dict[tuple[str, ...], list[QueueEvent]]" = {}
+        for event, channels in batch:
+            grouped.setdefault(tuple(channels), []).extend(self._event_chunks(event))
+        for channels, events in grouped.items():
+            for event in events:
+                for channel in channels:
+                    await self._publish_one(event, channel=channel)
+
+    def _event_chunks(self, event: "QueueEvent") -> "Sequence[QueueEvent]":
+        if self._max_payload_bytes is None:
+            return (event,)
+        from litestar_queues.events.chunking import estimate_event_payload_bytes, split_event_batch_by_size
+
+        estimator = self._payload_size_estimator or estimate_event_payload_bytes
+        return split_event_batch_by_size(event, max_bytes=self._max_payload_bytes, size_estimator=estimator)
+
+    async def _publish_one(self, event: "QueueEvent", *, channel: "str") -> "None":
+        event_channel = self._get_event_channel()
+        await event_channel.publish(channel, event.to_dict(), _metadata_for(event))
+
+    def _get_event_channel(self) -> "Any":
+        if self._channel is None:
+            sqlspec_config = self._get_sqlspec_config()
+            self._apply_event_settings(sqlspec_config)
+            self._channel = self._get_or_create_sqlspec().event_channel(sqlspec_config)
+            self._owns_channel = True
+        return self._channel
+
+    def _get_or_create_sqlspec(self) -> "Any":
+        if self._sqlspec is None:
+            from sqlspec import SQLSpec
+
+            self._sqlspec = SQLSpec()
+        return self._sqlspec
+
+    def _get_sqlspec_config(self) -> "Any":
+        if self._sqlspec_config is not None:
+            return self._sqlspec_config
+        registered_configs = tuple(cast("dict[int, Any]", self._get_or_create_sqlspec().configs).values())
+        if len(registered_configs) == 1:
+            self._sqlspec_config = registered_configs[0]
+            return self._sqlspec_config
+        if len(registered_configs) > 1:
+            from litestar_queues.exceptions import QueueConfigurationError
+
+            msg = (
+                "SQLSpec event producer received a SQLSpec manager with multiple configs; "
+                "pass config to select the event database."
+            )
+            raise QueueConfigurationError(msg)
+        from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+        self._sqlspec_config = AiosqliteConfig()
+        return self._sqlspec_config
+
+    def _apply_event_settings(self, sqlspec_config: "Any") -> "None":
+        extension_config = deepcopy(getattr(sqlspec_config, "extension_config", None) or {})
+        event_settings = dict(extension_config.get(_EVENT_EXTENSION_NAME, {}))
+        configured_settings = getattr(self._backend_config, "event_settings", None)
+        if isinstance(configured_settings, dict):
+            event_settings.update(configured_settings)
+        backend_name = _event_backend_name(self._backend_config, event_settings)
+        if backend_name is not None:
+            event_settings["backend"] = backend_name
+        queue_table = getattr(self._backend_config, "event_queue_table", None)
+        if queue_table is not None:
+            event_settings["queue_table"] = str(queue_table)
+        poll_interval = getattr(self._backend_config, "event_poll_interval", None)
+        if poll_interval is not None:
+            event_settings["poll_interval"] = float(poll_interval)
+        extension_config[_EVENT_EXTENSION_NAME] = event_settings
+        sqlspec_config.extension_config = extension_config
+        migration_config = dict(getattr(sqlspec_config, "migration_config", None) or {})
+        set_migration_config = getattr(sqlspec_config, "set_migration_config", None)
+        if set_migration_config is not None:
+            set_migration_config(migration_config)
+        else:
+            sqlspec_config.migration_config = migration_config
+
+
+def _event_backend_name(backend_config: "object", event_settings: "dict[str, Any]") -> "str | None":
+    configured = getattr(backend_config, "event_backend", None)
+    if configured is not None:
+        return str(configured)
+    configured = event_settings.get("backend")
+    if configured is not None:
+        return str(configured)
+    transport = getattr(backend_config, "notify_transport", None)
+    if transport is not None and transport != _POLLING_TRANSPORT:
+        return str(transport)
+    return None
+
+
+def _metadata_for(event: "QueueEvent") -> "dict[str, object]":
+    return {"event_type": event.type, "queue_event_id": event.id, "queue_event_scope": event.scope}

--- a/src/litestar_queues/models.py
+++ b/src/litestar_queues/models.py
@@ -47,6 +47,7 @@ class QueueBackendCapabilities:
     supports_notifications: "bool" = False
     notification_backend: "str | None" = None
     notifications_durable: "bool" = False
+    supports_batch_claim: "bool" = False
     supports_heartbeats: "bool" = True
     supports_atomic_claim: "bool" = True
     supports_atomic_delayed_promotion: "bool" = True

--- a/src/litestar_queues/plugin.py
+++ b/src/litestar_queues/plugin.py
@@ -3,7 +3,7 @@ import contextlib
 import logging
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from litestar.plugins import InitPlugin
 
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from litestar.datastructures import State
 
     from litestar_queues.backends import BaseQueueBackend
+    from litestar_queues.backends.sqlspec._typing import SQLSpecConfig
     from litestar_queues.events import QueueEventPublisher
     from litestar_queues.typing import ChannelsLike
 
@@ -71,12 +72,47 @@ class QueuePlugin(InitPlugin):
             return self._service
         return QueueService(self._config, queue_backend=self._queue_backend, event_publisher=self._event_publisher)
 
+    def _configure_sqlspec_migrations(self) -> "None":
+        """Register queue migrations with the application's SQLSpec config.
+
+        Returns:
+            None.
+        """
+        from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+
+        backend_config = self._config.queue_backend
+        if not isinstance(backend_config, SQLSpecBackendConfig):
+            return
+
+        sqlspec_config = backend_config.config
+        if sqlspec_config is None and backend_config.sqlspec is not None:
+            registered_configs = tuple(backend_config.sqlspec.configs.values())
+            if len(registered_configs) == 1:
+                sqlspec_config = registered_configs[0]
+        if sqlspec_config is None:
+            return
+
+        from litestar_queues.backends.sqlspec import configure_queue_migration_extension
+        from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME
+
+        extension_config = sqlspec_config.extension_config or {}
+        queue_settings = dict(extension_config.get("litestar_queues", {}) or {})
+        queue_table_name = backend_config.queue_table_name or queue_settings.get("table_name") or DEFAULT_TABLE_NAME
+        event_log_config = self._config.event_log
+        configure_queue_migration_extension(
+            cast("SQLSpecConfig", sqlspec_config),
+            queue_table_name=str(queue_table_name),
+            event_log_enabled=event_log_config is not None and event_log_config.enabled,
+            event_log_table_name=backend_config.event_log_table_name,
+        )
+
     def on_app_init(self, app_config: "AppConfig") -> "AppConfig":
         """Register queue dependencies, signature namespace, state, and the lifespan manager.
 
         Returns:
             The updated application configuration.
         """
+        self._configure_sqlspec_migrations()
         self._queue_backend = self._config.get_queue_backend()
         event_config = self._config.event
         if (
@@ -209,6 +245,8 @@ class QueuePlugin(InitPlugin):
         Args:
             cli: The root ``click.Group`` of the Litestar CLI.
         """
+        self._configure_sqlspec_migrations()
+
         from litestar_queues._cli import register
 
         register(cli)

--- a/src/litestar_queues/task.py
+++ b/src/litestar_queues/task.py
@@ -502,8 +502,6 @@ class Task(Generic[P, T]):
         kwargs = dict(record.kwargs)
         if extra_kwargs:
             kwargs.update(extra_kwargs)
-        if self._accepts_job_id():
-            kwargs["_job_id"] = str(record.id)
         if task_context is not None and self._accepts_task_context():
             kwargs["_task_context"] = task_context
         if inspect.iscoroutinefunction(self._func):
@@ -577,13 +575,6 @@ class Task(Generic[P, T]):
 
         async with QueueService(QueueConfig(execution_backend="immediate")) as service:
             return await service.enqueue(cast("Task[Any, Any]", self), *args, **enqueue_kwargs)
-
-    def _accepts_job_id(self) -> "bool":
-        signature = inspect.signature(self._func)
-        parameters = signature.parameters
-        return "_job_id" in parameters or any(
-            param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()
-        )
 
     def _accepts_task_context(self) -> "bool":
         signature = inspect.signature(self._func)

--- a/src/litestar_queues/worker.py
+++ b/src/litestar_queues/worker.py
@@ -162,6 +162,8 @@ class Worker:
         queue_backend = self._service.get_queue_backend()
         execution_backend_name_ = execution_backend_name(self._service.config.execution_backend)
         records: 'list["QueuedTaskRecord"]' = []
+        if queue_backend.capabilities.supports_batch_claim and not self._queues:
+            return await queue_backend.claim_many(limit=limit, execution_backend=execution_backend_name_)
         if not self._queues:
             for _ in range(limit):
                 claimed = await queue_backend.claim_next(execution_backend=execution_backend_name_)
@@ -175,6 +177,15 @@ class Worker:
             for queue in self._queues:
                 if len(records) >= limit:
                     break
+                if queue_backend.capabilities.supports_batch_claim:
+                    claimed_records = await queue_backend.claim_many(
+                        limit=1, queue=queue, execution_backend=execution_backend_name_
+                    )
+                    if not claimed_records:
+                        continue
+                    records.extend(claimed_records)
+                    claimed_this_pass = True
+                    continue
                 claimed = await queue_backend.claim_next(queue=queue, execution_backend=execution_backend_name_)
                 if claimed is None:
                     continue

--- a/src/tests/e2e/server_manager.py
+++ b/src/tests/e2e/server_manager.py
@@ -148,9 +148,7 @@ class ExampleServer:
         env = os.environ.copy()
         env.update({
             "LITESTAR_APP": EXAMPLE_APPS[self.example_name],
-            "LITESTAR_QUEUES_EXAMPLE_STEPS": "2",
-            "LITESTAR_QUEUES_EXAMPLE_STEP_DELAY": "0.05",
-            "LITESTAR_QUEUES_EXAMPLE_VITE_DEV": "1" if self.mode == "dev" else "0",
+            "VITE_DEV_MODE": "1" if self.mode == "dev" else "0",
             "LITESTAR_BYPASS_ENV_CHECK": "1",
             "PYTHONUNBUFFERED": "1",
         })

--- a/src/tests/e2e/test_realtime_browser.py
+++ b/src/tests/e2e/test_realtime_browser.py
@@ -87,7 +87,7 @@ def _start_mission(page: Any, base_url: str) -> str:
     with page.expect_response(
         lambda response: response.request.method == "POST" and response.url == f"{base_url}/demo/restart"
     ) as response_info:
-        page.get_by_role("button", name="Restart the demo queue job and crawl").click()
+        page.get_by_role("button", name="Restart the demo queue task").click()
     response = response_info.value
     assert response.status == 200, response.status_text
 
@@ -98,9 +98,11 @@ def _start_mission(page: Any, base_url: str) -> str:
     return task_id
 
 
-def _wait_for_completion(page: Any) -> None:
-    page.locator("#job-readout").filter(has_text="Mission complete").wait_for(state="visible")
-    assert "1/2 -" in page.locator("#crawl-lines").inner_text()
+def _wait_for_completion(page: Any, *, require_first_line: bool = True) -> None:
+    page.locator("#job-readout").filter(has_text="Task complete").wait_for(state="visible")
+    if require_first_line:
+        assert "1/6 -" in page.locator("#crawl-lines").inner_text()
+    assert "Backend message received" in page.locator("#delivery-status").inner_text()
 
 
 @pytest.mark.parametrize("example_name", ["sse"], indirect=True)
@@ -204,4 +206,22 @@ def test_replacing_stream_mount_reconnects_cleanly(
         assert second_socket is not None, websocket_states
         assert websocket_states[first_socket], websocket_states
     assert not _ERROR_EVENTS.intersection(events), events
+    _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode, allow_stream_abort=True)
+
+
+@pytest.mark.parametrize("example_name", ["sse"], indirect=True)
+def test_repeated_start_reuses_active_task(
+    example_server: Any, browser_page: Any, browser_diagnostics: BrowserDiagnostics
+) -> None:
+    """A second click while the demo is active follows the same queue record."""
+    page = browser_page
+    page.goto(example_server.base_url, wait_until="domcontentloaded")
+    _install_event_collector(page)
+
+    first_task_id = _start_mission(page, example_server.base_url)
+    second_task_id = _start_mission(page, example_server.base_url)
+
+    assert second_task_id == first_task_id
+    page.locator("#job-readout").filter(has_text="already running").wait_for(state="visible")
+    _wait_for_completion(page, require_first_line=False)
     _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode, allow_stream_abort=True)

--- a/src/tests/e2e/test_realtime_topology.py
+++ b/src/tests/e2e/test_realtime_topology.py
@@ -54,8 +54,6 @@ def test_shared_channels_deliver_from_a_standalone_worker(
         url_env: url,
         "LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS": "1",
         "LITESTAR_QUEUES_EXAMPLE_IN_APP_WORKER": "0",
-        "LITESTAR_QUEUES_EXAMPLE_STEPS": "2",
-        "LITESTAR_QUEUES_EXAMPLE_STEP_DELAY": "0.05",
         f"LITESTAR_QUEUES_EXAMPLE_{key_env}_KEY_PREFIX": queue_prefix,
         "LITESTAR_QUEUES_EXAMPLE_CHANNELS_KEY_PREFIX": f"litestar_queues:e2e:{suffix}:channels",
     }

--- a/src/tests/integration/_backends.py
+++ b/src/tests/integration/_backends.py
@@ -112,16 +112,20 @@ async def _build_memory(ctx: "FixtureCtx") -> "BaseQueueBackend":
     return InMemoryQueueBackend()
 
 
-def _sqlspec_backend(sqlspec_config: "SQLSpecStoreConfig", *, table_name: "str | None" = None) -> "BaseQueueBackend":
+def _sqlspec_backend(
+    sqlspec_config: "SQLSpecStoreConfig", *, queue_table_name: "str | None" = None
+) -> "BaseQueueBackend":
     """Return a SQLSpec backend configured through the typed config object.
 
-    ``table_name`` is set per-case by the fixture so adapters sharing the
+    ``queue_table_name`` is set per-case by the fixture so adapters sharing the
     same Docker database (the Postgres/MySQL/Oracle service containers)
     each own a dedicated queue table and cannot pollute one another.
     """
     from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueBackend
 
-    return SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config, table_name=table_name))
+    return SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, queue_table_name=queue_table_name)
+    )
 
 
 async def _build_aiosqlite(ctx: "FixtureCtx") -> "BaseQueueBackend":
@@ -129,7 +133,7 @@ async def _build_aiosqlite(ctx: "FixtureCtx") -> "BaseQueueBackend":
 
     return _sqlspec_backend(
         AiosqliteConfig(connection_config={"database": str(ctx.tmp_path / "queue-aiosqlite.db")}),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -140,7 +144,7 @@ async def _build_adbc_sqlite(ctx: "FixtureCtx") -> "BaseQueueBackend":
         AdbcConfig(
             connection_config={"driver_name": "adbc_driver_sqlite", "uri": str(ctx.tmp_path / "queue-adbc-sqlite.db")}
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -148,7 +152,8 @@ async def _build_sqlite(ctx: "FixtureCtx") -> "BaseQueueBackend":
     from sqlspec.adapters.sqlite import SqliteConfig
 
     return _sqlspec_backend(
-        SqliteConfig(connection_config={"database": str(ctx.tmp_path / "queue-sqlite.db")}), table_name=ctx.table_name
+        SqliteConfig(connection_config={"database": str(ctx.tmp_path / "queue-sqlite.db")}),
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -156,7 +161,8 @@ async def _build_duckdb(ctx: "FixtureCtx") -> "BaseQueueBackend":
     from sqlspec.adapters.duckdb import DuckDBConfig
 
     return _sqlspec_backend(
-        DuckDBConfig(connection_config={"database": str(ctx.tmp_path / "queue-duckdb.db")}), table_name=ctx.table_name
+        DuckDBConfig(connection_config={"database": str(ctx.tmp_path / "queue-duckdb.db")}),
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -175,7 +181,7 @@ async def _build_postgres_asyncpg(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "database": svc.database,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -194,7 +200,7 @@ async def _build_postgres_psycopg(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "dbname": svc.database,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -213,7 +219,7 @@ async def _build_postgres_psqlpy(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "db_name": svc.database,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -233,7 +239,7 @@ async def _build_cockroach_asyncpg(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "ssl": False,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -244,7 +250,7 @@ async def _build_cockroach_psycopg(ctx: "FixtureCtx") -> "BaseQueueBackend":
     assert svc is not None
     conninfo = f"postgresql://root@{svc.host}:{svc.port}/{svc.database}?sslmode=disable"
     return _sqlspec_backend(
-        CockroachPsycopgAsyncConfig(connection_config={"conninfo": conninfo}), table_name=ctx.table_name
+        CockroachPsycopgAsyncConfig(connection_config={"conninfo": conninfo}), queue_table_name=ctx.table_name
     )
 
 
@@ -263,7 +269,7 @@ async def _build_mysql_asyncmy(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "database": svc.db,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -282,7 +288,7 @@ async def _build_mysql_aiomysql(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "db": svc.db,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -301,7 +307,7 @@ async def _build_mysql_mysqlconnector(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "database": svc.db,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -320,7 +326,7 @@ async def _build_mysql_pymysql(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "database": svc.db,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -339,7 +345,7 @@ async def _build_oracle_oracledb(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "service_name": svc.service_name,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -366,7 +372,7 @@ async def _build_mssql_mssql_python(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "trust_server_certificate": True,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -391,7 +397,7 @@ async def _build_mssql_pymssql(ctx: "FixtureCtx") -> "BaseQueueBackend":
                 "database": svc.database,
             }
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 
@@ -405,7 +411,7 @@ async def _build_arrow_odbc_mssql(ctx: "FixtureCtx") -> "BaseQueueBackend":
             connection_config={"connection_string": svc.connection_string},
             driver_features={"dbms_name": "Microsoft SQL Server"},
         ),
-        table_name=ctx.table_name,
+        queue_table_name=ctx.table_name,
     )
 
 

--- a/src/tests/integration/backends/advanced_alchemy/_aa_engines.py
+++ b/src/tests/integration/backends/advanced_alchemy/_aa_engines.py
@@ -2,8 +2,8 @@
 
 Mirrors ``tests.integration._backends`` but for ``SQLAlchemyAsyncConfig``
 factories. Each ``AAEngineCase`` knows how to build a config from a
-``FixtureCtx``; the subdir conftest wraps that config in
-``AdvancedAlchemyBackendConfig(create_schema=True)`` and owns lifecycle.
+``FixtureCtx``. The subdir conftest creates the test table with SQLAlchemy's
+native ``Table.create`` path before opening the queue backend.
 """
 
 from dataclasses import dataclass
@@ -30,8 +30,8 @@ class AAEngineCase:
 
 # ---------------------------------------------------------------------------
 # Config factories. Each returns an unopened SQLAlchemyAsyncConfig; the
-# fixture wraps it in AdvancedAlchemyBackendConfig(create_schema=True) and
-# runs open()/close().
+# fixture creates the test model's table and runs the backend open()/close()
+# lifecycle.
 # ---------------------------------------------------------------------------
 
 

--- a/src/tests/integration/backends/advanced_alchemy/_aa_schema.py
+++ b/src/tests/integration/backends/advanced_alchemy/_aa_schema.py
@@ -1,0 +1,21 @@
+"""Native SQLAlchemy schema helpers for Advanced Alchemy integration tests."""
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+    from sqlalchemy import Table
+
+
+class MappedModel(Protocol):
+    """Minimal protocol for a mapped model with a SQLAlchemy table."""
+
+    __table__: "Table"
+
+
+async def create_tables(config: "SQLAlchemyAsyncConfig", *models: "type[MappedModel]") -> "None":
+    """Create selected tables through SQLAlchemy's native table lifecycle."""
+    engine = config.get_engine()
+    async with engine.begin() as connection:
+        for model in models:
+            await connection.run_sync(model.__table__.create, checkfirst=True)

--- a/src/tests/integration/backends/advanced_alchemy/_aa_schema.py
+++ b/src/tests/integration/backends/advanced_alchemy/_aa_schema.py
@@ -1,6 +1,6 @@
 """Native SQLAlchemy schema helpers for Advanced Alchemy integration tests."""
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 if TYPE_CHECKING:
     from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
@@ -13,9 +13,10 @@ class MappedModel(Protocol):
     __table__: "Table"
 
 
-async def create_tables(config: "SQLAlchemyAsyncConfig", *models: "type[MappedModel]") -> "None":
+async def create_tables(config: "SQLAlchemyAsyncConfig", *models: "type[object]") -> "None":
     """Create selected tables through SQLAlchemy's native table lifecycle."""
     engine = config.get_engine()
     async with engine.begin() as connection:
         for model in models:
-            await connection.run_sync(model.__table__.create, checkfirst=True)
+            table = cast("MappedModel", model).__table__
+            await connection.run_sync(table.create, checkfirst=True)

--- a/src/tests/integration/backends/advanced_alchemy/conftest.py
+++ b/src/tests/integration/backends/advanced_alchemy/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures and parametrize hook for Advanced Alchemy backend tests.
 
 Provides the ``advanced_alchemy_backend`` async fixture that yields an
-opened ``AdvancedAlchemyQueueBackend`` parametrized over ``AA_ENGINES``.
+opened ``SQLAlchemyBackend`` parametrized over ``AA_ENGINES``.
 For service-backed engines, drops the queue table on teardown so the
 shared Docker DB stays isolated between tests.
 """
@@ -14,6 +14,7 @@ import pytest
 from tests.integration._backends import FixtureCtx
 from tests.integration._names import table_name_for_test
 from tests.integration.backends.advanced_alchemy._aa_engines import AA_ENGINES, AAEngineCase
+from tests.integration.backends.advanced_alchemy._aa_schema import create_tables
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy import Table
 
-    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyQueueBackend
+    from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend
 
 
 class MappedQueueModel(Protocol):
@@ -47,7 +48,7 @@ def _queue_model(table_name: "str") -> "type[object]":
 @pytest.fixture
 async def advanced_alchemy_backend(
     request: "pytest.FixtureRequest", tmp_path: "Path"
-) -> "AsyncIterator[AdvancedAlchemyQueueBackend]":
+) -> "AsyncIterator[SQLAlchemyBackend]":
     """Yield an opened Advanced Alchemy queue backend parametrized over AA_ENGINES.
 
     For service-backed engines (Postgres/MySQL/Oracle), the queue table is
@@ -55,7 +56,7 @@ async def advanced_alchemy_backend(
     In-process (aiosqlite) gets a unique tmp_path DB file per test so no extra
     cleanup is required.
     """
-    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, AdvancedAlchemyQueueBackend
+    from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend, SQLAlchemyBackendConfig
 
     case: "AAEngineCase" = request.param
     for extra in case.extras:
@@ -73,10 +74,10 @@ async def advanced_alchemy_backend(
     ctx = FixtureCtx(tmp_path=tmp_path, service=service)
     config = case.build_config(ctx)
     table_name = table_name_for_test("aa_queue_task", case.name, request.node.nodeid)
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=config, model_class=_queue_model(table_name), create_schema=True
-        )
+    model_class = _queue_model(table_name)
+    await create_tables(config, model_class)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=model_class)
     )
     await backend.open()
     try:
@@ -88,7 +89,7 @@ async def advanced_alchemy_backend(
         await backend.close()
 
 
-async def _drop_queue_tables(backend: "AdvancedAlchemyQueueBackend") -> "None":
+async def _drop_queue_tables(backend: "SQLAlchemyBackend") -> "None":
     """Drop the queue table for service-backed engines.
 
     Uses the dialect-aware ``Table.drop()`` path for the queue table so

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -27,13 +27,10 @@ from advanced_alchemy.operations import MergeStatement
 
 from litestar_queues import HeartbeatTouch, QueueConfig, QueueService, task
 from litestar_queues.backends import get_queue_backend_class, list_queue_backends
-from litestar_queues.backends.advanced_alchemy import (
-    AdvancedAlchemyBackendConfig,
-    AdvancedAlchemyQueueBackend,
-    QueueTaskModelMixin,
-)
+from litestar_queues.backends.advanced_alchemy import QueueTaskModelMixin, SQLAlchemyBackend, SQLAlchemyBackendConfig
 from litestar_queues.models import EnqueueSpec, QueuedTaskRecord
 from litestar_queues.task import clear_task_registry
+from tests.integration.backends.advanced_alchemy._aa_schema import create_tables
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -50,12 +47,12 @@ def clean_task_registry() -> "None":
 
 
 class ContractQueueTask(UUIDAuditBase, QueueTaskModelMixin):
-    __tablename__ = "aa_contract_queue_tasks"
+    __tablename__ = "aa_contract_queue_task"
 
 
 async def test_advanced_alchemy_backend_is_registered_without_sqlspec() -> "None":
     assert "advanced-alchemy" in list_queue_backends()
-    assert get_queue_backend_class("advanced-alchemy") is AdvancedAlchemyQueueBackend
+    assert get_queue_backend_class("advanced-alchemy") is SQLAlchemyBackend
 
 
 def test_top_level_litestar_queues_import_does_not_require_advanced_alchemy() -> "None":
@@ -78,7 +75,7 @@ import litestar_queues
 from litestar_queues import InMemoryQueueBackend, QueueConfig
 
 assert "InMemoryQueueBackend" in litestar_queues.__all__
-assert "AdvancedAlchemyQueueBackend" not in litestar_queues.__all__
+assert "SQLAlchemyBackend" not in litestar_queues.__all__
 assert QueueConfig().queue_backend == "memory"
 """
     result = run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
@@ -86,13 +83,13 @@ assert QueueConfig().queue_backend == "memory"
     assert result.returncode == 0, result.stderr
 
 
-async def test_advanced_alchemy_backend_exposes_schema_bootstrap_config(tmp_path: "Path") -> "None":
-    backend_config = AdvancedAlchemyBackendConfig(
-        sqlalchemy_config=_sqlite_config(tmp_path / "configured.db"), model_class=ContractQueueTask, create_schema=True
-    )
+def test_advanced_alchemy_backend_uses_upstream_schema_lifecycle(tmp_path: "Path") -> "None":
+    sqlalchemy_config = _sqlite_config(tmp_path / "configured.db")
+    backend_config = SQLAlchemyBackendConfig(sqlalchemy_config=sqlalchemy_config, model_class=ContractQueueTask)
 
     assert backend_config.model_class is ContractQueueTask
-    assert backend_config.create_schema is True
+    assert sqlalchemy_config.create_all is False
+    assert not hasattr(backend_config, "create_schema")
 
 
 def test_advanced_alchemy_mixin_uses_native_json_column_types() -> "None":
@@ -192,7 +189,7 @@ def test_advanced_alchemy_keyed_enqueue_uses_native_upsert_for_supported_dialect
 
 
 async def test_advanced_alchemy_backend_deduplicates_active_keys_and_replaces_terminal_keys(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     first = await advanced_alchemy_backend.enqueue("tasks.sync", kwargs={"account_id": "acct-1"}, key="sync:acct-1")
     duplicate = await advanced_alchemy_backend.enqueue("tasks.sync", kwargs={"account_id": "acct-2"}, key="sync:acct-1")
@@ -213,10 +210,10 @@ async def test_advanced_alchemy_backend_deduplicates_active_keys_and_replaces_te
 
 
 async def test_advanced_alchemy_enqueue_many_uses_one_operation_and_coalesces_due_wakeups(tmp_path: "Path") -> "None":
-    backend = _CountingAdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "bulk.db"), model_class=ContractQueueTask, create_schema=True
-        )
+    config = _sqlite_config(tmp_path / "bulk.db")
+    await create_tables(config, ContractQueueTask)
+    backend = _CountingSQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=ContractQueueTask)
     )
     await backend.open()
     try:
@@ -238,12 +235,10 @@ async def test_advanced_alchemy_enqueue_many_uses_one_operation_and_coalesces_du
 
 
 async def test_advanced_alchemy_enqueue_many_empty_batch_opens_no_operation(tmp_path: "Path") -> "None":
-    backend = _CountingAdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "empty-bulk.db"),
-            model_class=ContractQueueTask,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "empty-bulk.db")
+    await create_tables(config, ContractQueueTask)
+    backend = _CountingSQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=ContractQueueTask)
     )
     await backend.open()
     try:
@@ -255,12 +250,10 @@ async def test_advanced_alchemy_enqueue_many_empty_batch_opens_no_operation(tmp_
 
 
 async def test_advanced_alchemy_enqueue_many_rolls_back_and_skips_notification_on_failure(tmp_path: "Path") -> "None":
-    backend = _CountingAdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "bulk-failure.db"),
-            model_class=ContractQueueTask,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "bulk-failure.db")
+    await create_tables(config, ContractQueueTask)
+    backend = _CountingSQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=ContractQueueTask)
     )
     await backend.open()
     failing_service = type("FailingBulkService", (backend._service_class,), {"enqueue_many": _failing_enqueue_many})
@@ -276,12 +269,10 @@ async def test_advanced_alchemy_enqueue_many_rolls_back_and_skips_notification_o
 
 
 async def test_advanced_alchemy_enqueue_many_handles_large_batch_with_bounded_operation(tmp_path: "Path") -> "None":
-    backend = _CountingAdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "bulk-large.db"),
-            model_class=ContractQueueTask,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "bulk-large.db")
+    await create_tables(config, ContractQueueTask)
+    backend = _CountingSQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=ContractQueueTask)
     )
     await backend.open()
     try:
@@ -297,7 +288,7 @@ async def test_advanced_alchemy_enqueue_many_handles_large_batch_with_bounded_op
 
 
 async def test_advanced_alchemy_claim_many_falls_back_safely_on_sqlite(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     first = await advanced_alchemy_backend.enqueue("tasks.claim.first", priority=1)
     second = await advanced_alchemy_backend.enqueue("tasks.claim.second", priority=10)
@@ -317,30 +308,27 @@ async def test_advanced_alchemy_claim_many_falls_back_safely_on_sqlite(
 async def test_advanced_alchemy_capabilities_are_polling_only_without_postgres_notifications(
     tmp_path: "Path",
 ) -> "None":
-    sqlite_backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "polling.db"),
-            model_class=ContractQueueTask,
-            create_schema=True,
-            notifications=True,
+    sqlite_backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(tmp_path / "polling.db"), model_class=ContractQueueTask, notifications=True
         )
     )
-    postgres_backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
+    postgres_backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
             sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="postgresql+asyncpg://user:pass@localhost/db"),
             model_class=ContractQueueTask,
             notifications=True,
         )
     )
-    mysql_backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
+    mysql_backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
             sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="mysql+asyncmy://user:pass@localhost/db"),
             model_class=ContractQueueTask,
             notifications=True,
         )
     )
-    oracle_backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
+    oracle_backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
             sqlalchemy_config=SQLAlchemyAsyncConfig(
                 connection_string="oracle+oracledb_async://user:pass@localhost:1521/?service_name=FREEPDB1"
             ),
@@ -360,8 +348,8 @@ async def test_advanced_alchemy_capabilities_are_polling_only_without_postgres_n
 
 
 async def test_advanced_alchemy_wait_for_notifications_uses_dedicated_listener(tmp_path: "Path") -> "None":
-    backend = _FakeListenerAdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
+    backend = _FakeListenerSQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
             sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="postgresql+asyncpg://user:pass@localhost/db"),
             model_class=ContractQueueTask,
             notifications=True,
@@ -388,16 +376,17 @@ async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_serv
     pytest.importorskip("asyncpg")
     table_name = f"aa_notify_{uuid4().hex}"
     model_class = _dynamic_queue_model(table_name)
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=SQLAlchemyAsyncConfig(
-                connection_string=(
-                    f"postgresql+asyncpg://{postgres_service.user}:{postgres_service.password}"
-                    f"@{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
-                )
-            ),
+    sqlalchemy_config = SQLAlchemyAsyncConfig(
+        connection_string=(
+            f"postgresql+asyncpg://{postgres_service.user}:{postgres_service.password}"
+            f"@{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
+        )
+    )
+    await create_tables(sqlalchemy_config, model_class)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=sqlalchemy_config,
             model_class=model_class,
-            create_schema=True,
             notifications=True,
             notification_channel=f"lq_notify_{uuid4().hex}",
         )
@@ -421,7 +410,7 @@ async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_serv
 
 
 async def test_advanced_alchemy_backend_claims_due_tasks_by_priority(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     later = datetime.now(timezone.utc) + timedelta(minutes=5)
 
@@ -444,7 +433,7 @@ async def test_advanced_alchemy_backend_claims_due_tasks_by_priority(
 
 
 async def test_advanced_alchemy_backend_fail_task_retries_then_fails_permanently(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     record = await advanced_alchemy_backend.enqueue("tasks.flaky", max_retries=1)
 
@@ -465,7 +454,7 @@ async def test_advanced_alchemy_backend_fail_task_retries_then_fails_permanently
 
 
 async def test_advanced_alchemy_backend_preserves_json_string_results(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     record = await advanced_alchemy_backend.enqueue("tasks.string-result")
     claimed = await advanced_alchemy_backend.claim_task(record.id)
@@ -481,7 +470,7 @@ async def test_advanced_alchemy_backend_preserves_json_string_results(
 
 
 async def test_advanced_alchemy_backend_cancels_heartbeats_and_requeues_stale_running(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     pending = await advanced_alchemy_backend.enqueue("tasks.cancel")
 
@@ -533,7 +522,7 @@ async def test_advanced_alchemy_backend_cancels_heartbeats_and_requeues_stale_ru
 
 
 async def test_advanced_alchemy_backend_touch_heartbeats_handles_mixed_metadata_patches(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     patched = await advanced_alchemy_backend.enqueue(
         "tasks.heartbeat.patched", metadata={"existing": "kept", "patch": "old"}
@@ -569,7 +558,7 @@ async def test_advanced_alchemy_backend_touch_heartbeats_handles_mixed_metadata_
 
 
 async def test_advanced_alchemy_backend_operational_queries_and_execution_refs(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+    advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":
     local = await advanced_alchemy_backend.enqueue("tasks.local", priority=100, execution_backend="local")
     external = await advanced_alchemy_backend.enqueue(
@@ -616,10 +605,10 @@ async def test_queue_service_uses_advanced_alchemy_backend(tmp_path: "Path") -> 
     async def aa_task() -> "str":
         return "ok"
 
+    sqlalchemy_config = _sqlite_config(tmp_path / "service.db")
+    await create_tables(sqlalchemy_config, ContractQueueTask)
     queue_config = QueueConfig(
-        queue_backend=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "service.db"), model_class=ContractQueueTask, create_schema=True
-        )
+        queue_backend=SQLAlchemyBackendConfig(sqlalchemy_config=sqlalchemy_config, model_class=ContractQueueTask)
     )
 
     async with QueueService(queue_config) as service:
@@ -659,7 +648,7 @@ def _dynamic_queue_model(table_name: "str") -> "type[object]":
     )
 
 
-async def _drop_dynamic_queue_model(backend: "AdvancedAlchemyQueueBackend", model_class: "type[object]") -> "None":
+async def _drop_dynamic_queue_model(backend: "SQLAlchemyBackend", model_class: "type[object]") -> "None":
     sqlalchemy_config = backend._sqlalchemy_config
     if sqlalchemy_config is None:
         return
@@ -696,7 +685,7 @@ async def _failing_enqueue_many(self: "Any", specs: "Any") -> "Any":
     raise RuntimeError(msg)
 
 
-class _CountingAdvancedAlchemyQueueBackend(AdvancedAlchemyQueueBackend):
+class _CountingSQLAlchemyBackend(SQLAlchemyBackend):
     __slots__ = ("notification_batches", "operation_count")
 
     def __init__(self, *args: "Any", **kwargs: "Any") -> "None":
@@ -745,7 +734,7 @@ class _FakeNotificationListener:
         self.notified = True
 
 
-class _FakeListenerAdvancedAlchemyQueueBackend(AdvancedAlchemyQueueBackend):
+class _FakeListenerSQLAlchemyBackend(SQLAlchemyBackend):
     __slots__ = ("listener",)
 
     def __init__(self, *args: "Any", **kwargs: "Any") -> "None":

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -6,7 +6,9 @@ fixture parametrized over ``AA_ENGINES`` (aiosqlite + Postgres + MySQL +
 Oracle async configs) by the subdir conftest.
 """
 
+import asyncio
 import sys
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from subprocess import run
 from typing import TYPE_CHECKING, Any, cast
@@ -30,11 +32,14 @@ from litestar_queues.backends.advanced_alchemy import (
     AdvancedAlchemyQueueBackend,
     QueueTaskModelMixin,
 )
-from litestar_queues.models import QueuedTaskRecord
+from litestar_queues.models import EnqueueSpec, QueuedTaskRecord
 from litestar_queues.task import clear_task_registry
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
+
+    from tests.integration._backends import PostgresService
 
 pytestmark = pytest.mark.anyio
 
@@ -205,6 +210,214 @@ async def test_advanced_alchemy_backend_deduplicates_active_keys_and_replaces_te
     keyed = await advanced_alchemy_backend.get_task_by_key("sync:acct-1")
     assert keyed is not None
     assert keyed.id == replacement.id
+
+
+async def test_advanced_alchemy_enqueue_many_uses_one_operation_and_coalesces_due_wakeups(tmp_path: "Path") -> "None":
+    backend = _CountingAdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(tmp_path / "bulk.db"), model_class=ContractQueueTask, create_schema=True
+        )
+    )
+    await backend.open()
+    try:
+        later = datetime.now(timezone.utc) + timedelta(minutes=5)
+        records = await backend.enqueue_many([
+            EnqueueSpec("tasks.bulk.first", key="bulk:active", kwargs={"value": 1}),
+            EnqueueSpec("tasks.bulk.future", scheduled_at=later),
+            EnqueueSpec("tasks.bulk.duplicate", key="bulk:active", kwargs={"value": 2}),
+        ])
+
+        assert backend.operation_count == 1
+        assert [record.task_name for record in records] == ["tasks.bulk.first", "tasks.bulk.future", "tasks.bulk.first"]
+        assert records[0].id == records[2].id
+        assert records[1].status == "scheduled"
+        assert len(backend.notification_batches) == 1
+        assert [record.id for record in backend.notification_batches[0]] == [records[0].id]
+    finally:
+        await backend.close()
+
+
+async def test_advanced_alchemy_enqueue_many_empty_batch_opens_no_operation(tmp_path: "Path") -> "None":
+    backend = _CountingAdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(tmp_path / "empty-bulk.db"),
+            model_class=ContractQueueTask,
+            create_schema=True,
+        )
+    )
+    await backend.open()
+    try:
+        assert await backend.enqueue_many([]) == []
+        assert backend.operation_count == 0
+        assert backend.notification_batches == []
+    finally:
+        await backend.close()
+
+
+async def test_advanced_alchemy_enqueue_many_rolls_back_and_skips_notification_on_failure(tmp_path: "Path") -> "None":
+    backend = _CountingAdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(tmp_path / "bulk-failure.db"),
+            model_class=ContractQueueTask,
+            create_schema=True,
+        )
+    )
+    await backend.open()
+    failing_service = type("FailingBulkService", (backend._service_class,), {"enqueue_many": _failing_enqueue_many})
+    backend._service_class = failing_service
+    try:
+        with pytest.raises(RuntimeError, match="bulk failed"):
+            await backend.enqueue_many([EnqueueSpec("tasks.bulk.failure")])
+
+        assert backend.notification_batches == []
+        assert (await backend.get_statistics()).total == 0
+    finally:
+        await backend.close()
+
+
+async def test_advanced_alchemy_enqueue_many_handles_large_batch_with_bounded_operation(tmp_path: "Path") -> "None":
+    backend = _CountingAdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(tmp_path / "bulk-large.db"),
+            model_class=ContractQueueTask,
+            create_schema=True,
+        )
+    )
+    await backend.open()
+    try:
+        records = await backend.enqueue_many([EnqueueSpec(f"tasks.bulk.{index}") for index in range(1000)])
+        pending = await backend.list_pending(limit=1000)
+
+        assert len(records) == 1000
+        assert len(pending) == 1000
+        assert backend.operation_count == 1
+        assert len(backend.notification_batches) == 1
+    finally:
+        await backend.close()
+
+
+async def test_advanced_alchemy_claim_many_falls_back_safely_on_sqlite(
+    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend",
+) -> "None":
+    first = await advanced_alchemy_backend.enqueue("tasks.claim.first", priority=1)
+    second = await advanced_alchemy_backend.enqueue("tasks.claim.second", priority=10)
+    future = await advanced_alchemy_backend.enqueue(
+        "tasks.claim.future", priority=100, scheduled_at=datetime.now(timezone.utc) + timedelta(minutes=5)
+    )
+
+    claimed = await advanced_alchemy_backend.claim_many(limit=5)
+
+    assert [record.id for record in claimed] == [second.id, first.id]
+    assert all(record.status == "running" for record in claimed)
+    stored_future = await advanced_alchemy_backend.get_task(future.id)
+    assert stored_future is not None
+    assert stored_future.status == "scheduled"
+
+
+async def test_advanced_alchemy_capabilities_are_polling_only_without_postgres_notifications(
+    tmp_path: "Path",
+) -> "None":
+    sqlite_backend = AdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(tmp_path / "polling.db"),
+            model_class=ContractQueueTask,
+            create_schema=True,
+            notifications=True,
+        )
+    )
+    postgres_backend = AdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="postgresql+asyncpg://user:pass@localhost/db"),
+            model_class=ContractQueueTask,
+            notifications=True,
+        )
+    )
+    mysql_backend = AdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="mysql+asyncmy://user:pass@localhost/db"),
+            model_class=ContractQueueTask,
+            notifications=True,
+        )
+    )
+    oracle_backend = AdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=SQLAlchemyAsyncConfig(
+                connection_string="oracle+oracledb_async://user:pass@localhost:1521/?service_name=FREEPDB1"
+            ),
+            model_class=ContractQueueTask,
+            notifications=True,
+        )
+    )
+
+    assert sqlite_backend.capabilities.supports_notifications is False
+    assert sqlite_backend.capabilities.notification_backend is None
+    assert sqlite_backend.capabilities.notifications_durable is False
+    assert mysql_backend.capabilities.supports_notifications is False
+    assert oracle_backend.capabilities.supports_notifications is False
+    assert postgres_backend.capabilities.supports_notifications is True
+    assert postgres_backend.capabilities.notification_backend == "postgres-listen-notify"
+    assert postgres_backend.capabilities.notifications_durable is False
+
+
+async def test_advanced_alchemy_wait_for_notifications_uses_dedicated_listener(tmp_path: "Path") -> "None":
+    backend = _FakeListenerAdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="postgresql+asyncpg://user:pass@localhost/db"),
+            model_class=ContractQueueTask,
+            notifications=True,
+        )
+    )
+    backend.listener.due_on_reconcile = True
+
+    assert await backend.wait_for_notifications(timeout=0.01) is True
+    assert backend.listener.started == 1
+    assert backend.listener.waits == []
+
+    backend.listener.due_on_reconcile = False
+    backend.listener.mark_notified()
+
+    assert await backend.wait_for_notifications(timeout=0.01) is True
+    assert backend.listener.started == 1
+    assert backend.listener.waits == [0.01]
+
+    await backend.close()
+    assert backend.listener.closed is True
+
+
+async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_service: "PostgresService") -> "None":
+    pytest.importorskip("asyncpg")
+    table_name = f"aa_notify_{uuid4().hex}"
+    model_class = _dynamic_queue_model(table_name)
+    backend = AdvancedAlchemyQueueBackend(
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=SQLAlchemyAsyncConfig(
+                connection_string=(
+                    f"postgresql+asyncpg://{postgres_service.user}:{postgres_service.password}"
+                    f"@{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
+                )
+            ),
+            model_class=model_class,
+            create_schema=True,
+            notifications=True,
+            notification_channel=f"lq_notify_{uuid4().hex}",
+        )
+    )
+    await backend.open()
+    try:
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=2.0))
+        record = await backend.enqueue("tasks.pg.notify")
+
+        assert await waiter is True
+        assert backend.capabilities.supports_notifications is True
+        assert backend.capabilities.notification_backend == "postgres-listen-notify"
+
+        claimed = await backend.claim_task(record.id)
+        assert claimed is not None
+        assert await backend.wait_for_notifications(timeout=0.01) is False
+    finally:
+        with suppress(Exception):
+            await _drop_dynamic_queue_model(backend, model_class)
+        await backend.close()
 
 
 async def test_advanced_alchemy_backend_claims_due_tasks_by_priority(
@@ -438,6 +651,23 @@ def _oracle_dialect() -> "Any":
     return oracle.dialect()  # type: ignore[no-untyped-call]
 
 
+def _dynamic_queue_model(table_name: "str") -> "type[object]":
+    return type(
+        f"NotificationQueueTask{table_name[-8:]}",
+        (UUIDAuditBase, QueueTaskModelMixin),
+        {"__module__": __name__, "__tablename__": table_name},
+    )
+
+
+async def _drop_dynamic_queue_model(backend: "AdvancedAlchemyQueueBackend", model_class: "type[object]") -> "None":
+    sqlalchemy_config = backend._sqlalchemy_config
+    if sqlalchemy_config is None:
+        return
+    engine = sqlalchemy_config.get_engine()
+    async with engine.begin() as connection:
+        await connection.run_sync(cast("Any", model_class).__table__.drop, checkfirst=True)
+
+
 class _CasClaimService:
     def __init__(self, records: "list[QueuedTaskRecord]", target: "QueuedTaskRecord") -> "None":
         self.records = records
@@ -458,3 +688,72 @@ class _CasClaimService:
         if task_id == self.target.id:
             return self.target
         return None
+
+
+async def _failing_enqueue_many(self: "Any", specs: "Any") -> "Any":
+    del self, specs
+    msg = "bulk failed"
+    raise RuntimeError(msg)
+
+
+class _CountingAdvancedAlchemyQueueBackend(AdvancedAlchemyQueueBackend):
+    __slots__ = ("notification_batches", "operation_count")
+
+    def __init__(self, *args: "Any", **kwargs: "Any") -> "None":
+        super().__init__(*args, **kwargs)
+        self.operation_count = 0
+        self.notification_batches: "list[tuple[QueuedTaskRecord, ...]]" = []
+
+    @asynccontextmanager
+    async def _operation(self) -> "Any":
+        self.operation_count += 1
+        async with super()._operation() as service:
+            yield service
+
+    async def notify_new_tasks(self, records: "Sequence[QueuedTaskRecord]") -> "None":
+        for record in records:
+            if record.is_due and record.status in {"pending", "scheduled"}:
+                self.notification_batches.append((record,))
+                return
+
+
+class _FakeNotificationListener:
+    __slots__ = ("closed", "due_on_reconcile", "notified", "started", "waits")
+
+    def __init__(self) -> "None":
+        self.closed = False
+        self.due_on_reconcile = False
+        self.notified = False
+        self.started = 0
+        self.waits: "list[float | None]" = []
+
+    async def start(self) -> "None":
+        if self.started:
+            return
+        self.started += 1
+
+    async def wait(self, timeout: "float | None") -> "bool":
+        self.waits.append(timeout)
+        notified = self.notified
+        self.notified = False
+        return notified
+
+    async def close(self) -> "None":
+        self.closed = True
+
+    def mark_notified(self) -> "None":
+        self.notified = True
+
+
+class _FakeListenerAdvancedAlchemyQueueBackend(AdvancedAlchemyQueueBackend):
+    __slots__ = ("listener",)
+
+    def __init__(self, *args: "Any", **kwargs: "Any") -> "None":
+        super().__init__(*args, **kwargs)
+        self.listener = _FakeNotificationListener()
+
+    def _create_notification_listener(self) -> "_FakeNotificationListener":
+        return self.listener
+
+    async def _has_due_tasks(self) -> "bool":
+        return self.listener.due_on_reconcile

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -394,6 +394,9 @@ async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_serv
     await backend.open()
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=2.0))
+        # Give the dedicated LISTEN connection time to subscribe before the
+        # enqueue commits and publishes its notification.
+        await asyncio.sleep(0.2)
         record = await backend.enqueue("tasks.pg.notify")
 
         assert await waiter is True

--- a/src/tests/integration/backends/advanced_alchemy/test_event_log.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_event_log.py
@@ -1,0 +1,93 @@
+"""Advanced Alchemy backend-managed queue event history tests."""
+
+import pytest
+
+pytest.importorskip("advanced_alchemy")
+pytest.importorskip("aiosqlite")
+pytest.importorskip("sqlalchemy")
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from advanced_alchemy.base import UUIDAuditBase
+from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+
+from litestar_queues import EventLogConfig, QueueConfig, QueueService, task
+from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
+from litestar_queues.events import publish_task_event, publish_task_log, publish_task_progress
+from litestar_queues.task import clear_task_registry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.anyio
+
+
+class AAEventQueueTask(UUIDAuditBase, QueueTaskModelMixin):
+    __tablename__ = "aa_event_queue_task"
+
+
+class AAEventQueueEvent(UUIDAuditBase, QueueEventLogModelMixin):
+    __tablename__ = "aa_event_queue_event"
+
+
+async def test_advanced_alchemy_event_log_records_queries_and_cleans_up(tmp_path: "Path") -> "None":
+    clear_task_registry()
+
+    @task("tasks.aa_event_history")
+    async def aa_event_history_task() -> "str":
+        await publish_task_log("loaded", payload={"stage": "load", "duration_ms": 7, "items": 3})
+        await publish_task_progress(current=2, total=4, payload={"stage": "load", "duration_ms": 5})
+        await publish_task_event("task.event", message="stored", payload={"stage": "store", "duration_ms": 11})
+        return "ok"
+
+    db_path = tmp_path / "aa-event-history.db"
+    event_log_config = EventLogConfig(buffer_size=100, flush_interval=60)
+    backend_config = AdvancedAlchemyBackendConfig(
+        sqlalchemy_config=_sqlite_config(db_path),
+        model_class=AAEventQueueTask,
+        event_log_model_class=AAEventQueueEvent,
+        create_schema=True,
+    )
+    config = QueueConfig(queue_backend=backend_config, execution_backend="immediate", event_log=event_log_config)
+
+    async with QueueService(config) as service:
+        result = await service.enqueue(aa_event_history_task)
+
+    reader_config = QueueConfig(
+        queue_backend=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(db_path),
+            model_class=AAEventQueueTask,
+            event_log_model_class=AAEventQueueEvent,
+            create_schema=False,
+        ),
+        event_log=event_log_config,
+    )
+    async with QueueService(reader_config) as reader:
+        event_log = reader.get_queue_backend().get_event_log(event_log_config)
+        assert event_log is not None
+
+        records = await event_log.list_events(task_id=str(result.id))
+        task_name_records = await event_log.list_events(task_name=aa_event_history_task.name, limit=2)
+        deleted = await event_log.cleanup_before(datetime.now(timezone.utc) + timedelta(seconds=1))
+        remaining = await event_log.list_events(task_id=str(result.id))
+
+    assert [record.event_type for record in records] == [
+        "task.started",
+        "task.log",
+        "task.progress",
+        "task.event",
+        "task.completed",
+    ]
+    assert [record.sequence for record in task_name_records] == [1, 2]
+    custom = next(record for record in records if record.event_type == "task.event")
+    assert custom.detail == {"stage": "store", "duration_ms": 11}
+    assert custom.stage == "store"
+    assert custom.duration_ms == 11
+    assert deleted == len(records)
+    assert remaining == []
+
+
+def _sqlite_config(path: "Path") -> "SQLAlchemyAsyncConfig":
+    return SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{path}")

--- a/src/tests/integration/backends/advanced_alchemy/test_event_log.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_event_log.py
@@ -13,10 +13,11 @@ from advanced_alchemy.base import UUIDAuditBase
 from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
 
 from litestar_queues import EventLogConfig, QueueConfig, QueueService, task
-from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig
+from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackendConfig
 from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 from litestar_queues.events import publish_task_event, publish_task_log, publish_task_progress
 from litestar_queues.task import clear_task_registry
+from tests.integration.backends.advanced_alchemy._aa_schema import create_tables
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -29,7 +30,7 @@ class AAEventQueueTask(UUIDAuditBase, QueueTaskModelMixin):
 
 
 class AAEventQueueEvent(UUIDAuditBase, QueueEventLogModelMixin):
-    __tablename__ = "aa_event_queue_event"
+    __tablename__ = "aa_event_queue_task_event_log"
 
 
 async def test_advanced_alchemy_event_log_records_queries_and_cleans_up(tmp_path: "Path") -> "None":
@@ -43,12 +44,11 @@ async def test_advanced_alchemy_event_log_records_queries_and_cleans_up(tmp_path
         return "ok"
 
     db_path = tmp_path / "aa-event-history.db"
+    sqlalchemy_config = _sqlite_config(db_path)
+    await create_tables(sqlalchemy_config, AAEventQueueTask, AAEventQueueEvent)
     event_log_config = EventLogConfig(buffer_size=100, flush_interval=60)
-    backend_config = AdvancedAlchemyBackendConfig(
-        sqlalchemy_config=_sqlite_config(db_path),
-        model_class=AAEventQueueTask,
-        event_log_model_class=AAEventQueueEvent,
-        create_schema=True,
+    backend_config = SQLAlchemyBackendConfig(
+        sqlalchemy_config=sqlalchemy_config, model_class=AAEventQueueTask, event_log_model_class=AAEventQueueEvent
     )
     config = QueueConfig(queue_backend=backend_config, execution_backend="immediate", event_log=event_log_config)
 
@@ -56,11 +56,10 @@ async def test_advanced_alchemy_event_log_records_queries_and_cleans_up(tmp_path
         result = await service.enqueue(aa_event_history_task)
 
     reader_config = QueueConfig(
-        queue_backend=AdvancedAlchemyBackendConfig(
+        queue_backend=SQLAlchemyBackendConfig(
             sqlalchemy_config=_sqlite_config(db_path),
             model_class=AAEventQueueTask,
             event_log_model_class=AAEventQueueEvent,
-            create_schema=False,
         ),
         event_log=event_log_config,
     )

--- a/src/tests/integration/backends/advanced_alchemy/test_heartbeat_session_maker.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_heartbeat_session_maker.py
@@ -21,11 +21,8 @@ from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from litestar_queues import HeartbeatTouch
-from litestar_queues.backends.advanced_alchemy import (
-    AdvancedAlchemyBackendConfig,
-    AdvancedAlchemyQueueBackend,
-    QueueTaskModelMixin,
-)
+from litestar_queues.backends.advanced_alchemy import QueueTaskModelMixin, SQLAlchemyBackend, SQLAlchemyBackendConfig
+from tests.integration.backends.advanced_alchemy._aa_schema import create_tables
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -42,15 +39,15 @@ def _sqlite_config(path: "Path") -> "SQLAlchemyAsyncConfig":
 
 
 class HeartbeatQueueTask(UUIDAuditBase, QueueTaskModelMixin):
-    __tablename__ = "heartbeat_queue_tasks"
+    __tablename__ = "heartbeat_queue_task"
 
 
 async def test_advanced_alchemy_backend_default_heartbeat_uses_main_session(tmp_path: "Path") -> "None":
     """When heartbeat_session_maker is None, heartbeat writes use the main session."""
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "queue.db"), model_class=HeartbeatQueueTask, create_schema=True
-        )
+    config = _sqlite_config(tmp_path / "queue.db")
+    await create_tables(config, HeartbeatQueueTask)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=HeartbeatQueueTask)
     )
     await backend.open()
     try:
@@ -78,15 +75,13 @@ async def test_advanced_alchemy_backend_dedicated_heartbeat_maker_isolates_write
     """touch_heartbeats / null_heartbeats use the dedicated heartbeat sessionmaker."""
     queue_path = tmp_path / "queue.db"
     main_config = _sqlite_config(queue_path)
+    await create_tables(main_config, HeartbeatQueueTask)
     heartbeat_config = _sqlite_config(queue_path)
     heartbeat_maker = async_sessionmaker(heartbeat_config.get_engine(), expire_on_commit=False)
 
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=main_config,
-            model_class=HeartbeatQueueTask,
-            heartbeat_session_maker=heartbeat_maker,
-            create_schema=True,
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=main_config, model_class=HeartbeatQueueTask, heartbeat_session_maker=heartbeat_maker
         )
     )
     await backend.open()
@@ -97,27 +92,27 @@ async def test_advanced_alchemy_backend_dedicated_heartbeat_maker_isolates_write
         claimed = await backend.claim_task(record.id)
         assert claimed is not None
 
-        original_operation = AdvancedAlchemyQueueBackend._operation
-        original_heartbeat = AdvancedAlchemyQueueBackend._heartbeat_operation
+        original_operation = SQLAlchemyBackend._operation
+        original_heartbeat = SQLAlchemyBackend._heartbeat_operation
         operation_calls = 0
         heartbeat_calls = 0
 
         @contextlib.asynccontextmanager
-        async def counting_operation(self: "AdvancedAlchemyQueueBackend") -> 'AsyncIterator["QueueTaskService"]':
+        async def counting_operation(self: "SQLAlchemyBackend") -> 'AsyncIterator["QueueTaskService"]':
             nonlocal operation_calls
             operation_calls += 1
             async with original_operation(self) as service:
                 yield service
 
         @contextlib.asynccontextmanager
-        async def counting_heartbeat(self: "AdvancedAlchemyQueueBackend") -> 'AsyncIterator["QueueTaskService"]':
+        async def counting_heartbeat(self: "SQLAlchemyBackend") -> 'AsyncIterator["QueueTaskService"]':
             nonlocal heartbeat_calls
             heartbeat_calls += 1
             async with original_heartbeat(self) as service:
                 yield service
 
-        monkeypatch.setattr(AdvancedAlchemyQueueBackend, "_operation", counting_operation)
-        monkeypatch.setattr(AdvancedAlchemyQueueBackend, "_heartbeat_operation", counting_heartbeat)
+        monkeypatch.setattr(SQLAlchemyBackend, "_operation", counting_operation)
+        monkeypatch.setattr(SQLAlchemyBackend, "_heartbeat_operation", counting_heartbeat)
 
         result = await backend.touch_heartbeats([
             HeartbeatTouch(task_id=claimed.id, expected_retry_count=claimed.retry_count)
@@ -138,15 +133,13 @@ async def test_advanced_alchemy_backend_dedicated_heartbeat_maker_handles_concur
     """Many concurrent heartbeats over the dedicated maker must not deadlock."""
     queue_path = tmp_path / "queue.db"
     main_config = _sqlite_config(queue_path)
+    await create_tables(main_config, HeartbeatQueueTask)
     heartbeat_config = _sqlite_config(queue_path)
     heartbeat_maker = async_sessionmaker(heartbeat_config.get_engine(), expire_on_commit=False)
 
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=main_config,
-            model_class=HeartbeatQueueTask,
-            heartbeat_session_maker=heartbeat_maker,
-            create_schema=True,
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=main_config, model_class=HeartbeatQueueTask, heartbeat_session_maker=heartbeat_maker
         )
     )
     await backend.open()
@@ -185,15 +178,13 @@ async def test_advanced_alchemy_backend_touch_heartbeats_groups_updates_in_one_s
     """A multi-record heartbeat tick uses one heartbeat session and one grouped update."""
     queue_path = tmp_path / "queue.db"
     main_config = _sqlite_config(queue_path)
+    await create_tables(main_config, HeartbeatQueueTask)
     heartbeat_config = _sqlite_config(queue_path)
     heartbeat_maker = async_sessionmaker(heartbeat_config.get_engine(), expire_on_commit=False)
 
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=main_config,
-            model_class=HeartbeatQueueTask,
-            heartbeat_session_maker=heartbeat_maker,
-            create_schema=True,
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=main_config, model_class=HeartbeatQueueTask, heartbeat_session_maker=heartbeat_maker
         )
     )
     await backend.open()
@@ -208,11 +199,11 @@ async def test_advanced_alchemy_backend_touch_heartbeats_groups_updates_in_one_s
             assert c is not None
             claimed.append(c)
 
-        original_heartbeat = AdvancedAlchemyQueueBackend._heartbeat_operation
+        original_heartbeat = SQLAlchemyBackend._heartbeat_operation
         heartbeat_calls = 0
 
         @contextlib.asynccontextmanager
-        async def counting_heartbeat(self: "AdvancedAlchemyQueueBackend") -> 'AsyncIterator["QueueTaskService"]':
+        async def counting_heartbeat(self: "SQLAlchemyBackend") -> 'AsyncIterator["QueueTaskService"]':
             nonlocal heartbeat_calls
             heartbeat_calls += 1
             async with original_heartbeat(self) as service:
@@ -231,7 +222,7 @@ async def test_advanced_alchemy_backend_touch_heartbeats_groups_updates_in_one_s
                 update_calls += 1
             return await original_execute(self, statement, *args, **kwargs)
 
-        monkeypatch.setattr(AdvancedAlchemyQueueBackend, "_heartbeat_operation", counting_heartbeat)
+        monkeypatch.setattr(SQLAlchemyBackend, "_heartbeat_operation", counting_heartbeat)
         monkeypatch.setattr(AsyncSession, "execute", counting_execute)
 
         result = await backend.touch_heartbeats([

--- a/src/tests/integration/backends/advanced_alchemy/test_litestar_integration.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_litestar_integration.py
@@ -12,7 +12,7 @@ from advanced_alchemy.base import UUIDAuditBase
 from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig, SQLAlchemyPlugin
 
 from litestar_queues import QueueConfig, QueuePlugin, QueueService, task
-from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, QueueTaskModelMixin
+from litestar_queues.backends.advanced_alchemy import QueueTaskModelMixin, SQLAlchemyBackendConfig
 from litestar_queues.task import clear_task_registry
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ def clean_task_registry() -> "None":
 
 
 def _sqlite_config(path: "Path") -> "SQLAlchemyAsyncConfig":
-    return SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{path}")
+    return SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{path}", create_all=True)
 
 
 class LitestarQueueTask(UUIDAuditBase, QueueTaskModelMixin):
@@ -42,9 +42,7 @@ def test_advanced_alchemy_litestar_integration_uses_app_owned_sqlalchemy_plugin(
     alchemy_config = _sqlite_config(tmp_path / "litestar.db")
     queue_plugin = QueuePlugin(
         QueueConfig(
-            queue_backend=AdvancedAlchemyBackendConfig(
-                sqlalchemy_config=alchemy_config, model_class=LitestarQueueTask, create_schema=True
-            ),
+            queue_backend=SQLAlchemyBackendConfig(sqlalchemy_config=alchemy_config, model_class=LitestarQueueTask),
             initialize_schedules=False,
         )
     )
@@ -61,12 +59,12 @@ def test_advanced_alchemy_litestar_integration_uses_app_owned_sqlalchemy_plugin(
 
     assert response.status_code == 201
     assert response.json()["status"] == "pending"
-    assert isinstance(queue_plugin.config.queue_backend, AdvancedAlchemyBackendConfig)
+    assert isinstance(queue_plugin.config.queue_backend, SQLAlchemyBackendConfig)
     assert queue_plugin.config.queue_backend.sqlalchemy_config is alchemy_config
 
 
 def test_advanced_alchemy_backend_does_not_create_sqlalchemy_litestar_plugin() -> "None":
-    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyQueueBackend
+    from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend
 
     with pytest.raises(TypeError):
-        AdvancedAlchemyQueueBackend(register_plugin=True)  # type: ignore[call-arg]
+        SQLAlchemyBackend(register_plugin=True)  # type: ignore[call-arg]

--- a/src/tests/integration/backends/advanced_alchemy/test_model_class.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_model_class.py
@@ -18,9 +18,10 @@ from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from litestar_queues import EventLogConfig, QueueConfig
-from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, AdvancedAlchemyQueueBackend
+from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend, SQLAlchemyBackendConfig
 from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 from litestar_queues.exceptions import QueueConfigurationError
+from tests.integration.backends.advanced_alchemy._aa_schema import create_tables
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,19 +38,19 @@ class MappedQueueModel(Protocol):
 
 
 class BareQueueTaskModel(UUIDAuditBase, QueueTaskModelMixin):
-    __tablename__ = "bare_queue_tasks"
+    __tablename__ = "bare_queue_task"
 
 
 class AppQueueTask(UUIDAuditBase, QueueTaskModelMixin):
-    __tablename__ = "app_queue_tasks"
+    __tablename__ = "app_queue_task"
 
 
 class CustomQueueTaskModel(UUIDAuditBase, QueueTaskModelMixin):
-    __tablename__ = "custom_queue_tasks"
+    __tablename__ = "custom_queue_task"
 
 
 class CustomQueueEventLogModel(UUIDAuditBase, QueueEventLogModelMixin):
-    __tablename__ = "custom_queue_task_events"
+    __tablename__ = "custom_queue_task_event_log"
 
 
 class AbstractQueueTaskModel(QueueTaskModelMixin):
@@ -61,7 +62,7 @@ class AbstractQueueEventLogModel(QueueEventLogModelMixin):
 
 
 class RenamedColumnQueueTaskModel(UUIDAuditBase, QueueTaskModelMixin):
-    __tablename__ = "renamed_column_queue_tasks"
+    __tablename__ = "renamed_column_queue_task"
 
     task_name: "Mapped[str]" = mapped_column("queue_task_name", String(length=500), nullable=False)
 
@@ -70,20 +71,18 @@ def test_queue_task_model_mixin_adds_queue_schema_to_app_owned_model() -> "None"
     assert {"id", "created_at", "updated_at"} <= _column_names(BareQueueTaskModel)
     assert {"task_name", "task_args", "task_kwargs", "execution_ref", "metadata"} <= _column_names(BareQueueTaskModel)
     assert {
-        "ix_bare_queue_tasks_pending",
-        "ix_bare_queue_tasks_heartbeat",
-        "ix_bare_queue_tasks_execution",
+        "ix_bare_queue_task_pending",
+        "ix_bare_queue_task_heartbeat",
+        "ix_bare_queue_task_execution",
     } <= _index_names(BareQueueTaskModel)
 
 
 def test_queue_task_model_mixin_composes_with_custom_advanced_alchemy_base() -> "None":
     assert {"id", "created_at", "updated_at"} <= _column_names(AppQueueTask)
     assert {"task_name", "task_args", "task_kwargs", "execution_ref", "metadata"} <= _column_names(AppQueueTask)
-    assert {
-        "ix_app_queue_tasks_pending",
-        "ix_app_queue_tasks_heartbeat",
-        "ix_app_queue_tasks_execution",
-    } <= _index_names(AppQueueTask)
+    assert {"ix_app_queue_task_pending", "ix_app_queue_task_heartbeat", "ix_app_queue_task_execution"} <= _index_names(
+        AppQueueTask
+    )
 
 
 def test_queue_event_log_model_mixin_adds_generic_event_history_schema() -> "None":
@@ -108,10 +107,10 @@ def test_queue_event_log_model_mixin_adds_generic_event_history_schema() -> "Non
     } <= _column_names(CustomQueueEventLogModel)
     assert {"stage", "duration_ms"}.isdisjoint(_column_names(CustomQueueEventLogModel))
     assert {
-        "ix_custom_queue_task_events_task_id",
-        "ix_custom_queue_task_events_task_name",
-        "ix_custom_queue_task_events_event_type",
-        "ix_custom_queue_task_events_occurred_at",
+        "ix_custom_queue_task_event_log_task_id",
+        "ix_custom_queue_task_event_log_task_name",
+        "ix_custom_queue_task_event_log_event_type",
+        "ix_custom_queue_task_event_log_occurred_at",
     } <= _index_names(CustomQueueEventLogModel)
 
 
@@ -128,8 +127,8 @@ def test_queue_task_model_mixin_preserves_canonical_python_attributes() -> "None
 def test_advanced_alchemy_backend_uses_default_model_class(tmp_path: "Path") -> "None":
     from litestar_queues.backends.advanced_alchemy import QueueEventLogModel, QueueTaskModel
 
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=_sqlite_config(tmp_path / "default-model.db"))
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=_sqlite_config(tmp_path / "default-model.db"))
     )
 
     assert backend._model_class is QueueTaskModel
@@ -138,49 +137,49 @@ def test_advanced_alchemy_backend_uses_default_model_class(tmp_path: "Path") -> 
     assert _table(QueueEventLogModel).name == "litestar_queue_task_event_log"
 
 
-async def test_advanced_alchemy_event_log_schema_is_gated_by_event_log_config(tmp_path: "Path") -> "None":
+async def test_advanced_alchemy_schema_is_created_by_native_sqlalchemy_lifecycle(tmp_path: "Path") -> "None":
     disabled_db = tmp_path / "event-log-disabled.db"
-    disabled_backend = AdvancedAlchemyQueueBackend(
+    disabled_config = _sqlite_config(disabled_db)
+    await create_tables(disabled_config, CustomQueueTaskModel)
+    disabled_backend = SQLAlchemyBackend(
         QueueConfig(),
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(disabled_db),
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=disabled_config,
             model_class=CustomQueueTaskModel,
             event_log_model_class=CustomQueueEventLogModel,
-            create_schema=True,
         ),
     )
 
     await disabled_backend.open()
     await disabled_backend.close()
 
-    assert "custom_queue_tasks" in _sqlite_table_names(disabled_db)
-    assert "custom_queue_task_events" not in _sqlite_table_names(disabled_db)
+    assert "custom_queue_task" in _sqlite_table_names(disabled_db)
+    assert "custom_queue_task_event_log" not in _sqlite_table_names(disabled_db)
 
     enabled_db = tmp_path / "event-log-enabled.db"
-    enabled_backend = AdvancedAlchemyQueueBackend(
+    enabled_config = _sqlite_config(enabled_db)
+    await create_tables(enabled_config, CustomQueueTaskModel, CustomQueueEventLogModel)
+    enabled_backend = SQLAlchemyBackend(
         QueueConfig(event_log=EventLogConfig()),
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(enabled_db),
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=enabled_config,
             model_class=CustomQueueTaskModel,
             event_log_model_class=CustomQueueEventLogModel,
-            create_schema=True,
         ),
     )
 
     await enabled_backend.open()
     await enabled_backend.close()
 
-    assert "custom_queue_tasks" in _sqlite_table_names(enabled_db)
-    assert "custom_queue_task_events" in _sqlite_table_names(enabled_db)
+    assert "custom_queue_task" in _sqlite_table_names(enabled_db)
+    assert "custom_queue_task_event_log" in _sqlite_table_names(enabled_db)
 
 
 async def test_advanced_alchemy_backend_uses_supplied_model_class(tmp_path: "Path") -> "None":
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "custom-model.db"),
-            model_class=CustomQueueTaskModel,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "custom-model.db")
+    await create_tables(config, CustomQueueTaskModel)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=CustomQueueTaskModel)
     )
     await backend.open()
     try:
@@ -194,7 +193,7 @@ async def test_advanced_alchemy_backend_uses_supplied_model_class(tmp_path: "Pat
     assert claimed.status == "running"
     assert completed is not None
     assert completed.result == {"ok": True}
-    assert _table(CustomQueueTaskModel).name == "custom_queue_tasks"
+    assert _table(CustomQueueTaskModel).name == "custom_queue_task"
 
 
 async def test_advanced_alchemy_keyed_enqueue_recovers_from_racing_insert(
@@ -202,12 +201,10 @@ async def test_advanced_alchemy_keyed_enqueue_recovers_from_racing_insert(
 ) -> "None":
     from litestar_queues.backends.advanced_alchemy.service import QueueTaskService
 
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "key-race.db"),
-            model_class=CustomQueueTaskModel,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "key-race.db")
+    await create_tables(config, CustomQueueTaskModel)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=CustomQueueTaskModel)
     )
     select_count = 0
     select_gate = asyncio.Event()
@@ -270,12 +267,10 @@ async def test_advanced_alchemy_core_updates_touch_updated_at(
     from litestar_queues.backends.advanced_alchemy import service as service_module
 
     claim_time = datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc)
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "updated-at.db"),
-            model_class=CustomQueueTaskModel,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "updated-at.db")
+    await create_tables(config, CustomQueueTaskModel)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=CustomQueueTaskModel)
     )
 
     await backend.open()
@@ -300,12 +295,10 @@ async def test_advanced_alchemy_requeues_heartbeat_at_exact_stale_cutoff(
 
     fixed_now = datetime(2026, 5, 25, tzinfo=timezone.utc)
     monkeypatch.setattr(service_module, "_utc_now", lambda: fixed_now)
-    backend = AdvancedAlchemyQueueBackend(
-        backend_config=AdvancedAlchemyBackendConfig(
-            sqlalchemy_config=_sqlite_config(tmp_path / "stale-cutoff.db"),
-            model_class=CustomQueueTaskModel,
-            create_schema=True,
-        )
+    config = _sqlite_config(tmp_path / "stale-cutoff.db")
+    await create_tables(config, CustomQueueTaskModel)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=CustomQueueTaskModel)
     )
     await backend.open()
     try:
@@ -327,23 +320,21 @@ def test_advanced_alchemy_backend_rejects_invalid_model_class(tmp_path: "Path") 
     config = _sqlite_config(tmp_path / "invalid-model.db")
 
     with pytest.raises(QueueConfigurationError, match="QueueTaskModelMixin"):
-        AdvancedAlchemyQueueBackend(
-            backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=config, model_class=object)
-        )
+        SQLAlchemyBackend(backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=object))
 
     with pytest.raises(QueueConfigurationError, match="__tablename__"):
-        AdvancedAlchemyQueueBackend(
-            backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=config, model_class=AbstractQueueTaskModel)
+        SQLAlchemyBackend(
+            backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, model_class=AbstractQueueTaskModel)
         )
 
     with pytest.raises(QueueConfigurationError, match="QueueEventLogModelMixin"):
-        AdvancedAlchemyQueueBackend(
-            backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=config, event_log_model_class=object)
+        SQLAlchemyBackend(
+            backend_config=SQLAlchemyBackendConfig(sqlalchemy_config=config, event_log_model_class=object)
         )
 
     with pytest.raises(QueueConfigurationError, match="__tablename__"):
-        AdvancedAlchemyQueueBackend(
-            backend_config=AdvancedAlchemyBackendConfig(
+        SQLAlchemyBackend(
+            backend_config=SQLAlchemyBackendConfig(
                 sqlalchemy_config=config, event_log_model_class=AbstractQueueEventLogModel
             )
         )

--- a/src/tests/integration/backends/advanced_alchemy/test_model_class.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_model_class.py
@@ -1,6 +1,7 @@
 """Advanced Alchemy custom queue model integration tests."""
 
 import asyncio
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Protocol, cast
 from uuid import uuid4
@@ -16,8 +17,9 @@ from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
+from litestar_queues import EventLogConfig, QueueConfig
 from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, AdvancedAlchemyQueueBackend
-from litestar_queues.backends.advanced_alchemy.mixins import QueueTaskModelMixin
+from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
@@ -46,7 +48,15 @@ class CustomQueueTaskModel(UUIDAuditBase, QueueTaskModelMixin):
     __tablename__ = "custom_queue_tasks"
 
 
+class CustomQueueEventLogModel(UUIDAuditBase, QueueEventLogModelMixin):
+    __tablename__ = "custom_queue_task_events"
+
+
 class AbstractQueueTaskModel(QueueTaskModelMixin):
+    __abstract__ = True
+
+
+class AbstractQueueEventLogModel(QueueEventLogModelMixin):
     __abstract__ = True
 
 
@@ -76,6 +86,35 @@ def test_queue_task_model_mixin_composes_with_custom_advanced_alchemy_base() -> 
     } <= _index_names(AppQueueTask)
 
 
+def test_queue_event_log_model_mixin_adds_generic_event_history_schema() -> "None":
+    assert {"id", "created_at", "updated_at"} <= _column_names(CustomQueueEventLogModel)
+    assert {
+        "event_id",
+        "event_type",
+        "task_id",
+        "task_name",
+        "queue",
+        "worker_id",
+        "execution_backend",
+        "execution_profile",
+        "level",
+        "message",
+        "detail_json",
+        "progress_current",
+        "progress_total",
+        "progress_percent",
+        "sequence",
+        "occurred_at",
+    } <= _column_names(CustomQueueEventLogModel)
+    assert {"stage", "duration_ms"}.isdisjoint(_column_names(CustomQueueEventLogModel))
+    assert {
+        "ix_custom_queue_task_events_task_id",
+        "ix_custom_queue_task_events_task_name",
+        "ix_custom_queue_task_events_event_type",
+        "ix_custom_queue_task_events_occurred_at",
+    } <= _index_names(CustomQueueEventLogModel)
+
+
 def test_queue_task_model_mixin_preserves_canonical_python_attributes() -> "None":
     assert _mapped_column_name(BareQueueTaskModel, "task_key") == "task_key"
     assert _mapped_column_name(BareQueueTaskModel, "task_name") == "task_name"
@@ -87,14 +126,52 @@ def test_queue_task_model_mixin_preserves_canonical_python_attributes() -> "None
 
 
 def test_advanced_alchemy_backend_uses_default_model_class(tmp_path: "Path") -> "None":
-    from litestar_queues.backends.advanced_alchemy import QueueTaskModel
+    from litestar_queues.backends.advanced_alchemy import QueueEventLogModel, QueueTaskModel
 
     backend = AdvancedAlchemyQueueBackend(
         backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=_sqlite_config(tmp_path / "default-model.db"))
     )
 
     assert backend._model_class is QueueTaskModel
+    assert backend._event_log_model_class is QueueEventLogModel
     assert _table(QueueTaskModel).name == "litestar_queue_task"
+    assert _table(QueueEventLogModel).name == "litestar_queue_task_event_log"
+
+
+async def test_advanced_alchemy_event_log_schema_is_gated_by_event_log_config(tmp_path: "Path") -> "None":
+    disabled_db = tmp_path / "event-log-disabled.db"
+    disabled_backend = AdvancedAlchemyQueueBackend(
+        QueueConfig(),
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(disabled_db),
+            model_class=CustomQueueTaskModel,
+            event_log_model_class=CustomQueueEventLogModel,
+            create_schema=True,
+        ),
+    )
+
+    await disabled_backend.open()
+    await disabled_backend.close()
+
+    assert "custom_queue_tasks" in _sqlite_table_names(disabled_db)
+    assert "custom_queue_task_events" not in _sqlite_table_names(disabled_db)
+
+    enabled_db = tmp_path / "event-log-enabled.db"
+    enabled_backend = AdvancedAlchemyQueueBackend(
+        QueueConfig(event_log=EventLogConfig()),
+        backend_config=AdvancedAlchemyBackendConfig(
+            sqlalchemy_config=_sqlite_config(enabled_db),
+            model_class=CustomQueueTaskModel,
+            event_log_model_class=CustomQueueEventLogModel,
+            create_schema=True,
+        ),
+    )
+
+    await enabled_backend.open()
+    await enabled_backend.close()
+
+    assert "custom_queue_tasks" in _sqlite_table_names(enabled_db)
+    assert "custom_queue_task_events" in _sqlite_table_names(enabled_db)
 
 
 async def test_advanced_alchemy_backend_uses_supplied_model_class(tmp_path: "Path") -> "None":
@@ -259,6 +336,18 @@ def test_advanced_alchemy_backend_rejects_invalid_model_class(tmp_path: "Path") 
             backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=config, model_class=AbstractQueueTaskModel)
         )
 
+    with pytest.raises(QueueConfigurationError, match="QueueEventLogModelMixin"):
+        AdvancedAlchemyQueueBackend(
+            backend_config=AdvancedAlchemyBackendConfig(sqlalchemy_config=config, event_log_model_class=object)
+        )
+
+    with pytest.raises(QueueConfigurationError, match="__tablename__"):
+        AdvancedAlchemyQueueBackend(
+            backend_config=AdvancedAlchemyBackendConfig(
+                sqlalchemy_config=config, event_log_model_class=AbstractQueueEventLogModel
+            )
+        )
+
 
 def _sqlite_config(path: "Path") -> "SQLAlchemyAsyncConfig":
     return SQLAlchemyAsyncConfig(connection_string=f"sqlite+aiosqlite:///{path}")
@@ -274,6 +363,12 @@ def _column_names(model: "type[object]") -> "set[str]":
 
 def _index_names(model: "type[object]") -> "set[str]":
     return {str(index.name) for index in _table(model).indexes if index.name is not None}
+
+
+def _sqlite_table_names(path: "Path") -> "set[str]":
+    with sqlite3.connect(path) as connection:
+        rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        return {cast("str", row[0]) for row in rows}
 
 
 def _mapped_column_name(model: "type[object]", attribute_name: "str") -> "str":

--- a/src/tests/integration/backends/advanced_alchemy/test_stale_recovery_fencing.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_stale_recovery_fencing.py
@@ -17,13 +17,13 @@ from litestar_queues.backends.advanced_alchemy.service import QueueTaskService, 
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyQueueBackend
+    from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend
 
 pytestmark = pytest.mark.anyio
 
 
 async def test_advanced_alchemy_stale_recovery_does_not_requeue_task_completed_after_stale_select(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+    advanced_alchemy_backend: "SQLAlchemyBackend", monkeypatch: "pytest.MonkeyPatch"
 ) -> "None":
     record = await advanced_alchemy_backend.enqueue("tasks.stale.completed", max_retries=2)
     claimed = await advanced_alchemy_backend.claim_task(record.id)
@@ -55,7 +55,7 @@ async def test_advanced_alchemy_stale_recovery_does_not_requeue_task_completed_a
 
 
 async def test_advanced_alchemy_expected_retry_count_prevents_stale_owner_from_failing_reclaimed_task(
-    advanced_alchemy_backend: "AdvancedAlchemyQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+    advanced_alchemy_backend: "SQLAlchemyBackend", monkeypatch: "pytest.MonkeyPatch"
 ) -> "None":
     record = await advanced_alchemy_backend.enqueue("tasks.stale.owner", max_retries=2)
     claimed = await advanced_alchemy_backend.claim_task(record.id)

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -16,6 +16,7 @@ import pytest
 
 pytest.importorskip("redis")
 
+from litestar_queues import EnqueueSpec
 from litestar_queues.backends import get_queue_backend_class, list_queue_backends
 from litestar_queues.models import HeartbeatTouch
 
@@ -107,6 +108,25 @@ async def test_redis_backend_claims_due_tasks_once_by_priority_and_filters_execu
     stored_low = await redis_backend.get_task(low.id)
     assert stored_low is not None
     assert stored_low.status == "pending"
+
+
+async def test_redis_enqueue_many_records_remain_claimable_when_batch_marker_is_dropped(
+    redis_backend: "RedisQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    async def drop_marker(self: "RedisQueueBackend", records: "object") -> "None":
+        del self, records
+
+    monkeypatch.setattr(type(redis_backend), "notify_new_tasks", drop_marker)
+
+    records = await redis_backend.enqueue_many([
+        EnqueueSpec(task_name=f"tasks.batch.{index}", kwargs={"index": index}) for index in range(25)
+    ])
+    pending = await redis_backend.list_pending(limit=30)
+    claimed = [await redis_backend.claim_task(record.id) for record in pending]
+
+    assert [record.kwargs["index"] for record in records] == list(range(25))
+    assert {record.id for record in pending} == {record.id for record in records}
+    assert {record.id for record in claimed if record is not None} == {record.id for record in records}
 
 
 async def test_redis_backend_releases_locks_by_token_via_lua_script(redis_backend: "RedisQueueBackend") -> "None":

--- a/src/tests/integration/backends/redis/test_event_log.py
+++ b/src/tests/integration/backends/redis/test_event_log.py
@@ -1,0 +1,127 @@
+"""Redis backend-managed queue event history tests."""
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+pytest.importorskip("redis")
+
+from litestar_queues import EventLogConfig, QueueConfig, QueueService
+from litestar_queues.backends.redis import RedisBackendConfig, RedisQueueBackend
+from litestar_queues.backends.redis.event_log import RedisQueueEventLog
+from litestar_queues.events import QueueEvent
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_redis_event_log_records_queries_and_cleans_up(redis_backend: "RedisQueueBackend") -> "None":
+    event_log_config = EventLogConfig(buffer_size=10, flush_interval=60)
+    event_log = redis_backend.get_event_log(event_log_config)
+    assert event_log is not None
+
+    task_id = "task-redis-1"
+    await event_log.publish_event(
+        _event("redis-event-2", task_id=task_id, task_name="tasks.redis.history", sequence=2, second=2)
+    )
+    await event_log.publish_event(
+        _event(
+            "redis-event-1",
+            task_id=task_id,
+            task_name="tasks.redis.history",
+            sequence=1,
+            second=1,
+            detail={"stage": "load", "duration_ms": 7},
+        )
+    )
+    await event_log.publish_event(
+        _event("redis-event-other", task_id="task-redis-2", task_name="tasks.other", sequence=1, second=3)
+    )
+    await event_log.flush_events()
+
+    records = await event_log.list_events(task_id=task_id)
+    limited = await event_log.list_events(task_name="tasks.redis.history", limit=1)
+    deleted = await event_log.cleanup_before(datetime(2026, 1, 1, 0, 0, 3, tzinfo=timezone.utc))
+    remaining = await event_log.list_events(task_name="tasks.redis.history")
+
+    assert [record.event_id for record in records] == ["redis-event-1", "redis-event-2"]
+    assert records[0].detail == {"stage": "load", "duration_ms": 7}
+    assert records[0].stage == "load"
+    assert records[0].duration_ms == 7
+    assert [record.event_id for record in limited] == ["redis-event-1"]
+    assert deleted == 2
+    assert remaining == []
+
+
+async def test_redis_queue_service_accepts_event_log_config(redis_backend: "RedisQueueBackend") -> "None":
+    async with QueueService(QueueConfig(event_log=EventLogConfig()), queue_backend=redis_backend) as service:
+        assert service.get_queue_backend().get_event_log(EventLogConfig()) is not None
+
+
+async def test_redis_event_log_non_strict_flush_preserves_failed_batch() -> "None":
+    backend = RedisQueueBackend(
+        backend_config=RedisBackendConfig(
+            client=cast("Any", _FailingRedisClient()),
+            key_prefix="litestar_queues:test:failing-event-log",
+            notifications=False,
+        )
+    )
+    await backend.open()
+    event_log = backend.get_event_log(EventLogConfig(buffer_size=1, strict=False))
+    assert isinstance(event_log, RedisQueueEventLog)
+
+    await event_log.publish_event(_event("redis-failing-event"))
+
+    assert len(event_log._pending) == 1
+
+
+def _event(
+    event_id: "str",
+    *,
+    task_id: "str" = "task-redis",
+    task_name: "str" = "tasks.redis.history",
+    sequence: "int" = 1,
+    second: "int" = 1,
+    detail: "dict[str, Any] | None" = None,
+) -> "QueueEvent":
+    return QueueEvent(
+        id=event_id,
+        type="task.event",
+        scope="task",
+        task_id=task_id,
+        task_name=task_name,
+        queue="default",
+        sequence=sequence,
+        payload=dict(detail or {}),
+        occurred_at=datetime(2026, 1, 1, 0, 0, second, tzinfo=timezone.utc),
+    )
+
+
+class _FailingPipeline:
+    def hset(self, *_args: "Any", **_kwargs: "Any") -> "None":
+        return None
+
+    def zadd(self, *_args: "Any", **_kwargs: "Any") -> "None":
+        return None
+
+    def execute(self) -> "None":
+        msg = "controlled pipeline failure"
+        raise RuntimeError(msg)
+
+
+class _FailingRedisClient:
+    def pipeline(self, *, transaction: "bool" = False) -> "_FailingPipeline":
+        del transaction
+        return _FailingPipeline()
+
+    async def zrangebyscore(
+        self,
+        _name: "str",
+        _minimum: "float | str",
+        _maximum: "float | str",
+        *,
+        start: "int | None" = None,
+        num: "int | None" = None,
+    ) -> "list[Any]":
+        del start, num
+        return []

--- a/src/tests/integration/backends/redis/test_notifications.py
+++ b/src/tests/integration/backends/redis/test_notifications.py
@@ -12,6 +12,8 @@ import pytest
 
 pytest.importorskip("redis")
 
+from litestar_queues import EnqueueSpec
+
 if TYPE_CHECKING:
     from litestar_queues.backends.redis import RedisQueueBackend
 
@@ -32,3 +34,16 @@ async def test_redis_backend_pubsub_notifications_wake_waiters(redis_backend: "R
     assert redis_backend.capabilities.notification_backend == "redis-pubsub"
     assert await redis_backend.wait_for_notifications(timeout=0.01) is False
     assert record.status == "pending"
+
+
+async def test_redis_backend_enqueue_many_publishes_one_batch_notification(
+    redis_backend: "RedisQueueBackend",
+) -> "None":
+    waiter = asyncio.create_task(redis_backend.wait_for_notifications(timeout=2.0))
+    await asyncio.sleep(0.2)
+
+    records = await redis_backend.enqueue_many([EnqueueSpec(task_name=f"tasks.batch.{index}") for index in range(5)])
+
+    assert await waiter is True
+    assert len(records) == 5
+    assert await redis_backend.wait_for_notifications(timeout=0.05) is False

--- a/src/tests/integration/backends/sqlspec/_schema.py
+++ b/src/tests/integration/backends/sqlspec/_schema.py
@@ -1,0 +1,46 @@
+"""Explicit SQLSpec schema setup helpers for integration tests."""
+
+from inspect import isawaitable
+from typing import TYPE_CHECKING
+
+from litestar_queues import QueueConfig
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueBackend
+from litestar_queues.backends.sqlspec.extension import configure_queue_migration_extension
+from litestar_queues.events import EventLogConfig
+
+if TYPE_CHECKING:
+    from litestar_queues.backends.sqlspec._typing import SQLSpecStoreConfig
+
+
+async def bootstrap_queue_schema(
+    backend_config: "SQLSpecBackendConfig", *, event_log_enabled: "bool" = False
+) -> "None":
+    """Use the queue backend's explicit direct-DDL fallback for a test database."""
+    queue_config = QueueConfig(
+        queue_backend=backend_config, event_log=EventLogConfig(enabled=True) if event_log_enabled else None
+    )
+    backend = SQLSpecQueueBackend(config=queue_config, backend_config=backend_config)
+    await backend.open()
+    try:
+        await backend.create_schema()
+    finally:
+        await backend.close()
+
+
+async def run_queue_migrations(
+    sqlspec_config: "SQLSpecStoreConfig",
+    *,
+    queue_table_name: "str" = "litestar_queue_task",
+    event_log_enabled: "bool" = False,
+    event_log_table_name: "str | None" = None,
+) -> "None":
+    """Register and run the queue migration through SQLSpec itself."""
+    configure_queue_migration_extension(
+        sqlspec_config,
+        queue_table_name=queue_table_name,
+        event_log_enabled=event_log_enabled,
+        event_log_table_name=event_log_table_name,
+    )
+    result = sqlspec_config.migrate_up(echo=False)
+    if isawaitable(result):
+        await result

--- a/src/tests/integration/backends/sqlspec/_schema.py
+++ b/src/tests/integration/backends/sqlspec/_schema.py
@@ -9,7 +9,7 @@ from litestar_queues.backends.sqlspec.extension import configure_queue_migration
 from litestar_queues.events import EventLogConfig
 
 if TYPE_CHECKING:
-    from litestar_queues.backends.sqlspec._typing import SQLSpecStoreConfig
+    from litestar_queues.backends.sqlspec._typing import SQLSpecConfig
 
 
 async def bootstrap_queue_schema(
@@ -28,7 +28,7 @@ async def bootstrap_queue_schema(
 
 
 async def run_queue_migrations(
-    sqlspec_config: "SQLSpecStoreConfig",
+    sqlspec_config: "SQLSpecConfig",
     *,
     queue_table_name: "str" = "litestar_queue_task",
     event_log_enabled: "bool" = False,

--- a/src/tests/integration/backends/sqlspec/conftest.py
+++ b/src/tests/integration/backends/sqlspec/conftest.py
@@ -45,6 +45,7 @@ async def sqlspec_backend(tmp_path: "Path") -> "AsyncIterator[SQLSpecQueueBacken
     """Yield an opened aiosqlite-backed SQLSpec queue backend."""
     backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=_sqlite_config(tmp_path / "queue.db")))
     await backend.open()
+    await backend.create_schema()
     try:
         yield backend
     finally:
@@ -63,6 +64,7 @@ async def duckdb_backend(tmp_path: "Path") -> "AsyncIterator[SQLSpecQueueBackend
         )
     )
     await backend.open()
+    await backend.create_schema()
     try:
         yield backend
     finally:

--- a/src/tests/integration/backends/sqlspec/test_bulk_enqueue.py
+++ b/src/tests/integration/backends/sqlspec/test_bulk_enqueue.py
@@ -97,24 +97,24 @@ async def test_enqueue_many_honors_scheduled_status(sqlspec_backend: "SQLSpecQue
     assert fetched.status == "scheduled"
 
 
-async def test_enqueue_many_notifies_only_immediately_due_records(
+async def test_enqueue_many_notifies_once_after_persistence(
     sqlspec_backend: "SQLSpecQueueBackend", bulk_tier: "str", monkeypatch: "pytest.MonkeyPatch"
 ) -> "None":
-    notified_ids = []
+    notified_batches: "list[list[Any]]" = []
     later = datetime.now(timezone.utc) + timedelta(minutes=5)
 
-    async def notify(self: "SQLSpecQueueBackend", record: "Any") -> "None":
+    async def notify(self: "SQLSpecQueueBackend", records: "Any") -> "None":
         del self
-        notified_ids.append(record.id)
+        notified_batches.append(list(records))
 
-    monkeypatch.setattr(SQLSpecQueueBackend, "notify_new_task", notify)
+    monkeypatch.setattr(SQLSpecQueueBackend, "notify_new_tasks", notify)
 
     records = await sqlspec_backend.enqueue_many([
         EnqueueSpec(task_name="tasks.now"),
         EnqueueSpec(task_name="tasks.later", scheduled_at=later),
     ])
 
-    assert notified_ids == [records[0].id]
+    assert [[record.id for record in batch] for batch in notified_batches] == [[record.id for record in records]]
 
 
 async def test_enqueue_many_deduplicates_active_keys(

--- a/src/tests/integration/backends/sqlspec/test_column_map.py
+++ b/src/tests/integration/backends/sqlspec/test_column_map.py
@@ -168,13 +168,14 @@ async def test_column_map_operates_against_adopter_owned_sqlite_table(
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
             config=sqlite_config_factory(db_path),
-            table_name="adopter_jobs",
+            queue_table_name="adopter_jobs",
             column_map=ADOPTER_COLUMN_MAP,
             manage_schema=False,
         )
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue(
             "tasks.adopter",
@@ -239,6 +240,7 @@ async def test_manage_schema_false_emits_no_schema_ddl(
 
     store = create_queue_store(config, manage_schema=False)
     await backend.open()
+    await backend.create_schema()
     await backend.close()
 
     assert store.create_statements() == []

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -61,6 +61,7 @@ from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import QueuedTaskRecord
 from tests.integration._backends import QUEUE_BACKENDS
 from tests.integration._names import table_name_for_test
+from tests.integration.backends.sqlspec._schema import bootstrap_queue_schema, run_queue_migrations
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping
@@ -233,6 +234,7 @@ async def test_sqlspec_backend_supports_sync_sqlspec_config_via_sync_tools_bridg
         )
     )
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue("tasks.sync_bridge", kwargs={"a": 1})
         claimed = await backend.claim_task(record.id)
@@ -263,6 +265,7 @@ async def test_adbc_sqlite_completed_query_survives_prior_aiosqlite_query(tmp_pa
         )
     )
     await aiosqlite_backend.open()
+    await aiosqlite_backend.create_schema()
     try:
         await _complete_report_task(aiosqlite_backend)
         aiosqlite_records = await aiosqlite_backend.list_completed_by_task("tasks.report")
@@ -277,6 +280,7 @@ async def test_adbc_sqlite_completed_query_survives_prior_aiosqlite_query(tmp_pa
         )
     )
     await adbc_backend.open()
+    await adbc_backend.create_schema()
     try:
         completed_id = await _complete_report_task(adbc_backend)
         adbc_records = await adbc_backend.list_completed_by_task("tasks.report")
@@ -459,10 +463,10 @@ for adapter_name, dialect, config_type_name, expected_store in expected:
 async def test_sqlspec_backend_exposes_config_type_and_builder_store(
     tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
 ) -> "None":
-    backend_config = SQLSpecBackendConfig(table_name="queue_tasks")
-    store = create_queue_store(sqlite_config_factory(tmp_path / "queue.db"), table_name=backend_config.table_name)
+    backend_config = SQLSpecBackendConfig(queue_table_name="queue_tasks")
+    store = create_queue_store(sqlite_config_factory(tmp_path / "queue.db"), table_name=backend_config.queue_table_name)
 
-    assert backend_config.table_name == "queue_tasks"
+    assert backend_config.queue_table_name == "queue_tasks"
     assert isinstance(store, AiosqliteQueueStore)
     assert store.table_name == "queue_tasks"
     assert any('"queue_tasks"' in statement for statement in store.create_statements())
@@ -816,10 +820,11 @@ async def test_sqlspec_backend_uses_spanner_update_ddl_for_schema_bootstrap() ->
     config = _fake_adapter_config("spanner", dialect="spanner", config_type_name="SpannerSyncConfig")
     config.get_database = lambda: database
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(config=config, table_name="queue_tasks", notifications=False)
+        backend_config=SQLSpecBackendConfig(config=config, queue_table_name="queue_tasks", notifications=False)
     )
 
     await backend.open()
+    await backend.create_schema()
     await backend.close()
 
     assert database.statement_batches
@@ -880,7 +885,7 @@ async def test_sqlspec_mssql_python_select_task_uses_native_stream() -> "None":
     config = _fake_adapter_config("mssql_python", dialect="tsql", config_type_name="MssqlPythonAsyncConfig")
     store = create_queue_store(config, table_name="queue_tasks")
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(config=config, table_name="queue_tasks", notifications=False)
+        backend_config=SQLSpecBackendConfig(config=config, queue_table_name="queue_tasks", notifications=False)
     )
     backend._store = store
     driver = _StreamOnlySelectDriver({"id": str(task_id)})
@@ -1004,12 +1009,12 @@ async def test_sqlspec_sync_bridge_can_skip_cleanup_rollback_for_driver_owned_se
 )
 def test_sqlspec_backend_accepts_sqlspec_qualified_table_names(table_name: "str", expected: "str") -> "None":
     """Table-name validation follows SQLSpec's identifier splitter."""
-    backend_config = SQLSpecBackendConfig(table_name=table_name)
+    backend_config = SQLSpecBackendConfig(queue_table_name=table_name)
     store = create_queue_store(
-        _fake_adapter_config("aiosqlite", dialect="sqlite"), table_name=backend_config.table_name
+        _fake_adapter_config("aiosqlite", dialect="sqlite"), table_name=backend_config.queue_table_name
     )
 
-    assert backend_config.table_name == expected
+    assert backend_config.queue_table_name == expected
     assert store.table_name == expected
     assert ".".join(f'"{part}"' for part in expected.split(".")) in "\n".join(store.create_statements())
 
@@ -1019,7 +1024,7 @@ def test_sqlspec_backend_accepts_sqlspec_qualified_table_names(table_name: "str"
 )
 def test_sqlspec_backend_rejects_invalid_table_names(table_name: "str") -> "None":
     with pytest.raises(QueueConfigurationError, match="Invalid SQLSpec queue table name"):
-        SQLSpecBackendConfig(table_name=table_name)
+        SQLSpecBackendConfig(queue_table_name=table_name)
 
 
 @pytest.mark.parametrize(
@@ -1347,10 +1352,11 @@ async def test_sqlspec_postgres_touch_heartbeats_uses_bulk_path(
                     "database": postgres_service.database,
                 }
             ),
-            table_name=table_name,
+            queue_table_name=table_name,
         )
     )
     await backend.open()
+    await backend.create_schema()
     try:
         first = await backend.enqueue("tasks.heartbeat.postgres.first", metadata={"existing": "kept"})
         second = await backend.enqueue("tasks.heartbeat.postgres.second")
@@ -1415,20 +1421,20 @@ async def test_sqlspec_backend_can_start_with_packaged_migrations(
 ) -> "None":
     db_path = tmp_path / "migrated.db"
 
-    first = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(
-            config=sqlite_config_factory(db_path), create_schema=False, run_migrations=True
-        )
-    )
+    first_config = sqlite_config_factory(db_path)
+    await run_queue_migrations(first_config)
+
+    first = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=first_config))
     await first.open()
+    await first.create_schema()
     await first.close()
 
-    second = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(
-            config=sqlite_config_factory(db_path), create_schema=False, run_migrations=True
-        )
-    )
+    second_config = sqlite_config_factory(db_path)
+    await run_queue_migrations(second_config)
+
+    second = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=second_config))
     await second.open()
+    await second.create_schema()
     try:
         record = await second.enqueue("tasks.migrated")
     finally:
@@ -1449,13 +1455,13 @@ async def test_sqlspec_backend_packaged_migrations_do_not_mutate_adopter_config(
     sqlspec_config = sqlite_config_factory(db_path)
     original_extension_config = deepcopy(sqlspec_config.extension_config)
     original_migration_config = deepcopy(sqlspec_config.migration_config)
+    await run_queue_migrations(sqlspec_config)
 
-    backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(config=sqlspec_config, create_schema=False, run_migrations=True)
-    )
+    backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config))
 
     caplog.set_level(logging.WARNING, logger="sqlspec.migrations.base")
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue("tasks.migrated_config")
     finally:
@@ -1472,10 +1478,11 @@ async def test_sqlspec_backend_uses_configured_table_name(
 ) -> "None":
     db_path = tmp_path / "custom-table.db"
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(config=sqlite_config_factory(db_path), table_name="queue_tasks")
+        backend_config=SQLSpecBackendConfig(config=sqlite_config_factory(db_path), queue_table_name="queue_tasks")
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue("tasks.custom_table")
     finally:
@@ -1500,6 +1507,7 @@ async def test_sqlspec_backend_uses_structured_extension_config_when_explicit_va
     backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config))
 
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue("tasks.extension_config")
     finally:
@@ -1520,10 +1528,11 @@ async def test_sqlspec_backend_explicit_config_values_override_sqlspec_extension
         extension_config={QUEUE_EXTENSION_NAME: {"table_name": "extension_queue_tasks"}},
     )
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(config=sqlspec_config, table_name="explicit_queue_tasks")
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, queue_table_name="explicit_queue_tasks")
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue("tasks.explicit_config")
     finally:
@@ -1544,10 +1553,9 @@ async def test_queue_service_uses_sqlspec_backend_from_config(
     async def lowercase(value: "str") -> "str":
         return value.lower()
 
-    config = QueueConfig(
-        queue_backend=SQLSpecBackendConfig(config=sqlite_config_factory(tmp_path / "service.db")),
-        execution_backend="local",
-    )
+    backend_config = SQLSpecBackendConfig(config=sqlite_config_factory(tmp_path / "service.db"))
+    await bootstrap_queue_schema(backend_config)
+    config = QueueConfig(queue_backend=backend_config, execution_backend="local")
 
     async with QueueService(config) as service:
         result = await service.enqueue(lowercase, "QUEUE")

--- a/src/tests/integration/backends/sqlspec/test_datetime_roundtrip.py
+++ b/src/tests/integration/backends/sqlspec/test_datetime_roundtrip.py
@@ -49,6 +49,7 @@ async def test_duckdb_roundtrips_aware_utc_datetimes_on_non_utc_host(
         )
     )
     await backend.open()
+    await backend.create_schema()
     try:
         scheduled_at = datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc)
         record = await backend.enqueue("tasks.duckdb-timezone", scheduled_at=scheduled_at)

--- a/src/tests/integration/backends/sqlspec/test_event_log.py
+++ b/src/tests/integration/backends/sqlspec/test_event_log.py
@@ -16,6 +16,7 @@ from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.events import publish_task_log, publish_task_progress
 from litestar_queues.task import clear_task_registry
+from tests.integration.backends.sqlspec._schema import bootstrap_queue_schema
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -41,8 +42,10 @@ async def test_sqlspec_event_log_records_and_queries_task_history(
     db_path = tmp_path / "event-history.db"
     live_sink = InMemoryQueueEventSink()
     event_log_config = EventLogConfig(enabled=True, buffer_size=100, flush_interval=60)
+    backend_config = SQLSpecBackendConfig(config=sqlite_config_factory(db_path))
+    await bootstrap_queue_schema(backend_config, event_log_enabled=True)
     config = QueueConfig(
-        queue_backend=SQLSpecBackendConfig(config=sqlite_config_factory(db_path)),
+        queue_backend=backend_config,
         execution_backend="immediate",
         event=EventConfig(sink=live_sink),
         event_log=event_log_config,
@@ -95,20 +98,17 @@ async def test_sqlspec_event_log_table_follows_event_log_enabled_lifecycle(
 ) -> "None":
     """SQLSpec only creates the durable event table when event history is enabled."""
     disabled_db_path = tmp_path / "event-log-disabled.db"
-    async with QueueService(
-        QueueConfig(queue_backend=SQLSpecBackendConfig(config=sqlite_config_factory(disabled_db_path)))
-    ):
+    disabled_backend_config = SQLSpecBackendConfig(config=sqlite_config_factory(disabled_db_path))
+    await bootstrap_queue_schema(disabled_backend_config)
+    async with QueueService(QueueConfig(queue_backend=disabled_backend_config)):
         pass
 
     assert "litestar_queue_task_event_log" not in _sqlite_table_names(disabled_db_path)
 
     enabled_db_path = tmp_path / "event-log-enabled.db"
-    async with QueueService(
-        QueueConfig(
-            queue_backend=SQLSpecBackendConfig(config=sqlite_config_factory(enabled_db_path)),
-            event_log=EventLogConfig(enabled=True),
-        )
-    ):
+    enabled_backend_config = SQLSpecBackendConfig(config=sqlite_config_factory(enabled_db_path))
+    await bootstrap_queue_schema(enabled_backend_config, event_log_enabled=True)
+    async with QueueService(QueueConfig(queue_backend=enabled_backend_config, event_log=EventLogConfig(enabled=True))):
         pass
 
     assert "litestar_queue_task_event_log" in _sqlite_table_names(enabled_db_path)
@@ -119,14 +119,11 @@ async def test_sqlspec_event_log_table_name_follows_queue_table_name(
 ) -> "None":
     """SQLSpec derives the default event-log table from the resolved queue table."""
     derived_db_path = tmp_path / "event-log-derived.db"
-    async with QueueService(
-        QueueConfig(
-            queue_backend=SQLSpecBackendConfig(
-                config=sqlite_config_factory(derived_db_path), table_name="custom_queue_task"
-            ),
-            event_log=EventLogConfig(enabled=True),
-        )
-    ):
+    derived_backend_config = SQLSpecBackendConfig(
+        config=sqlite_config_factory(derived_db_path), queue_table_name="custom_queue_task"
+    )
+    await bootstrap_queue_schema(derived_backend_config, event_log_enabled=True)
+    async with QueueService(QueueConfig(queue_backend=derived_backend_config, event_log=EventLogConfig(enabled=True))):
         pass
 
     derived_tables = _sqlite_table_names(derived_db_path)
@@ -134,16 +131,13 @@ async def test_sqlspec_event_log_table_name_follows_queue_table_name(
     assert "litestar_queue_task_event_log" not in derived_tables
 
     explicit_db_path = tmp_path / "event-log-explicit.db"
-    async with QueueService(
-        QueueConfig(
-            queue_backend=SQLSpecBackendConfig(
-                config=sqlite_config_factory(explicit_db_path),
-                table_name="explicit_queue_task",
-                event_log_table_name="queue_events",
-            ),
-            event_log=EventLogConfig(enabled=True),
-        )
-    ):
+    explicit_backend_config = SQLSpecBackendConfig(
+        config=sqlite_config_factory(explicit_db_path),
+        queue_table_name="explicit_queue_task",
+        event_log_table_name="queue_events",
+    )
+    await bootstrap_queue_schema(explicit_backend_config, event_log_enabled=True)
+    async with QueueService(QueueConfig(queue_backend=explicit_backend_config, event_log=EventLogConfig(enabled=True))):
         pass
 
     explicit_tables = _sqlite_table_names(explicit_db_path)

--- a/src/tests/integration/backends/sqlspec/test_extension_migrations.py
+++ b/src/tests/integration/backends/sqlspec/test_extension_migrations.py
@@ -2,8 +2,8 @@
 
 Covers the ``ext_litestar_queues_0001`` packaged migration script: that it
 dispatches through the per-adapter queue store, that the packaged asset is
-discoverable, and that running it twice is idempotent (the
-``run_migrations``-twice flow is exercised by the contract suite).
+discoverable, and that running it twice is idempotent (the twice-open flow is
+exercised by the contract suite).
 """
 
 import importlib

--- a/src/tests/integration/backends/sqlspec/test_heartbeat_pool.py
+++ b/src/tests/integration/backends/sqlspec/test_heartbeat_pool.py
@@ -64,6 +64,7 @@ async def test_sqlspec_backend_sync_sessions_use_sqlspec_managed_async_executor(
         )
     )
     await backend.open()
+    await backend.create_schema()
     try:
         record = await backend.enqueue("tasks.sync_bridge")
         claimed = await backend.claim_task(record.id)
@@ -88,6 +89,7 @@ async def test_sqlspec_backend_dedicated_heartbeat_pool_isolates_heartbeat_write
         backend_config=SQLSpecBackendConfig(sqlspec=sqlspec, config=main_config, heartbeat_pool_config=heartbeat_config)
     )
     await backend.open()
+    await backend.create_schema()
     try:
         assert id(heartbeat_config) in sqlspec.configs
         assert backend._heartbeat_pool_registered is True
@@ -155,6 +157,7 @@ async def test_sqlspec_backend_heartbeat_pool_failure_falls_back_to_main(
     )
     with caplog.at_level("WARNING", logger="litestar_queues"):
         await backend.open()
+        await backend.create_schema()
     try:
         assert backend._heartbeat_pool_registered is False
         assert backend._heartbeat_pool_enabled is False
@@ -184,6 +187,7 @@ async def test_sqlspec_backend_dedicated_heartbeat_pool_handles_concurrent_heart
         backend_config=SQLSpecBackendConfig(config=main_config, heartbeat_pool_config=heartbeat_config)
     )
     await backend.open()
+    await backend.create_schema()
     try:
         records = [await backend.enqueue(f"tasks.bulk-{i}") for i in range(16)]
         claimed = []

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -267,23 +267,14 @@ async def test_sqlspec_backend_event_channel_notifications_wake_waiters(
     await backend.open()
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=1))
-        record = await backend.enqueue("tasks.notified", queue="critical", execution_backend="local")
+        await backend.enqueue("tasks.notified", queue="critical", execution_backend="local")
 
         assert await waiter is True
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == "poll_queue"
         assert backend.capabilities.notifications_durable is True
         assert event_channel.published == [
-            (
-                "queue_notifications",
-                {
-                    "task_id": str(record.id),
-                    "task_name": "tasks.notified",
-                    "queue": "critical",
-                    "execution_backend": "local",
-                },
-                {"event_type": "litestar_queues.task_available"},
-            )
+            ("queue_notifications", {"event": "task_available"}, {"event_type": "litestar_queues.task_available"})
         ]
         assert event_channel.acked == ["event-1"]
     finally:

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -51,6 +51,21 @@ _ORACLE_AQ_QUEUE = "LQ_EVENTS_AQ_QUEUE"
 _ORACLE_TXEVENTQ_QUEUE = "LQ_EVENTS_TXQ"
 
 
+class RecordingPollIntervalEventChannel(StubAsyncEventChannel):
+    """Stub channel that records the poll interval passed to ``iter_events``."""
+
+    __slots__ = ("poll_intervals",)
+
+    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+        super().__init__(backend_name=backend_name)
+        self.poll_intervals: "list[float | None]" = []
+
+    async def iter_events(self, channel: "str", *, poll_interval: "float | None" = None) -> "Any":
+        self.poll_intervals.append(poll_interval)
+        async for event in super().iter_events(channel, poll_interval=poll_interval):
+            yield event
+
+
 def _oracle_sync_config(
     oracle_service: "OracleService", *, user: "str | None" = None, password: "str | None" = None
 ) -> "Any":
@@ -271,6 +286,53 @@ async def test_sqlspec_backend_event_channel_notifications_wake_waiters(
             )
         ]
         assert event_channel.acked == ["event-1"]
+    finally:
+        await backend.close()
+
+
+async def test_sqlspec_backend_worker_timeout_does_not_set_event_poll_interval(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    event_channel = RecordingPollIntervalEventChannel()
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlite_config_factory(tmp_path / "worker-timeout.db"),
+            event_channel=cast("AsyncEventChannel", event_channel),
+            notification_channel="worker_timeout",
+        )
+    )
+
+    await backend.open()
+    try:
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=0.25))
+        await backend.enqueue("tasks.worker_timeout")
+
+        assert await waiter is True
+        assert event_channel.poll_intervals == [None]
+    finally:
+        await backend.close()
+
+
+async def test_sqlspec_backend_event_poll_interval_is_passed_to_event_channel(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    event_channel = RecordingPollIntervalEventChannel()
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlite_config_factory(tmp_path / "event-poll-interval.db"),
+            event_channel=cast("AsyncEventChannel", event_channel),
+            notification_channel="event_poll_interval",
+            event_poll_interval=0.01,
+        )
+    )
+
+    await backend.open()
+    try:
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=0.25))
+        await backend.enqueue("tasks.event_poll_interval")
+
+        assert await waiter is True
+        assert event_channel.poll_intervals == [0.01]
     finally:
         await backend.close()
 

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -30,6 +30,7 @@ from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueB
 from litestar_queues.backends.sqlspec.backend import _adapter_notify_transport
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.exceptions import QueueConfigurationError
+from tests.integration.backends.sqlspec._schema import run_queue_migrations
 from tests.integration.backends.sqlspec.conftest import StubAsyncEventChannel
 
 if TYPE_CHECKING:
@@ -265,6 +266,7 @@ async def test_sqlspec_backend_event_channel_notifications_wake_waiters(
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=1))
         await backend.enqueue("tasks.notified", queue="critical", execution_backend="local")
@@ -294,6 +296,7 @@ async def test_sqlspec_backend_worker_timeout_does_not_set_event_poll_interval(
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=0.25))
         await backend.enqueue("tasks.worker_timeout")
@@ -318,6 +321,7 @@ async def test_sqlspec_backend_event_poll_interval_is_passed_to_event_channel(
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=0.25))
         await backend.enqueue("tasks.event_poll_interval")
@@ -335,15 +339,13 @@ async def test_sqlspec_backend_derives_sqlspec_event_channel_from_config(tmp_pat
     )
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
-            config=sqlspec_config,
-            create_schema=False,
-            run_migrations=True,
-            notifications=True,
-            notification_channel="derived_notifications",
+            config=sqlspec_config, notifications=True, notification_channel="derived_notifications"
         )
     )
 
     await backend.open()
+    await backend.create_schema()
+    await run_queue_migrations(sqlspec_config)
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=1))
         await backend.enqueue("tasks.derived_notified")
@@ -370,6 +372,7 @@ async def test_sqlspec_backend_notification_channel_uses_extension_config_with_e
         )
     )
     await extension_backend.open()
+    await extension_backend.create_schema()
     try:
         await extension_backend.enqueue("tasks.extension_notified")
     finally:
@@ -381,10 +384,11 @@ async def test_sqlspec_backend_notification_channel_uses_extension_config_with_e
             config=sqlspec_config,
             event_channel=cast("AsyncEventChannel", explicit_channel),
             notification_channel="explicit_notifications",
-            table_name="explicit_notification_queue",
+            queue_table_name="explicit_notification_queue",
         )
     )
     await explicit_backend.open()
+    await explicit_backend.create_schema()
     try:
         await explicit_backend.enqueue("tasks.explicit_notified")
     finally:
@@ -401,16 +405,13 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
     sqlspec_config = sqlite_config_factory(tmp_path / "litestar.db")
     sqlspec.add_config(sqlspec_config)
 
-    plugin = QueuePlugin(
-        QueueConfig(
-            queue_backend=SQLSpecBackendConfig(sqlspec=sqlspec, create_schema=False), initialize_schedules=False
-        )
-    )
+    plugin = QueuePlugin(QueueConfig(queue_backend=SQLSpecBackendConfig(sqlspec=sqlspec), initialize_schedules=False))
 
     app = Litestar(plugins=[SQLSpecPlugin(sqlspec), plugin])
 
     assert "db_session" in app.dependencies
     assert "AiosqliteDriver" in app.signature_namespace
+    assert QUEUE_EXTENSION_NAME in sqlspec_config.get_migration_commands().extension_configs
 
 
 @pytest.mark.parametrize(
@@ -447,6 +448,18 @@ def test_notify_transport_config_rejects_unknown_value() -> "None":
         SQLSpecBackendConfig(notify_transport="not-a-transport")
 
 
+def test_queue_plugin_registers_sqlspec_migrations_for_cli() -> "None":
+    """CLI initialization exposes queue migrations to SQLSpec's database command."""
+    from click import Group
+
+    sqlspec_config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    plugin = QueuePlugin(QueueConfig(queue_backend=SQLSpecBackendConfig(config=sqlspec_config)))
+
+    plugin.on_cli_init(Group())
+
+    assert QUEUE_EXTENSION_NAME in sqlspec_config.get_migration_commands().extension_configs
+
+
 @pytest.mark.parametrize("transport", ("listen_notify", "listen_notify_durable", "table_queue"))
 def test_notify_transport_config_rejects_legacy_public_names(transport: "str") -> "None":
     with pytest.raises(QueueConfigurationError):
@@ -475,6 +488,7 @@ async def test_oracle_event_backend_names_are_reported_durable(
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == backend_name
@@ -502,7 +516,7 @@ async def test_sqlspec_backend_oracle_event_transports_wake_waiters(
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
             config=sqlspec_config,
-            table_name=table_name,
+            queue_table_name=table_name,
             notifications=True,
             notify_transport=event_backend,
             event_settings={"aq_queue": aq_queue, "aq_wait_seconds": 1},
@@ -512,6 +526,7 @@ async def test_sqlspec_backend_oracle_event_transports_wake_waiters(
 
     with queue_manager:
         await backend.open()
+        await backend.create_schema()
         try:
             assert backend.capabilities.supports_notifications is True
             assert backend.capabilities.notification_backend == event_backend
@@ -543,6 +558,7 @@ async def test_sqlspec_backend_non_notify_adapter_polls(
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         assert backend.capabilities.supports_notifications is False
         assert backend.capabilities.notification_backend is None
@@ -564,14 +580,14 @@ async def test_sqlspec_backend_notify_transport_override_enables_poll_queue(tmp_
         backend_config=SQLSpecBackendConfig(
             config=sqlspec_config,
             notify_transport="poll_queue",
-            create_schema=False,
-            run_migrations=True,
             notification_channel="override_poll_queue",
             event_poll_interval=0.01,
         )
     )
 
     await backend.open()
+    await backend.create_schema()
+    await run_queue_migrations(sqlspec_config)
     try:
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == "poll_queue"
@@ -591,12 +607,11 @@ async def test_sqlspec_backend_notify_transport_polling_overrides_extension_conf
         extension_config={"events": {"backend": "table_queue", "poll_interval": 0.01}},
     )
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(
-            config=sqlspec_config, notify_transport="polling", create_schema=False, run_migrations=True
-        )
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, notify_transport="polling")
     )
 
     await backend.open()
+    await backend.create_schema()
     try:
         assert backend.capabilities.supports_notifications is False
         assert backend.capabilities.notification_backend is None
@@ -623,16 +638,16 @@ async def test_sqlspec_backend_postgres_listen_notify_durable_wakes(
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
             config=sqlspec_config,
-            table_name="lq_notify_asyncpg",
+            queue_table_name="lq_notify_asyncpg",
             notifications=True,
-            create_schema=False,
-            run_migrations=True,
             notification_channel="lq_asyncpg_wake",
             event_poll_interval=0.05,
         )
     )
 
     await backend.open()
+    await backend.create_schema()
+    await run_queue_migrations(sqlspec_config, queue_table_name="lq_notify_asyncpg")
     try:
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == "notify_queue"

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -2,7 +2,7 @@
 
 Covers ``event_channel`` wiring, derivation from extension config,
 explicit-override precedence, and the per-adapter wakeup-transport gate
-(``listen_notify_durable`` / ``table_queue`` / ``polling``). Adapter-agnostic
+(``notify`` / ``notify_queue`` / ``poll_queue`` / ``polling``). Adapter-agnostic
 cases pin to the aiosqlite adapter so the StubAsyncEventChannel can be injected
 without bringing up a real LISTEN/NOTIFY service; one case exercises the real
 Postgres NOTIFY path against a live container.
@@ -256,7 +256,7 @@ async def test_sqlspec_backend_event_channel_notifications_wake_waiters(
 
         assert await waiter is True
         assert backend.capabilities.supports_notifications is True
-        assert backend.capabilities.notification_backend == "table_queue"
+        assert backend.capabilities.notification_backend == "poll_queue"
         assert backend.capabilities.notifications_durable is True
         assert event_channel.published == [
             (
@@ -297,7 +297,7 @@ async def test_sqlspec_backend_derives_sqlspec_event_channel_from_config(tmp_pat
 
         assert await waiter is True
         assert backend.capabilities.supports_notifications is True
-        assert backend.capabilities.notification_backend == "table_queue"
+        assert backend.capabilities.notification_backend == "poll_queue"
         assert backend.capabilities.notifications_durable is True
     finally:
         await backend.close()
@@ -363,9 +363,9 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
 @pytest.mark.parametrize(
     ("adapter_name", "expected_transport"),
     [
-        ("asyncpg", "listen_notify_durable"),
-        ("psycopg", "table_queue"),
-        ("psqlpy", "table_queue"),
+        ("asyncpg", "notify_queue"),
+        ("psycopg", "poll_queue"),
+        ("psqlpy", "poll_queue"),
         ("cockroach_asyncpg", "polling"),
         ("cockroach_psycopg", "polling"),
         ("aiosqlite", "polling"),
@@ -382,9 +382,9 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
 def test_adapter_notify_transport_capability_gate(adapter_name: "str | None", expected_transport: "str") -> "None":
     """The wakeup transport is gated by adapter knowledge.
 
-    Postgres-over-asyncpg gets the durable LISTEN/NOTIFY hybrid; psycopg/psqlpy
-    fall back to the durable table queue until their LISTEN/NOTIFY path lands
-    upstream; every other family polls.
+    Postgres-over-asyncpg gets ``notify_queue``; psycopg/psqlpy fall back to
+    ``poll_queue`` until their native NOTIFY path lands upstream; every other
+    family reports ``polling``.
     """
     assert _adapter_notify_transport(adapter_name) == expected_transport
 
@@ -392,6 +392,12 @@ def test_adapter_notify_transport_capability_gate(adapter_name: "str | None", ex
 def test_notify_transport_config_rejects_unknown_value() -> "None":
     with pytest.raises(QueueConfigurationError):
         SQLSpecBackendConfig(notify_transport="not-a-transport")
+
+
+@pytest.mark.parametrize("transport", ("listen_notify", "listen_notify_durable", "table_queue"))
+def test_notify_transport_config_rejects_legacy_public_names(transport: "str") -> "None":
+    with pytest.raises(QueueConfigurationError):
+        SQLSpecBackendConfig(notify_transport=transport)
 
 
 @pytest.mark.parametrize("transport", ("aq", "txeventq"))
@@ -498,16 +504,16 @@ async def test_sqlspec_backend_non_notify_adapter_polls(
         await backend.close()
 
 
-async def test_sqlspec_backend_notify_transport_override_enables_table_queue(tmp_path: "Path") -> "None":
+async def test_sqlspec_backend_notify_transport_override_enables_poll_queue(tmp_path: "Path") -> "None":
     """An explicit ``notify_transport`` overrides the adapter's polling default."""
-    sqlspec_config = AiosqliteConfig(connection_config={"database": str(tmp_path / "override-table-queue.db")})
+    sqlspec_config = AiosqliteConfig(connection_config={"database": str(tmp_path / "override-poll-queue.db")})
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
             config=sqlspec_config,
-            notify_transport="table_queue",
+            notify_transport="poll_queue",
             create_schema=False,
             run_migrations=True,
-            notification_channel="override_table_queue",
+            notification_channel="override_poll_queue",
             event_poll_interval=0.01,
         )
     )
@@ -515,11 +521,11 @@ async def test_sqlspec_backend_notify_transport_override_enables_table_queue(tmp
     await backend.open()
     try:
         assert backend.capabilities.supports_notifications is True
-        assert backend.capabilities.notification_backend == "table_queue"
+        assert backend.capabilities.notification_backend == "poll_queue"
         assert backend.capabilities.notifications_durable is True
 
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=2))
-        await backend.enqueue("tasks.override_table_queue")
+        await backend.enqueue("tasks.override_poll_queue")
         assert await waiter is True
     finally:
         await backend.close()
@@ -576,7 +582,7 @@ async def test_sqlspec_backend_postgres_listen_notify_durable_wakes(
     await backend.open()
     try:
         assert backend.capabilities.supports_notifications is True
-        assert backend.capabilities.notification_backend == "listen_notify_durable"
+        assert backend.capabilities.notification_backend == "notify_queue"
         assert backend.capabilities.notifications_durable is True
 
         # NOTIFY wake: subscribe first, then enqueue, and measure latency.

--- a/src/tests/integration/backends/sqlspec/test_observability.py
+++ b/src/tests/integration/backends/sqlspec/test_observability.py
@@ -75,6 +75,7 @@ async def test_sqlspec_backend_emits_queue_metrics_spans_and_correlation(tmp_pat
         )
     )
     await backend.open()
+    await backend.create_schema()
     runtime = sqlspec_config.get_observability_runtime()
     runtime.register_lifecycle_hook("on_query_complete", lifecycle_events.append)
     span_manager = RecordingSpanManager()
@@ -151,6 +152,7 @@ async def test_sqlspec_backend_can_disable_queue_domain_observability(tmp_path: 
     )
     backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config, queue_observability=False))
     await backend.open()
+    await backend.create_schema()
     try:
         with CorrelationContext.context("queue-observability-disabled"):
             await backend.enqueue("tasks.observed.disabled")
@@ -171,6 +173,7 @@ async def test_package_observability_disables_sqlspec_queue_domain_observability
     queue_config = QueueConfig(observability=ObservabilityConfig(enable_otel=True))
     backend = SQLSpecQueueBackend(config=queue_config, backend_config=SQLSpecBackendConfig(config=sqlspec_config))
     await backend.open()
+    await backend.create_schema()
     try:
         with CorrelationContext.context("package-queue-observability"):
             await backend.enqueue("tasks.observed.package")

--- a/src/tests/integration/backends/sqlspec/test_spanner_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_spanner_contract.py
@@ -62,11 +62,12 @@ async def _run_spanner_contract(connection_config: "dict[str, object]", *, table
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
             config=SpannerSyncConfig(connection_config=connection_config, driver_features={"timeout": 30.0}),
-            table_name=table_name,
+            queue_table_name=table_name,
         )
     )
     try:
         await backend.open()
+        await backend.create_schema()
         record = await backend.enqueue("tasks.spanner.live", kwargs={"ok": True}, metadata={"source": "live"})
         claimed = await backend.claim_task(record.id)
         assert claimed is not None

--- a/src/tests/integration/backends/valkey/test_contract.py
+++ b/src/tests/integration/backends/valkey/test_contract.py
@@ -14,6 +14,7 @@ import pytest
 
 pytest.importorskip("valkey")
 
+from litestar_queues import EnqueueSpec
 from litestar_queues.models import HeartbeatTouch
 
 if TYPE_CHECKING:
@@ -66,6 +67,25 @@ async def test_valkey_backend_claims_due_tasks_once_by_priority_and_filters_exec
     stored_low = await valkey_backend.get_task(low.id)
     assert stored_low is not None
     assert stored_low.status == "pending"
+
+
+async def test_valkey_enqueue_many_records_remain_claimable_when_batch_marker_is_dropped(
+    valkey_backend: "ValkeyQueueBackend", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    async def drop_marker(self: "ValkeyQueueBackend", records: "object") -> "None":
+        del self, records
+
+    monkeypatch.setattr(type(valkey_backend), "notify_new_tasks", drop_marker)
+
+    records = await valkey_backend.enqueue_many([
+        EnqueueSpec(task_name=f"tasks.batch.{index}", kwargs={"index": index}) for index in range(25)
+    ])
+    pending = await valkey_backend.list_pending(limit=30)
+    claimed = [await valkey_backend.claim_task(record.id) for record in pending]
+
+    assert [record.kwargs["index"] for record in records] == list(range(25))
+    assert {record.id for record in pending} == {record.id for record in records}
+    assert {record.id for record in claimed if record is not None} == {record.id for record in records}
 
 
 async def test_valkey_backend_releases_locks_by_token_via_lua_script(valkey_backend: "ValkeyQueueBackend") -> "None":

--- a/src/tests/integration/backends/valkey/test_event_log.py
+++ b/src/tests/integration/backends/valkey/test_event_log.py
@@ -1,0 +1,42 @@
+"""Valkey backend-managed queue event history tests."""
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("valkey")
+
+from litestar_queues import EventLogConfig
+from litestar_queues.backends.redis.event_log import RedisQueueEventLog
+from litestar_queues.events import QueueEvent
+
+if TYPE_CHECKING:
+    from litestar_queues.backends.valkey import ValkeyQueueBackend
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_valkey_event_log_reuses_redis_protocol_implementation(valkey_backend: "ValkeyQueueBackend") -> "None":
+    event_log_config = EventLogConfig(buffer_size=10, flush_interval=60)
+    event_log = valkey_backend.get_event_log(event_log_config)
+    assert isinstance(event_log, RedisQueueEventLog)
+
+    await event_log.publish_event(
+        QueueEvent(
+            id="valkey-event-1",
+            type="task.event",
+            scope="task",
+            task_id="task-valkey-1",
+            task_name="tasks.valkey.history",
+            sequence=1,
+            payload={"stage": "load", "duration_ms": 7},
+            occurred_at=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        )
+    )
+    await event_log.flush_events()
+
+    records = await event_log.list_events(task_name="tasks.valkey.history")
+
+    assert [record.event_id for record in records] == ["valkey-event-1"]
+    assert records[0].detail == {"stage": "load", "duration_ms": 7}

--- a/src/tests/integration/backends/valkey/test_notifications.py
+++ b/src/tests/integration/backends/valkey/test_notifications.py
@@ -11,6 +11,8 @@ import pytest
 
 pytest.importorskip("valkey")
 
+from litestar_queues import EnqueueSpec
+
 if TYPE_CHECKING:
     from litestar_queues.backends.valkey import ValkeyQueueBackend
 
@@ -31,3 +33,16 @@ async def test_valkey_backend_pubsub_notifications_wake_waiters(valkey_backend: 
     assert valkey_backend.capabilities.notification_backend == "valkey-pubsub"
     assert await valkey_backend.wait_for_notifications(timeout=0.01) is False
     assert record.status == "pending"
+
+
+async def test_valkey_backend_enqueue_many_publishes_one_batch_notification(
+    valkey_backend: "ValkeyQueueBackend",
+) -> "None":
+    waiter = asyncio.create_task(valkey_backend.wait_for_notifications(timeout=2.0))
+    await asyncio.sleep(0.2)
+
+    records = await valkey_backend.enqueue_many([EnqueueSpec(task_name=f"tasks.batch.{index}") for index in range(5)])
+
+    assert await waiter is True
+    assert len(records) == 5
+    assert await valkey_backend.wait_for_notifications(timeout=0.05) is False

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -48,6 +48,8 @@ async def queue_backend(request: "pytest.FixtureRequest", tmp_path: "Path") -> "
     backend = await case.build(ctx)
     try:
         await backend.open()
+        if hasattr(backend, "create_schema"):
+            await backend.create_schema()  # type: ignore[attr-defined]
     except Exception as exc:
         if _is_missing_arrow_odbc_sql_server_driver(case, exc):
             pytest.skip("arrow-odbc-mssql requires ODBC Driver 18 for SQL Server")

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -49,7 +49,7 @@ async def queue_backend(request: "pytest.FixtureRequest", tmp_path: "Path") -> "
     try:
         await backend.open()
         if hasattr(backend, "create_schema"):
-            await backend.create_schema()  # type: ignore[attr-defined]
+            await backend.create_schema()
     except Exception as exc:
         if _is_missing_arrow_odbc_sql_server_driver(case, exc):
             pytest.skip("arrow-odbc-mssql requires ODBC Driver 18 for SQL Server")

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -247,37 +247,36 @@ async def test_task_dependency_resolver_merges_kwargs_into_task_call(queue_backe
     assert result.result["injected_service"] == "from-resolver"
 
 
-async def test_task_dependency_resolver_cannot_override_sentinels(queue_backend: "BaseQueueBackend") -> "None":
+async def test_task_dependency_resolver_cannot_override_task_context(queue_backend: "BaseQueueBackend") -> "None":
     clear_task_registry()
 
     async def resolver(
         _task: "Task[..., object]", _record: "QueuedTaskRecord", _context: "TaskExecutionContext"
     ) -> "dict[str, object]":
-        return {"_job_id": "hijacked", "_task_context": "hijacked"}
+        return {"injected_service": "resolved", "_task_context": "hijacked"}
 
-    @task("contract.resolver.sentinels")
-    async def sentinels(**kwargs: "object") -> "dict[str, object]":
-        task_context = kwargs["_task_context"]
+    @task("contract.resolver.context")
+    async def consume(**kwargs: "object") -> "dict[str, object]":
+        task_context = kwargs.pop("_task_context")
         assert isinstance(task_context, TaskExecutionContext)
         return {
-            "job_id": kwargs["_job_id"],
             "ctx_type": type(task_context).__name__,
             "ctx_task_name": task_context.task_name,
+            "extra_keys": sorted(kwargs),
         }
 
     config = QueueConfig(execution_backend="immediate", task_dependency_resolver=resolver)
     service = QueueService(config, queue_backend=queue_backend)
 
     async with service:
-        result = await service.enqueue("contract.resolver.sentinels")
+        result = await service.enqueue("contract.resolver.context")
         await result.refresh()
 
     assert result.status == "completed"
     assert isinstance(result.result, dict)
-    assert result.record is not None
-    assert str(result.result["job_id"]) == str(result.record.id)
     assert result.result["ctx_type"] == "TaskExecutionContext"
-    assert result.result["ctx_task_name"] == "contract.resolver.sentinels"
+    assert result.result["ctx_task_name"] == "contract.resolver.context"
+    assert result.result["extra_keys"] == ["injected_service"]
 
 
 async def test_task_dependency_resolver_exception_records_failure_and_retries(

--- a/src/tests/unit/backends/test_advanced_alchemy_config.py
+++ b/src/tests/unit/backends/test_advanced_alchemy_config.py
@@ -8,9 +8,9 @@ pytest.importorskip("sqlalchemy")
 
 def test_advanced_alchemy_config_defaults_to_singular_queue_task_model() -> "None":
     """Default Advanced Alchemy config should use the built-in queue task model."""
-    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyBackendConfig, QueueTaskModel
+    from litestar_queues.backends.advanced_alchemy import QueueTaskModel, SQLAlchemyBackendConfig
 
-    config = AdvancedAlchemyBackendConfig()
+    config = SQLAlchemyBackendConfig()
 
     assert config.model_class is QueueTaskModel
     assert QueueTaskModel.__tablename__ == "litestar_queue_task"

--- a/src/tests/unit/backends/test_bulk_enqueue.py
+++ b/src/tests/unit/backends/test_bulk_enqueue.py
@@ -7,11 +7,14 @@ integration suite.
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import pytest
 
 from litestar_queues import EnqueueSpec
 from litestar_queues.backends import InMemoryQueueBackend
+from litestar_queues.backends.base import BaseQueueBackend
+from litestar_queues.models import QueuedTaskRecord
 
 pytestmark = pytest.mark.anyio
 
@@ -72,3 +75,71 @@ async def test_enqueue_many_deduplicates_active_keys() -> "None":
     assert records[0].id == first.id
     assert records[0].kwargs == {"v": 1}
     assert records[1].task_name == "tasks.other"
+
+
+async def test_base_enqueue_many_calls_batch_notification_once_for_due_records() -> "None":
+    backend = _BatchNotifyingBackend()
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+    records = await backend.enqueue_many([
+        EnqueueSpec(task_name="tasks.one"),
+        EnqueueSpec(task_name="tasks.two", scheduled_at=later),
+        EnqueueSpec(task_name="tasks.three"),
+    ])
+
+    assert [record.task_name for record in records] == ["tasks.one", "tasks.two", "tasks.three"]
+    assert [record.task_name for record in backend.notified_records] == ["tasks.one"]
+
+
+async def test_base_enqueue_many_skips_batch_notification_when_no_records_are_due() -> "None":
+    backend = _BatchNotifyingBackend()
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+    records = await backend.enqueue_many([EnqueueSpec(task_name="tasks.later", scheduled_at=later)])
+
+    assert [record.status for record in records] == ["scheduled"]
+    assert backend.notified_records == []
+
+
+class _BatchNotifyingBackend(BaseQueueBackend):
+    __slots__ = ("notified_records", "records")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.records: "list[QueuedTaskRecord]" = []
+        self.notified_records: "list[QueuedTaskRecord]" = []
+
+    async def enqueue(
+        self,
+        task_name: "str",
+        *,
+        args: "tuple[Any, ...]" = (),
+        kwargs: "dict[str, Any] | None" = None,
+        queue: "str" = "default",
+        priority: "int" = 0,
+        max_retries: "int" = 0,
+        scheduled_at: "datetime | None" = None,
+        key: "str | None" = None,
+        execution_backend: "str" = "local",
+        execution_profile: "str | None" = None,
+        metadata: "dict[str, Any] | None" = None,
+    ) -> "QueuedTaskRecord":
+        record = QueuedTaskRecord(
+            task_name=task_name,
+            args=args,
+            kwargs=dict(kwargs or {}),
+            queue=queue,
+            priority=priority,
+            max_retries=max_retries,
+            scheduled_at=scheduled_at,
+            key=key,
+            execution_backend=execution_backend,
+            execution_profile=execution_profile,
+            metadata=dict(metadata or {}),
+            status="scheduled" if scheduled_at is not None and scheduled_at > datetime.now(timezone.utc) else "pending",
+        )
+        self.records.append(record)
+        return record
+
+    async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
+        self.notified_records.append(record)

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -1,9 +1,10 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 import pytest
 
-from litestar_queues import EventLogConfig, HeartbeatTouch, QueueConfig, QueueService, task
+from litestar_queues import EnqueueSpec, EventLogConfig, HeartbeatTouch, QueueConfig, QueueService, task
 from litestar_queues.backends import InMemoryQueueBackend
 from litestar_queues.events import QueueEvent, publish_task_event, publish_task_log, publish_task_progress
 from litestar_queues.task import clear_task_registry
@@ -311,6 +312,42 @@ async def test_memory_backend_touch_heartbeats_acquires_lock_once() -> "None":
     assert result.missed_task_ids == set()
 
 
+async def test_memory_backend_enqueue_many_acquires_lock_once_and_sets_event_once() -> "None":
+    backend = InMemoryQueueBackend()
+    lock = _CountingAsyncLock()
+    event = _CountingEvent()
+    backend._lock = cast("Any", lock)
+    backend._notification_event = cast("Any", event)
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+    records = await backend.enqueue_many([
+        EnqueueSpec(task_name="tasks.bulk.first", key="bulk:first"),
+        EnqueueSpec(task_name="tasks.bulk.later", scheduled_at=later),
+        EnqueueSpec(task_name="tasks.bulk.second", key="bulk:second"),
+    ])
+
+    assert lock.entries == 1
+    assert event.sets == 1
+    assert [record.task_name for record in records] == ["tasks.bulk.first", "tasks.bulk.later", "tasks.bulk.second"]
+    assert [record.id for record in await backend.list_pending(limit=10)] == [records[0].id, records[2].id]
+
+
+async def test_memory_backend_enqueue_many_future_records_do_not_wake_workers() -> "None":
+    backend = InMemoryQueueBackend()
+    lock = _CountingAsyncLock()
+    event = _CountingEvent()
+    backend._lock = cast("Any", lock)
+    backend._notification_event = cast("Any", event)
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+    records = await backend.enqueue_many([EnqueueSpec(task_name="tasks.bulk.later", scheduled_at=later)])
+
+    assert lock.entries == 1
+    assert event.sets == 0
+    assert records[0].status == "scheduled"
+    assert await backend.list_pending(limit=10) == []
+
+
 async def test_memory_backend_complete_and_fail_are_fenced_by_claim_ownership() -> "None":
     backend = InMemoryQueueBackend()
     record = await backend.enqueue("tasks.fenced", max_retries=1)
@@ -401,3 +438,24 @@ class _CountingAsyncLock:
 
     async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> "None":
         return None
+
+
+class _CountingEvent:
+    def __init__(self) -> "None":
+        self.clears = 0
+        self.sets = 0
+        self._event = asyncio.Event()
+
+    def is_set(self) -> "bool":
+        return self._event.is_set()
+
+    def set(self) -> "None":
+        self.sets += 1
+        self._event.set()
+
+    def clear(self) -> "None":
+        self.clears += 1
+        self._event.clear()
+
+    async def wait(self) -> "bool":
+        return await self._event.wait()

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -3,8 +3,9 @@ from typing import Any, cast
 
 import pytest
 
-from litestar_queues import HeartbeatTouch, QueueConfig, QueueService, task
+from litestar_queues import EventLogConfig, HeartbeatTouch, QueueConfig, QueueService, task
 from litestar_queues.backends import InMemoryQueueBackend
+from litestar_queues.events import QueueEvent, publish_task_event, publish_task_log, publish_task_progress
 from litestar_queues.task import clear_task_registry
 
 pytestmark = pytest.mark.anyio
@@ -29,6 +30,75 @@ async def test_memory_backend_deduplicates_active_keys_and_replaces_terminal_key
 
     assert replacement.id != first.id
     assert replacement.kwargs == {"account_id": "acct-2"}
+
+
+async def test_memory_backend_event_log_records_task_history_with_custom_detail() -> "None":
+    @task("tasks.memory_event_history")
+    async def memory_event_history() -> "str":
+        await publish_task_log("loaded", payload={"stage": "load", "duration_ms": 7})
+        await publish_task_progress(current=2, total=4, payload={"stage": "load", "duration_ms": 5})
+        await publish_task_event("task.event", message="custom", payload={"stage": "store", "duration_ms": 11})
+        return "ok"
+
+    event_log_config = EventLogConfig(buffer_size=100, flush_interval=60)
+    async with QueueService(QueueConfig(execution_backend="immediate", event_log=event_log_config)) as service:
+        result = await service.enqueue(memory_event_history)
+        event_log = service.get_queue_backend().get_event_log(event_log_config)
+        assert event_log is not None
+        records = await event_log.list_events(task_id=str(result.id))
+        task_name_records = await event_log.list_events(task_name=memory_event_history.name, limit=2)
+
+    assert [record.event_type for record in records] == [
+        "task.started",
+        "task.log",
+        "task.progress",
+        "task.event",
+        "task.completed",
+    ]
+    assert [record.sequence for record in task_name_records] == [1, 2]
+    custom = next(record for record in records if record.event_type == "task.event")
+    assert custom.message == "custom"
+    assert custom.detail == {"stage": "store", "duration_ms": 11}
+
+
+async def test_memory_backend_event_log_is_bounded_and_cleanup_is_queryable() -> "None":
+    event_log_config = EventLogConfig(max_records=3)
+    backend = InMemoryQueueBackend(QueueConfig(event_log=event_log_config))
+    event_log = backend.get_event_log(event_log_config)
+    assert event_log is not None
+
+    for index in range(5):
+        await event_log.publish_event(
+            QueueEvent(
+                type="task.log",
+                scope="task",
+                task_id=f"task-{index}",
+                task_name="tasks.bounded",
+                sequence=index,
+                payload={"index": index},
+                occurred_at=datetime(2026, 1, 1, 0, 0, index, tzinfo=timezone.utc),
+            )
+        )
+
+    records = await event_log.list_events(task_name="tasks.bounded")
+    deleted = await event_log.cleanup_before(datetime(2026, 1, 1, 0, 0, 4, tzinfo=timezone.utc))
+    remaining = await event_log.list_events(task_name="tasks.bounded")
+
+    assert [record.detail["index"] for record in records] == [2, 3, 4]
+    assert deleted == 2
+    assert [record.detail["index"] for record in remaining] == [4]
+
+
+async def test_memory_backend_clear_clears_event_log() -> "None":
+    event_log_config = EventLogConfig()
+    backend = InMemoryQueueBackend(QueueConfig(event_log=event_log_config))
+    event_log = backend.get_event_log(event_log_config)
+    assert event_log is not None
+
+    await event_log.publish_event(QueueEvent(type="task.log", scope="task", task_name="tasks.clear"))
+    await backend.clear()
+
+    assert await event_log.list_events(task_name="tasks.clear") == []
 
 
 async def test_memory_backend_claims_due_tasks_by_priority_and_marks_lifecycle() -> "None":

--- a/src/tests/unit/backends/test_redis_backend.py
+++ b/src/tests/unit/backends/test_redis_backend.py
@@ -1,12 +1,13 @@
 import builtins
 import json
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID, uuid4
 
 import pytest
 
-from litestar_queues import HeartbeatTouch
+from litestar_queues import EnqueueSpec, HeartbeatTouch
 from litestar_queues.backends.redis import RedisBackendConfig, RedisQueueBackend
 from litestar_queues.models import QueuedTaskRecord
 
@@ -57,6 +58,34 @@ async def test_redis_wait_for_notifications_reuses_pubsub_subscription() -> "Non
     assert client.pubsubs[0].subscribe_calls == 1
     assert client.pubsubs[0].unsubscribe_calls == 1
     assert client.pubsubs[0].close_calls == 1
+
+
+async def test_redis_enqueue_many_persists_unkeyed_batch_with_one_pipeline_and_one_notification() -> "None":
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), notifications=True))
+
+    records = await backend.enqueue_many([
+        EnqueueSpec(task_name="tasks.redis.batch", kwargs={"index": 0}),
+        EnqueueSpec(task_name="tasks.redis.batch", kwargs={"index": 1}),
+        EnqueueSpec(task_name="tasks.redis.batch", kwargs={"index": 2}),
+    ])
+
+    assert [record.kwargs["index"] for record in records] == [0, 1, 2]
+    assert client.pipeline_calls == 1
+    assert client.pipeline_execute_calls == 1
+    assert client.publish_calls == 1
+    assert json.loads(client.published[0][1]) == {"event": "task_available"}
+
+
+async def test_redis_enqueue_many_future_batch_does_not_publish_notification() -> "None":
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), notifications=True))
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+    records = await backend.enqueue_many([EnqueueSpec(task_name="tasks.redis.later", scheduled_at=later)])
+
+    assert records[0].status == "scheduled"
+    assert client.publish_calls == 0
 
 
 async def test_redis_backend_touch_heartbeats_fences_and_merges_metadata() -> "None":
@@ -154,6 +183,8 @@ class _CountingRedisClient:
         self.hgetall_calls = 0
         self.pipeline_calls = 0
         self.pipeline_execute_calls = 0
+        self.publish_calls = 0
+        self.published: "list[tuple[str, str]]" = []
         self.pubsub_calls = 0
         self.scard_calls = 0
         self.smembers_calls = 0
@@ -162,6 +193,11 @@ class _CountingRedisClient:
     async def hgetall(self, key: "str") -> "dict[str, str]":
         self.hgetall_calls += 1
         return self.hashes.get(key, {})
+
+    async def publish(self, channel: "str", payload: "str") -> "int":
+        self.publish_calls += 1
+        self.published.append((channel, payload))
+        return 1
 
     async def get(self, key: "str") -> "str | None":
         return self.strings.get(key)

--- a/src/tests/unit/events/test_external_producer.py
+++ b/src/tests/unit/events/test_external_producer.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
 from litestar_queues import EventConfig, QueueConfig
-from litestar_queues.events import QueueChannels, QueueEvent
+from litestar_queues.events import EventBufferConfig, QueueChannels, QueueEvent
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -57,7 +57,80 @@ async def test_factory_strict_propagates() -> None:
         QueueConfig(event=EventConfig(strict=True, channels_backend=_FailingChannelsBackend()))
     ) as producer:
         with pytest.raises(RuntimeError, match="publish failed"):
-            await producer.channel("imports:acme").publish("x")
+            await producer.channel("imports:acme").publish("x", immediate=True)
+
+
+async def test_factory_sqlspec_transport_publishes_through_event_channel() -> None:
+    from litestar_queues.events import create_event_producer
+
+    event_channel = _RecordingSqlSpecEventChannel()
+    config = QueueConfig(
+        queue_backend=_SqlSpecBackendConfig(event_channel=event_channel),
+        event=EventConfig(buffer=EventBufferConfig(enabled=False)),
+    )
+
+    async with create_event_producer(config, transport="sqlspec") as producer:
+        await producer.task("task-1").progress(current=1, total=2, immediate=True)
+
+    assert event_channel.shutdown_count == 0
+    [(channel, payload, metadata)] = event_channel.published
+    assert channel == QueueChannels.task("task-1")
+    assert payload["type"] == "task.progress"
+    assert payload["taskId"] == "task-1"
+    assert payload["progressCurrent"] == 1
+    assert metadata == {"event_type": "task.progress", "queue_event_id": payload["id"], "queue_event_scope": "task"}
+
+
+async def test_factory_sqlspec_transport_drains_buffer_before_close() -> None:
+    from litestar_queues.events import create_event_producer
+
+    event_channel = _RecordingSqlSpecEventChannel()
+    config = QueueConfig(
+        queue_backend=_SqlSpecBackendConfig(event_channel=event_channel),
+        event=EventConfig(buffer=EventBufferConfig(buffer_size=10, flush_interval=60)),
+    )
+
+    async with create_event_producer(config, transport="sqlspec") as producer:
+        await producer.task("task-1").log("buffered")
+        await producer.task("task-1").progress(current=1, total=2)
+        assert event_channel.published == []
+
+    assert [payload["type"] for _, payload, _ in event_channel.published] == ["task.log", "task.progress"]
+
+
+async def test_factory_sqlspec_transport_builds_channel_lazily_and_closes_owned_channel() -> None:
+    from litestar_queues.events import create_event_producer
+
+    sqlspec = _RecordingSQLSpec()
+    config = QueueConfig(
+        queue_backend=_SqlSpecBackendConfig(sqlspec=sqlspec, config=_RecordingSQLSpecConfig()),
+        event=EventConfig(buffer=EventBufferConfig(enabled=False)),
+    )
+    external = create_event_producer(config, transport="sqlspec")
+
+    assert sqlspec.channel_calls == 0
+    async with external as producer:
+        assert sqlspec.channel_calls == 0
+        await producer.channel("imports:acme").publish("import.note", immediate=True)
+        assert sqlspec.channel_calls == 1
+
+    assert sqlspec.created_event_channel.shutdown_count == 1
+    assert sqlspec.close_all_pools_count == 0
+
+
+def test_create_event_producer_import_does_not_load_sqlspec() -> None:
+    import subprocess
+    import sys
+
+    code = """
+import sys
+from litestar_queues.events import create_event_producer
+raise SystemExit(1 if "sqlspec" in sys.modules else 0)
+"""
+
+    result = subprocess.run([sys.executable, "-c", code], check=False, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stdout
 
 
 async def test_manual_aclose() -> None:
@@ -119,3 +192,62 @@ class _ExplodingBackendConfig(QueueConfig):
     def get_queue_backend(self) -> "BaseQueueBackend":
         msg = "queue backend must not open"
         raise AssertionError(msg)
+
+
+class _SqlSpecBackendConfig:
+    backend_name: "ClassVar[str]" = "sqlspec"
+
+    def __init__(
+        self,
+        *,
+        event_channel: "_RecordingSqlSpecEventChannel | None" = None,
+        sqlspec: "_RecordingSQLSpec | None" = None,
+        config: "_RecordingSQLSpecConfig | None" = None,
+    ) -> None:
+        self.event_channel = event_channel
+        self.sqlspec = sqlspec
+        self.config = config
+        self.event_backend = "table_queue"
+        self.event_queue_table = "litestar_queue_events"
+        self.event_poll_interval = None
+        self.event_settings: "dict[str, object]" = {}
+        self.notify_transport = None
+
+
+class _RecordingSQLSpecConfig:
+    def __init__(self) -> None:
+        self.extension_config: "dict[str, dict[str, object]]" = {}
+        self.migration_config: "dict[str, object]" = {}
+
+    def set_migration_config(self, config: "dict[str, object]") -> None:
+        self.migration_config = config
+
+
+class _RecordingSQLSpec:
+    def __init__(self) -> None:
+        self.channel_calls = 0
+        self.close_all_pools_count = 0
+        self.created_event_channel = _RecordingSqlSpecEventChannel()
+
+    def event_channel(self, config: "_RecordingSQLSpecConfig") -> "_RecordingSqlSpecEventChannel":
+        self.channel_calls += 1
+        return self.created_event_channel
+
+    async def close_all_pools(self) -> None:
+        self.close_all_pools_count += 1
+
+
+class _RecordingSqlSpecEventChannel:
+    def __init__(self) -> None:
+        self.published: "list[tuple[str, dict[str, object], dict[str, object] | None]]" = []
+        self.shutdown_count = 0
+
+    async def publish(
+        self, channel: "str", payload: "dict[str, object]", metadata: "dict[str, object] | None" = None
+    ) -> "str":
+        event_id = f"event-{len(self.published) + 1}"
+        self.published.append((channel, payload, metadata))
+        return event_id
+
+    async def shutdown(self) -> None:
+        self.shutdown_count += 1

--- a/src/tests/unit/events/test_litestar_streams.py
+++ b/src/tests/unit/events/test_litestar_streams.py
@@ -27,6 +27,43 @@ async def test_publish_many_groups_single_channel_into_one_call() -> "None":
     assert [QueueEvent.from_json(payload).type for payload in payloads] == ["task.progress", "task.log"]
 
 
+@pytest.mark.parametrize("backend_kind", ["sqlspec", "redis"])
+async def test_publish_many_keeps_channel_groups_separate(backend_kind: "str") -> "None":
+    backend = _RedisPipelineChannelsBackend() if backend_kind == "redis" else _BatchPublishingChannelsBackend()
+    sink = ChannelsQueueEventSink(cast("Any", backend))
+    first = QueueEvent(type="task.progress", scope="task", task_id="task-1")
+    second = QueueEvent(type="task.log", scope="task", task_id="task-2")
+    third = QueueEvent(type="task.event", scope="queue", scope_key="critical", queue="critical")
+
+    await sink.publish_many((
+        (first, ("task-1", "global")),
+        (second, ("task-2", "global")),
+        (third, ("task-1", "global")),
+    ))
+
+    assert len(backend.published_many) == 2
+    assert [channels for _, channels in backend.published_many] == [("task-1", "global"), ("task-2", "global")]
+    assert [[QueueEvent.from_json(payload).type for payload in payloads] for payloads, _ in backend.published_many] == [
+        ["task.progress", "task.event"],
+        ["task.log"],
+    ]
+
+
+async def test_publish_many_uses_valkey_native_batch_capability_without_redis_import() -> "None":
+    backend = _ValkeyPipelineChannelsBackend()
+    sink = ChannelsQueueEventSink(cast("Any", backend))
+    first = QueueEvent(type="task.progress", scope="task", task_id="task-1")
+    second = QueueEvent(type="task.log", scope="task", task_id="task-1")
+
+    await sink.publish_many(((first, ("events",)), (second, ("events",))))
+
+    assert backend.transport_label == "valkey"
+    assert backend.pipeline_count == 1
+    [(payloads, channels)] = backend.published_many
+    assert channels == ("events",)
+    assert [QueueEvent.from_json(payload).type for payload in payloads] == ["task.progress", "task.log"]
+
+
 async def test_publish_many_fallback_loops_when_no_batch_api() -> "None":
     backend = _WaitPublishingChannelsBackend()
     sink = ChannelsQueueEventSink(backend)
@@ -65,11 +102,29 @@ async def test_publish_many_honours_max_payload_bytes() -> "None":
 
 
 class _BatchPublishingChannelsBackend:
+    transport_label = "sqlspec"
+
     def __init__(self) -> None:
         self.published_many: "list[tuple[tuple[bytes | str, ...], tuple[str, ...]]]" = []
 
     def wait_published_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None:
         self.published_many.append((tuple(data), tuple(channels)))
+
+
+class _RedisPipelineChannelsBackend(_BatchPublishingChannelsBackend):
+    transport_label = "redis"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.pipeline_count = 0
+
+    def wait_published_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None:
+        self.pipeline_count += 1
+        super().wait_published_many(data, channels)
+
+
+class _ValkeyPipelineChannelsBackend(_RedisPipelineChannelsBackend):
+    transport_label = "valkey"
 
 
 class _WaitPublishingChannelsBackend:

--- a/src/tests/unit/events/test_sinks.py
+++ b/src/tests/unit/events/test_sinks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -20,6 +20,24 @@ async def test_inmemory_publish_many_records_all_in_order() -> None:
         (second, (QueueChannels.task("task-a"), QueueChannels.global_channel())),
     ))
 
+    assert sink.events == [first, second]
+    assert sink.events_for(QueueChannels.task("task-a")) == [first, second]
+    assert sink.events_for(QueueChannels.global_channel()) == [second]
+
+
+async def test_inmemory_publish_many_takes_one_lock_for_batch() -> None:
+    sink = InMemoryQueueEventSink()
+    lock = _CountingAsyncLock()
+    sink._lock = cast("Any", lock)
+    first = QueueEvent(type="task.progress", scope="task", task_id="task-a")
+    second = QueueEvent(type="task.log", scope="task", task_id="task-a")
+
+    await sink.publish_many((
+        (first, (QueueChannels.task("task-a"),)),
+        (second, (QueueChannels.task("task-a"), QueueChannels.global_channel())),
+    ))
+
+    assert lock.enter_count == 1
     assert sink.events == [first, second]
     assert sink.events_for(QueueChannels.task("task-a")) == [first, second]
     assert sink.events_for(QueueChannels.global_channel()) == [second]
@@ -50,3 +68,14 @@ class _PublishOnlySink:
 
     async def publish(self, event: "QueueEvent", *, channels: "Sequence[str]") -> None:
         self.published.append((event, tuple(channels)))
+
+
+class _CountingAsyncLock:
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    async def __aenter__(self) -> None:
+        self.enter_count += 1
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None

--- a/src/tests/unit/events/test_stream_config.py
+++ b/src/tests/unit/events/test_stream_config.py
@@ -1,6 +1,8 @@
 from dataclasses import fields
 from typing import get_type_hints
 
+import pytest
+
 
 def test_event_stream_config_defaults() -> "None":
     from litestar_queues.events import EventStreamConfig
@@ -52,6 +54,7 @@ def test_queue_config_sub_config_field_defaults() -> "None":
     assert config.observability is None
     assert EventConfig().enabled is True
     assert EventLogConfig().enabled is True
+    assert EventLogConfig().max_records == 1000
     assert EventStreamConfig().enabled is True
     assert config.signature_namespace["EventConfig"] is EventConfig
     assert config.signature_namespace["EventLogConfig"] is EventLogConfig
@@ -76,3 +79,10 @@ def test_queue_config_explicit_disable_keeps_config_object() -> "None":
     assert config.event_log.enabled is False
     assert config.event_stream is not None
     assert config.event_stream.enabled is False
+
+
+def test_event_log_config_requires_positive_max_records() -> "None":
+    from litestar_queues.events import EventLogConfig
+
+    with pytest.raises(ValueError, match="max_records"):
+        EventLogConfig(max_records=0)

--- a/src/tests/unit/examples/test_htmx_realtime_example.py
+++ b/src/tests/unit/examples/test_htmx_realtime_example.py
@@ -5,8 +5,8 @@ from typing import cast
 ROOT = Path(__file__).resolve().parents[4]
 EXAMPLES_ROOT = ROOT / "examples"
 
-# All ten examples carry the "space opera" design where the htmx SSE/WS
-# extensions own the stream connection declaratively.
+# All ten examples use the same simple frontend and declarative htmx stream
+# connection; only the queue backend and transport vary.
 BACKEND_VARIANTS = {
     "memory": {"suffix": "", "backend_markers": ('BACKEND_NAME = "memory"',)},
     "sqlspec": {
@@ -14,19 +14,17 @@ BACKEND_VARIANTS = {
         "backend_markers": (
             "SQLSpecBackendConfig",
             "AiosqliteConfig",
-            "LITESTAR_QUEUES_EXAMPLE_SQLSPEC_DB",
-            "create_schema=False",
-            "run_migrations=True",
+            'QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-sqlspec.db"',
         ),
     },
     "advanced-alchemy": {
         "suffix": "_advanced_alchemy",
         "backend_markers": (
-            "AdvancedAlchemyBackendConfig",
+            "SQLAlchemyBackendConfig",
             "SQLAlchemyAsyncConfig",
             "create_all=True",
             "sqlite+aiosqlite",
-            "LITESTAR_QUEUES_EXAMPLE_ADVANCED_ALCHEMY_DB",
+            'QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-advanced-alchemy.db"',
         ),
     },
     "redis": {

--- a/src/tests/unit/examples/test_htmx_realtime_example.py
+++ b/src/tests/unit/examples/test_htmx_realtime_example.py
@@ -243,7 +243,7 @@ def test_htmx_realtime_examples_use_litestar_asset_commands_and_current_packages
 
 
 def test_htmx_realtime_docs_import_from_runnable_example() -> None:
-    docs_source = (ROOT / "docs" / "usage" / "events.rst").read_text()
+    docs_source = (ROOT / "docs" / "usage" / "event-streams.rst").read_text()
     assert "examples/htmx_realtime_websocket/app.py" in docs_source
     assert "examples/htmx_realtime_websocket/resources/main.ts" in docs_source
     assert "examples/htmx_realtime_websocket/templates/index.html" in docs_source

--- a/src/tests/unit/test_docs_structure.py
+++ b/src/tests/unit/test_docs_structure.py
@@ -1,0 +1,84 @@
+import ast
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+DOCS = ROOT / "docs"
+
+
+def _quickstart_python_block() -> str:
+    source = (DOCS / "getting_started" / "quickstart.rst").read_text()
+    match = re.search(r"\.\. code-block:: python\n(?:\s+:\w+:.*\n)*\n(?P<body>(?:   .*\n|\n)+)", source)
+    assert match is not None
+    return "\n".join(line[3:] for line in match.group("body").splitlines())
+
+
+def test_quickstart_is_complete_and_beginner_focused() -> None:
+    block = _quickstart_python_block()
+    ast.parse(block)
+
+    for marker in ("@task(", "QueuePlugin", "QueueConfig", "QueueService", ".enqueue(", "Litestar("):
+        assert marker in block
+    for advanced_topic in ("SQLSpec", "Redis", "Valkey", "CloudRun", "EventConfig", "task_modules"):
+        assert advanced_topic not in block
+
+
+def test_configured_navigation_targets_exist() -> None:
+    source = (DOCS / "conf.py").read_text()
+    tree = ast.parse(source)
+    nav_links = next(
+        node.value
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "html_theme_options"
+    )
+    assert nav_links is not None
+    options = ast.literal_eval(nav_links)
+    targets = [
+        child["url"]
+        for group in options["nav_links"]
+        for child in group.get("children", ())
+        if not child["url"].startswith(("http://", "https://"))
+    ]
+
+    assert targets
+    for target in targets:
+        assert (DOCS / f"{target}.rst").is_file(), target
+
+
+def test_learning_path_and_canonical_terms_are_exposed() -> None:
+    conf = (DOCS / "conf.py").read_text()
+    homepage = (DOCS / "index.rst").read_text()
+    concepts = (DOCS / "usage" / "concepts.rst").read_text()
+
+    for label in ("Start here", "Concepts", "How-to guides", "Examples", "Reference"):
+        assert label in conf
+        assert label in homepage
+    for term in ("queue backend", "execution backend", "worker wakeup", "task event"):
+        assert term in concepts.lower()
+    assert "source of truth" in concepts.lower()
+    assert "worker discovery" in concepts.lower()
+
+
+def test_required_documentation_pages_exist() -> None:
+    pages = (
+        "examples/index.rst",
+        "usage/concepts.rst",
+        "usage/task-options.rst",
+        "usage/results.rst",
+        "usage/background-tasks.rst",
+        "usage/failures-and-cancellation.rst",
+        "usage/worker-wakeups.rst",
+        "usage/worker-recovery.rst",
+        "usage/backends/sqlspec.rst",
+        "usage/backends/advanced-alchemy.rst",
+        "usage/backends/redis-valkey.rst",
+        "usage/event-streams.rst",
+        "usage/event-history.rst",
+        "usage/event-testing.rst",
+        "contributing/documentation.rst",
+    )
+
+    for page in pages:
+        assert (DOCS / page).is_file(), page

--- a/src/tests/unit/test_public_api.py
+++ b/src/tests/unit/test_public_api.py
@@ -94,7 +94,7 @@ def test_public_exports() -> "None":
         "task",
     }
     forbidden_exports = {
-        "AdvancedAlchemyQueueBackend",
+        "SQLAlchemyBackend",
         "RedisBackendConfig",
         "RedisQueueBackend",
         "SQLSpecQueueBackend",
@@ -148,12 +148,12 @@ def test_public_exports() -> "None":
 def test_optional_backends_resolve_lazily_via_factory() -> "None":
     """Optional backends are not top-level exports but are resolvable by name through the factory."""
     from litestar_queues import get_queue_backend_class
-    from litestar_queues.backends.advanced_alchemy import AdvancedAlchemyQueueBackend
+    from litestar_queues.backends.advanced_alchemy import SQLAlchemyBackend
     from litestar_queues.backends.redis import RedisQueueBackend
     from litestar_queues.backends.sqlspec import SQLSpecQueueBackend
     from litestar_queues.backends.valkey import ValkeyQueueBackend
 
-    assert get_queue_backend_class("advanced-alchemy") is AdvancedAlchemyQueueBackend
+    assert get_queue_backend_class("advanced-alchemy") is SQLAlchemyBackend
     assert get_queue_backend_class("redis") is RedisQueueBackend
     assert get_queue_backend_class("sqlspec") is SQLSpecQueueBackend
     assert get_queue_backend_class("valkey") is ValkeyQueueBackend

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -318,18 +318,16 @@ async def test_recover_stale_tasks_publishes_summary_event() -> "None":
     assert event.payload == {"requeued": 0, "failed": 1, "skipped": 0, "handler_needed": 0}
 
 
-async def test_event_log_config_is_public_and_memory_backend_is_unsupported() -> "None":
+async def test_event_log_config_is_public_and_memory_backend_is_supported() -> "None":
     from litestar_queues import events
-    from litestar_queues.exceptions import QueueConfigurationError
 
     event_log_config_type = getattr(events, "EventLogConfig", None)
     assert event_log_config_type is not None
 
     config = QueueConfig(event_log=event_log_config_type(enabled=True))
 
-    with pytest.raises(QueueConfigurationError, match="event history"):
-        async with QueueService(config):
-            pass
+    async with QueueService(config) as service:
+        assert service.get_queue_backend().get_event_log(event_log_config_type()) is not None
 
 
 async def test_backend_event_log_records_events_when_live_events_are_disabled() -> "None":

--- a/src/tests/unit/test_task_api.py
+++ b/src/tests/unit/test_task_api.py
@@ -69,20 +69,19 @@ async def test_task_execute_record_merges_extra_kwargs_into_call() -> "None":
     assert result["another"] == 42
 
 
-async def test_task_execute_record_extra_kwargs_cannot_override_sentinels() -> "None":
-    @task("inject.sentinels")
-    async def sentinels(**kwargs: "object") -> "dict[str, object]":
+async def test_task_execute_record_injects_only_typed_context() -> "None":
+    @task("inject.context")
+    async def consume(**kwargs: "object") -> "dict[str, object]":
         return dict(kwargs)
 
-    record = QueuedTaskRecord(task_name="inject.sentinels")
+    record = QueuedTaskRecord(task_name="inject.context")
     context = _build_test_context(record)
 
-    result = await sentinels.execute_record(
-        record, task_context=context, extra_kwargs={"_job_id": "hijacked", "_task_context": "hijacked"}
+    result = await consume.execute_record(
+        record, task_context=context, extra_kwargs={"injected_service": "resolved", "_task_context": "hijacked"}
     )
 
-    assert result["_job_id"] == str(record.id)
-    assert result["_task_context"] is context
+    assert result == {"injected_service": "resolved", "_task_context": context}
 
 
 async def test_task_using_returns_configured_copy_without_mutating_original() -> "None":

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from litestar_queues._heartbeat import WorkerHeartbeatManager
+    from litestar_queues.events import TaskExecutionContext
     from litestar_queues.models import HeartbeatTouch, HeartbeatTouchResult, QueuedTaskRecord, StaleTaskRecoveryResult
     from litestar_queues.task import TaskResult
 
@@ -79,13 +80,13 @@ async def test_worker_retries_failed_task_until_success() -> "None":
     assert result.result == "ok"
 
 
-async def test_worker_non_retryable_failure_skips_retries_and_injects_job_id() -> "None":
-    captured_job_id: "str | None" = None
+async def test_worker_non_retryable_failure_skips_retries_and_injects_task_context() -> "None":
+    captured_task_id: "str | None" = None
 
     @task("tasks.permanent", retries=3)
-    async def permanent_failure(*, _job_id: "str") -> "None":
-        nonlocal captured_job_id
-        captured_job_id = _job_id
+    async def permanent_failure(*, _task_context: "TaskExecutionContext") -> "None":
+        nonlocal captured_task_id
+        captured_task_id = _task_context.task_id
         non_retryable("permanent failure")
 
     async with QueueService(QueueConfig(execution_backend="local")) as service:
@@ -95,7 +96,7 @@ async def test_worker_non_retryable_failure_skips_retries_and_injects_job_id() -
         assert await worker.run_once() == 1
         await result.wait(timeout=1, poll_interval=0.01)
 
-    assert captured_job_id == str(result.id)
+    assert captured_task_id == str(result.id)
     assert result.status == "failed"
     assert result.error == "permanent failure"
     assert result.record is not None
@@ -666,10 +667,14 @@ async def test_plugin_logs_when_in_app_worker_task_dies(monkeypatch: "pytest.Mon
 
 async def test_sync_task_uses_configured_executor_and_preserves_task_context() -> "None":
     @task("tasks.sync_context")
-    def sync_context(*, _job_id: "str") -> "dict[str, str | None]":
+    def sync_context(*, _task_context: "TaskExecutionContext") -> "dict[str, str | None]":
         context = get_current_task_context()
         assert context is not None
-        return {"job_id": _job_id, "context_task_id": context.task_id, "thread_name": threading.current_thread().name}
+        return {
+            "injected_task_id": _task_context.task_id,
+            "context_task_id": context.task_id,
+            "thread_name": threading.current_thread().name,
+        }
 
     async with QueueService(
         QueueConfig(execution_backend="immediate", sync_executor_max_workers=1, sync_executor_thread_name_prefix="lq")
@@ -677,7 +682,7 @@ async def test_sync_task_uses_configured_executor_and_preserves_task_context() -
         result = await service.enqueue(sync_context)
 
     assert isinstance(result.result, dict)
-    assert result.result["job_id"] == result.result["context_task_id"]
+    assert result.result["injected_task_id"] == result.result["context_task_id"]
     assert str(result.result["thread_name"]).startswith("lq")
 
 

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -22,6 +22,7 @@ from litestar_queues import (
 )
 from litestar_queues.backends import InMemoryQueueBackend
 from litestar_queues.events import EventConfig, InMemoryQueueEventSink
+from litestar_queues.models import QueueBackendCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -152,6 +153,24 @@ async def test_worker_claims_local_records_through_claim_next() -> "None":
     assert backend.claim_next_calls == [(None, "local"), (None, "local")]
     assert backend.list_pending_calls == []
     assert backend.claim_task_calls == []
+
+
+async def test_worker_uses_claim_many_when_backend_advertises_batch_claim() -> "None":
+    backend = _ClaimManyRecordingInMemoryQueueBackend()
+
+    @task("tasks.batch_claim")
+    async def batch_claim(value: "int") -> "int":
+        return value
+
+    async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
+        for value in range(5):
+            await service.enqueue(batch_claim, value)
+        worker = Worker(service, batch_size=10, max_concurrency=3)
+
+        assert await worker.run_once() == 3
+
+    assert backend.claim_many_calls == [(3, None, "local")]
+    assert backend.claim_next_calls == []
 
 
 async def test_worker_queue_filter_restricts_claimed_records() -> "None":
@@ -719,6 +738,31 @@ class _ClaimNextRecordingInMemoryQueueBackend(InMemoryQueueBackend):
     ) -> 'list["QueuedTaskRecord"]':
         self.list_pending_calls.append((limit, queue, execution_backend))
         return await super().list_pending(limit=limit, queue=queue, execution_backend=execution_backend)
+
+
+class _ClaimManyRecordingInMemoryQueueBackend(_ClaimNextRecordingInMemoryQueueBackend):
+    __slots__ = ("claim_many_calls",)
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.claim_many_calls: "list[tuple[int, str | None, str | None]]" = []
+
+    @property
+    def capabilities(self) -> "QueueBackendCapabilities":
+        return QueueBackendCapabilities(supports_batch_claim=True)
+
+    async def claim_many(
+        self, *, limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> 'list["QueuedTaskRecord"]':
+        self.claim_many_calls.append((limit, queue, execution_backend))
+        records: 'list["QueuedTaskRecord"]' = []
+        for pending in await InMemoryQueueBackend.list_pending(
+            self, limit=limit, queue=queue, execution_backend=execution_backend
+        ):
+            claimed = await InMemoryQueueBackend.claim_task(self, pending.id)
+            if claimed is not None:
+                records.append(claimed)
+        return records
 
 
 class _HeartbeatCleanupRecordingBackend(InMemoryQueueBackend):

--- a/tools/docs_audit.py
+++ b/tools/docs_audit.py
@@ -1,0 +1,271 @@
+"""Audit the documentation tree without modifying it."""
+
+import argparse
+import ast
+import builtins
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DOCS = ROOT / "docs"
+DEFAULT_README = ROOT / "README.md"
+HEADING_MARKS = '=-~^"`:+*#'
+CANONICAL_TERMS = ("queue backend", "execution backend", "worker wakeup", "task event", "event history")
+OLD_TRANSPORT_TERMS = ("listen_notify", "listen_notify_durable", "table_queue")
+OBSOLETE_HISTORY_TERMS = ("SQLiteQueueEventSink", "standalone SQLite", "queue-events.db")
+QUICKSTART_DUPLICATE_THRESHOLD = 4
+
+
+@dataclass(slots=True)
+class PageReport:
+    """Collected facts for one reStructuredText page."""
+
+    path: Path
+    words: int
+    headings: list[tuple[int, str]]
+    code_blocks: int
+    literalincludes: list[str]
+    generated_directives: int
+    tutorial_signals: int
+    toctree_entries: list[str]
+    undefined_names: set[str] = field(default_factory=set)
+    prompts: list[str] = field(default_factory=list)
+
+    GUIDE_WORD_BUDGET: ClassVar[int] = 1200
+
+    @property
+    def relative_path(self) -> str:
+        """Return the page path relative to the documentation root."""
+        return self.path.as_posix()
+
+
+def parse_page(path: Path, docs_root: Path) -> PageReport:
+    """Collect deterministic metrics and review prompts for one page.
+
+    Returns:
+        The collected page report.
+    """
+    source = path.read_text(encoding="utf-8")
+    headings = _headings(source)
+    python_blocks = _python_code_blocks(source)
+    includes = re.findall(r"^\.\. literalinclude::\s+(.+?)\s*$", source, flags=re.MULTILINE)
+    generated = len(re.findall(r"^\.\. auto(?:module|class|function|method)::", source, flags=re.MULTILINE))
+    tutorial_signals = len(re.findall(r"^\.\. (?:code-block|literalinclude)::", source, flags=re.MULTILINE))
+    report = PageReport(
+        path=path.relative_to(docs_root),
+        words=len(re.findall(r"\b[\w'-]+\b", _without_directives(source))),
+        headings=headings,
+        code_blocks=len(re.findall(r"^\.\. code-block::", source, flags=re.MULTILINE)),
+        literalincludes=includes,
+        generated_directives=generated,
+        tutorial_signals=tutorial_signals,
+        toctree_entries=_toctree_entries(source),
+    )
+    report.undefined_names.update(_undefined_names(python_blocks[0]) if python_blocks else ())
+    report.prompts.extend(_review_prompts(report))
+    return report
+
+
+def audit(docs_root: Path, readme: Path) -> int:
+    """Print the documentation audit and return a process exit status.
+
+    Returns:
+        One when structural errors exist, otherwise zero.
+    """
+    pages = [parse_page(path, docs_root) for path in sorted(docs_root.rglob("*.rst"))]
+    membership = _toctree_membership(pages)
+    errors: list[str] = []
+
+    print("Documentation source manifest")
+    print("path | words | headings | code | includes | toctree")
+    for page in pages:
+        member = "yes" if _docname(page.path) in membership or page.path == Path("index.rst") else "no"
+        print(
+            f"{page.relative_path} | {page.words} | {len(page.headings)} | "
+            f"{page.code_blocks} | {len(page.literalincludes)} | {member}"
+        )
+        if member == "no":
+            errors.append(f"page is not in a toctree: {page.relative_path}")
+        errors.extend(_literalinclude_errors(page, docs_root))
+
+    print("\nReview prompts")
+    prompts = [f"{page.relative_path}: {prompt}" for page in pages for prompt in page.prompts]
+    for prompt in prompts or ["none"]:
+        print(f"- {prompt}")
+
+    corpus = "\n".join((docs_root / page.path).read_text(encoding="utf-8") for page in pages)
+    print("\nVocabulary occurrences")
+    for term in CANONICAL_TERMS:
+        print(f"- {term}: {_occurrences(corpus, term)}")
+    for term in (*OLD_TRANSPORT_TERMS, *OBSOLETE_HISTORY_TERMS):
+        print(f"- obsolete {term}: {_occurrences(corpus, term)}")
+
+    print("\nQuickstart duplication")
+    print(f"- {_quickstart_duplication(readme, docs_root / 'getting_started' / 'quickstart.rst')}")
+
+    print("\nStructural errors")
+    for error in errors or ["none"]:
+        print(f"- {error}")
+    return 1 if errors else 0
+
+
+def _headings(source: str) -> list[tuple[int, str]]:
+    lines = source.splitlines()
+    headings: list[tuple[int, str]] = []
+    marks: list[str] = []
+    for index in range(len(lines) - 1):
+        title = lines[index].strip()
+        underline = lines[index + 1].strip()
+        if not title or len(underline) < len(title) or len(set(underline)) != 1 or underline[0] not in HEADING_MARKS:
+            continue
+        mark = underline[0]
+        if mark not in marks:
+            marks.append(mark)
+        headings.append((marks.index(mark) + 1, title))
+    return headings
+
+
+def _python_code_blocks(source: str) -> list[str]:
+    lines = source.splitlines()
+    blocks: list[str] = []
+    index = 0
+    while index < len(lines):
+        match = re.match(r"^\.\. code-block::\s+python\s*$", lines[index])
+        if match is None:
+            index += 1
+            continue
+        index += 1
+        while index < len(lines) and (not lines[index].strip() or lines[index].lstrip().startswith(":")):
+            index += 1
+        body: list[str] = []
+        while index < len(lines) and (not lines[index].strip() or lines[index].startswith("   ")):
+            body.append(lines[index][3:] if lines[index].startswith("   ") else "")
+            index += 1
+        blocks.append("\n".join(body).rstrip())
+    return blocks
+
+
+def _undefined_names(block: str) -> set[str]:
+    try:
+        tree = ast.parse(block)
+    except SyntaxError:
+        return {"<code block does not parse>"}
+    defined = set(dir(builtins))
+    loaded: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            defined.add(node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            defined.add(node.name)
+            defined.update(
+                argument.arg for argument in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
+            )
+        elif isinstance(node, ast.Import):
+            defined.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            defined.update(alias.asname or alias.name for alias in node.names)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            defined.add(node.id)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            loaded.add(node.id)
+    return loaded - defined
+
+
+def _review_prompts(report: PageReport) -> list[str]:
+    prompts: list[str] = []
+    if report.words > report.GUIDE_WORD_BUDGET and report.path.parts[0] != "reference":
+        prompts.append(f"review length ({report.words} words; guide threshold {report.GUIDE_WORD_BUDGET})")
+    previous = 0
+    for level, heading in report.headings:
+        if previous and level > previous + 1:
+            prompts.append(f"review heading hierarchy near {heading!r}")
+        previous = level
+        words = heading.split()
+        if len(words) > 1 and sum(word[:1].isupper() for word in words[1:]) > len(words[1:]) / 2:
+            prompts.append(f"review sentence case for heading {heading!r}")
+    if report.generated_directives and report.tutorial_signals:
+        prompts.append("page mixes generated API directives with tutorial code")
+    if report.undefined_names:
+        prompts.append(f"review primary Python block names: {', '.join(sorted(report.undefined_names))}")
+    return prompts
+
+
+def _toctree_entries(source: str) -> list[str]:
+    lines = source.splitlines()
+    entries: list[str] = []
+    index = 0
+    while index < len(lines):
+        if not re.match(r"^\.\. toctree::\s*$", lines[index]):
+            index += 1
+            continue
+        index += 1
+        while index < len(lines) and (not lines[index].strip() or lines[index].startswith("   :")):
+            index += 1
+        while index < len(lines) and lines[index].startswith("   "):
+            value = lines[index].strip()
+            if value and not value.startswith(":"):
+                entries.append(value)
+            index += 1
+    return entries
+
+
+def _toctree_membership(pages: list[PageReport]) -> set[str]:
+    membership: set[str] = set()
+    for page in pages:
+        parent = page.path.parent
+        for entry in page.toctree_entries:
+            if entry.startswith(("http://", "https://")):
+                continue
+            target = (parent / entry).with_suffix("")
+            membership.add(target.as_posix())
+    return membership
+
+
+def _literalinclude_errors(page: PageReport, docs_root: Path) -> list[str]:
+    source_dir = (docs_root / page.path).parent
+    return [
+        f"missing literalinclude from {page.relative_path}: {include}"
+        for include in page.literalincludes
+        if not (source_dir / include).resolve().is_file()
+    ]
+
+
+def _quickstart_duplication(readme: Path, quickstart: Path) -> str:
+    readme_source = readme.read_text(encoding="utf-8")
+    docs_source = quickstart.read_text(encoding="utf-8")
+    markers = ("QueuePlugin", "QueueService", "@task", "litestar run", "curl -X POST")
+    shared = [marker for marker in markers if marker in readme_source and marker in docs_source]
+    if len(shared) >= QUICKSTART_DUPLICATE_THRESHOLD:
+        return "README and docs share the canonical quickstart markers; review them together when either changes"
+    return "no likely competing quickstart detected"
+
+
+def _without_directives(source: str) -> str:
+    return re.sub(r"^\s*\.\..*$", "", source, flags=re.MULTILINE)
+
+
+def _docname(path: Path) -> str:
+    return path.with_suffix("").as_posix()
+
+
+def _occurrences(source: str, term: str) -> int:
+    return len(re.findall(re.escape(term), source, flags=re.IGNORECASE))
+
+
+def main() -> int:
+    """Run the command-line audit.
+
+    Returns:
+        The audit process exit status.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--docs", type=Path, default=DEFAULT_DOCS, help="Documentation source directory")
+    parser.add_argument("--readme", type=Path, default=DEFAULT_README, help="Project README path")
+    args = parser.parse_args()
+    return audit(args.docs.resolve(), args.readme.resolve())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add canonical SQLSpec notification transport names and separate event polling from worker waits.
- Add backend-native batch enqueue/claim and coalesced wakeups for memory, SQLSpec, Redis, Valkey, and SQLAlchemy backends.
- Add optional PostgreSQL LISTEN/NOTIFY hints for SQLAlchemy while retaining polling/reconciliation as the source of truth.
- Add bounded memory, SQLSpec, SQLAlchemy, Redis, and Valkey event-history support.
- Register SQLSpec queue migrations during Litestar app and CLI initialization without running migrations during backend startup.
- Align queue table configuration with `queue_table_name` and `event_log_table_name`, and use the upstream SQLAlchemy plugin for schema creation.
- Remove the `_job_id` task injection; `TaskExecutionContext.task_id` is now the sole injected execution identity. This is a breaking change.
- Simplify all ten realtime examples: in-process workers by default, fixed demo settings, task IDs from `TaskExecutionContext`, clear event messages, backend-delivery pulses, and safe repeated clicks.
- Overhaul the README, navigation, quickstart, backend/event/worker guides, examples gallery, contributor docs, and docs audit tooling.