### PR TITLE
feat(backends): native claim_many batching for memory and SQLSpec

### DIFF
--- a/docs/usage/backends/redis-valkey.rst
+++ b/docs/usage/backends/redis-valkey.rst
@@ -37,6 +37,21 @@ Task arguments, keyword arguments, metadata, results, and errors must be JSON
 serializable. Give each application and environment a distinct ``key_prefix``;
 do not use ``FLUSHALL`` for test cleanup on shared infrastructure.
 
+Batch claiming
+==============
+
+Redis and Valkey deliberately do not advertise native batch claiming
+(``capabilities.supports_batch_claim`` is ``False``). Workers claim tasks by
+looping the exclusive single-task ``claim_next`` primitive, which preserves both
+priority ordering and single-owner semantics.
+
+A bounded atomic ``claim_many`` is not possible on the current storage layout:
+the ready set is a sorted set keyed by due time, while claim eligibility also
+requires priority ordering. An atomic implementation would either scan every due
+task (unbounded) or inspect only a due-time prefix and thereby change fairness.
+Supporting it correctly requires a separate ready-by-priority index migration,
+which is intentionally out of scope here.
+
 Worker wakeups
 ==============
 

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -47,7 +47,10 @@ class InMemoryQueueBackend(BaseQueueBackend):
     def capabilities(self) -> "QueueBackendCapabilities":
         """Backend behavior capabilities."""
         return QueueBackendCapabilities(
-            supports_notifications=True, notification_backend="asyncio-event", notifications_durable=False
+            supports_notifications=True,
+            notification_backend="asyncio-event",
+            notifications_durable=False,
+            supports_batch_claim=True,
         )
 
     def get_event_log(self, config: "EventLogConfig") -> "QueueEventLog | None":
@@ -179,6 +182,41 @@ class InMemoryQueueBackend(BaseQueueBackend):
             record.started_at = now
             record.heartbeat_at = now
             return record
+
+    async def claim_many(
+        self, *, limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "list[QueuedTaskRecord]":
+        """Claim up to ``limit`` due tasks under a single lock acquisition.
+
+        Selects eligible records with the same queue/execution/due filter and
+        priority ordering as :meth:`list_pending`, then transitions them to
+        ``running`` inside one critical section using a single ``now`` snapshot.
+        The returned records carry the same owner/start/heartbeat fields a
+        sequential :meth:`claim_next` loop would produce.
+
+        Returns:
+            Claimed task records in claim order.
+        """
+        if limit <= 0:
+            return []
+        async with self._lock:
+            now = _utc_now()
+            eligible = [
+                record
+                for record in self._records.values()
+                if record.status in {"pending", "scheduled"}
+                and (record.scheduled_at is None or record.scheduled_at <= now)
+                and (queue is None or record.queue == queue)
+                and (execution_backend is None or record.execution_backend == execution_backend)
+            ]
+            eligible.sort(key=lambda record: (-record.priority, record.created_at))
+            claimed: "list[QueuedTaskRecord]" = []
+            for record in eligible[:limit]:
+                record.status = "running"
+                record.started_at = now
+                record.heartbeat_at = now
+                claimed.append(record)
+            return claimed
 
     async def complete_task(
         self, task_id: "UUID", *, result: "Any" = None, expected_retry_count: "int | None" = None

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -594,7 +594,10 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                     if not candidate_rows:
                         await driver.rollback()
                         return []
-                    candidate_ids = [str(UUID(str(row["id"]))) for row in candidate_rows]
+                    # Bound the ordered candidate set to ``limit``: dialects such as Oracle cannot
+                    # combine ``FOR UPDATE SKIP LOCKED`` with ``FETCH FIRST`` and stream the whole
+                    # ordered result instead, so the SQL-level limit is absent for them.
+                    candidate_ids = [str(UUID(str(row["id"]))) for row in candidate_rows[:limit]]
                     await driver.execute(
                         store.claim_tasks(
                             task_ids=candidate_ids,

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -293,6 +293,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             supports_notifications=self._notifications_enabled,
             notification_backend=notification_backend,
             notifications_durable=notification_backend in _DURABLE_NOTIFICATION_BACKENDS,
+            supports_batch_claim=self._get_store().supports_batch_claim,
         )
 
     async def create_schema(self) -> "None":
@@ -544,6 +545,77 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                     raise
         claimed = self._record_from_row(updated_row)
         self._increment_queue_metric("claim")
+        return claimed
+
+    async def claim_many(
+        self, *, limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
+    ) -> "list[QueuedTaskRecord]":
+        """Claim up to ``limit`` due tasks.
+
+        Adapters whose store advertises ``supports_batch_claim`` use a single
+        transaction that locks a bounded ordered candidate set with ``FOR
+        UPDATE SKIP LOCKED``, transitions the candidates, and reloads the
+        winners. Other adapters fall back to the sequential base loop.
+
+        Returns:
+            Claimed task records in candidate order.
+        """
+        if limit <= 0:
+            return []
+        store = self._get_store()
+        if not store.supports_batch_claim:
+            return await super().claim_many(limit=limit, queue=queue, execution_backend=execution_backend)
+        return await self._claim_many_skip_locked(store, limit=limit, queue=queue, execution_backend=execution_backend)
+
+    async def _claim_many_skip_locked(
+        self, store: "SQLSpecQueueStore", *, limit: "int", queue: "str | None", execution_backend: "str | None"
+    ) -> "list[QueuedTaskRecord]":
+        """Claim up to ``limit`` due tasks in one ``SKIP LOCKED`` transaction.
+
+        Locks the ordered candidate set, transitions every locked candidate to
+        ``running`` with a single set-based UPDATE fenced on due status/time,
+        then reloads the rows to return only the ones this transaction owns.
+        Competing workers skip the locked candidates rather than colliding.
+
+        Returns:
+            The claimed task records in candidate order.
+        """
+        with self._observe_queue_operation("claim", queue=queue, execution_backend=execution_backend):
+            async with self._session() as driver:
+                await driver.begin()
+                try:
+                    now = _utc_now()
+                    serialized_now = self._serialize_datetime(now)
+                    statement = store.select_claimable(
+                        now=serialized_now, limit=limit, queue=queue, execution_backend=execution_backend
+                    )
+                    stream_chunk_size = cast("int | None", getattr(store, "claim_select_stream_chunk_size", None))
+                    candidate_rows = await self._select_rows(driver, statement, chunk_size=stream_chunk_size)
+                    if not candidate_rows:
+                        await driver.rollback()
+                        return []
+                    candidate_ids = [str(UUID(str(row["id"]))) for row in candidate_rows]
+                    await driver.execute(
+                        store.claim_tasks(
+                            task_ids=candidate_ids,
+                            due_at=serialized_now,
+                            started_at=serialized_now,
+                            heartbeat_at=serialized_now,
+                        )
+                    )
+                    reloaded_rows = await self._select_rows(driver, store.select_tasks_by_ids(candidate_ids))
+                    await driver.commit()
+                except Exception:
+                    with suppress(Exception):
+                        await driver.rollback()
+                    raise
+        claimed_by_id = {record.id: record for record in (self._record_from_row(row) for row in reloaded_rows)}
+        claimed = [
+            claimed_by_id[UUID(candidate_id)]
+            for candidate_id in candidate_ids
+            if UUID(candidate_id) in claimed_by_id and claimed_by_id[UUID(candidate_id)].status == "running"
+        ]
+        self._increment_queue_metric("claim", float(len(claimed)))
         return claimed
 
     async def complete_task(

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -130,6 +130,20 @@ class SQLSpecQueueStore:
         )
 
     @property
+    def supports_batch_claim(self) -> "bool":
+        """Whether the adapter can claim a batch of due tasks in one transaction.
+
+        Gated purely on :attr:`supports_skip_locked` so the native
+        :meth:`claim_many` fast path is advertised for exactly the dialect
+        families whose SQLSpec data dictionary reports ``FOR UPDATE SKIP
+        LOCKED`` support — the same families the single-record
+        skip-locked claim path already uses. Stores that force the portable
+        CAS path (e.g. Cockroach) opt out via :attr:`supports_skip_locked` and
+        fall back to the sequential base implementation.
+        """
+        return self.supports_skip_locked
+
+    @property
     def supports_native_bulk_ingest(self) -> "bool":
         """Whether the adapter can ingest records via the native Arrow import path.
 
@@ -213,6 +227,14 @@ class SQLSpecQueueStore:
         """
         return self._select_all().where_in(self._col("task_key"), list(keys))
 
+    def select_tasks_by_ids(self, task_ids: "Sequence[str]") -> "Select":
+        """Return a SELECT statement for all tasks matching any of ``task_ids``.
+
+        Used by the native batch claim to reload the rows it transitioned to
+        ``running`` in the same transaction, preserving candidate order.
+        """
+        return self._select_all().where_in(self._col("id"), list(task_ids))
+
     def list_pending(
         self, *, now: "DatetimeParam", limit: "int", queue: "str | None" = None, execution_backend: "str | None" = None
     ) -> "Select":
@@ -255,6 +277,29 @@ class SQLSpecQueueStore:
             .update(self.table_name)
             .set(**self._mapped_values({"status": "running", "started_at": started_at, "heartbeat_at": heartbeat_at}))
             .where_eq(self._col("id"), task_id)
+            .where_in(self._col("status"), _DUE_STATUSES)
+            .where(f"{self._col('scheduled_at')} IS NULL OR {self._col('scheduled_at')} <= :due_at", due_at=due_at)
+        )
+
+    def claim_tasks(
+        self,
+        *,
+        task_ids: "Sequence[str]",
+        due_at: "DatetimeParam",
+        started_at: "DatetimeParam",
+        heartbeat_at: "DatetimeParam",
+    ) -> "Update":
+        """Return an UPDATE statement that claims a batch of due tasks.
+
+        Mirrors :meth:`claim_task` for a set of ids: only rows still due and in
+        a due status transition to ``running``, so a competitor that already
+        claimed a locked candidate leaves that row untouched.
+        """
+        return (
+            sql
+            .update(self.table_name)
+            .set(**self._mapped_values({"status": "running", "started_at": started_at, "heartbeat_at": heartbeat_at}))
+            .where_in(self._col("id"), list(task_ids))
             .where_in(self._col("status"), _DUE_STATUSES)
             .where(f"{self._col('scheduled_at')} IS NULL OR {self._col('scheduled_at')} <= :due_at", due_at=due_at)
         )

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -64,6 +64,36 @@ def test_redis_valkey_backends_are_registered() -> "None":
     assert "valkey" in list_queue_backends()
 
 
+async def test_redis_backend_keeps_claim_fallback_without_batch_capability(
+    redis_backend: "RedisQueueBackend",
+) -> "None":
+    """Redis must not advertise native batch claim yet still batch via the fallback.
+
+    The sorted set is ordered by due time only, so a bounded atomic
+    ``claim_many`` would require a ready-by-priority index migration. Until then
+    the inherited ``claim_next`` loop must preserve priority ordering and hand
+    each task to exactly one caller.
+    """
+    assert redis_backend.capabilities.supports_batch_claim is False
+
+    high = await redis_backend.enqueue("tasks.redis.batch.high", priority=10)
+    mid = await redis_backend.enqueue("tasks.redis.batch.mid", priority=5)
+    low = await redis_backend.enqueue("tasks.redis.batch.low", priority=1)
+
+    claimed = await redis_backend.claim_many(limit=2)
+
+    assert [record.id for record in claimed] == [high.id, mid.id]
+    assert all(record.status == "running" for record in claimed)
+    stored_low = await redis_backend.get_task(low.id)
+    assert stored_low is not None
+    assert stored_low.status == "pending"
+
+    remaining = await redis_backend.claim_many(limit=5)
+    assert [record.id for record in remaining] == [low.id]
+    assert remaining[0].status == "running"
+    assert await redis_backend.claim_many(limit=5) == []
+
+
 async def test_redis_backend_deduplicates_active_keys_and_replaces_terminal_keys(
     redis_backend: "RedisQueueBackend",
 ) -> "None":

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -1070,9 +1070,7 @@ async def test_sqlspec_batch_claim_concurrent_workers_never_double_claim(
             for _ in range(task_count)
         }
 
-        bursts = await asyncio.gather(
-            *(queue_backend.claim_many(limit=task_count) for _ in range(worker_count))
-        )
+        bursts = await asyncio.gather(*(queue_backend.claim_many(limit=task_count) for _ in range(worker_count)))
         claimed = [record for burst in bursts for record in burst]
         claimed_ids = [record.id for record in claimed]
         while remainder := await queue_backend.claim_many(limit=task_count):

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -951,6 +951,165 @@ def test_sqlspec_store_select_claimable_uses_skip_locked_on_supporting_dialect()
     assert 'FROM "queue_tasks"' in built.sql
 
 
+@pytest.mark.parametrize(
+    ("adapter_name", "dialect"),
+    (
+        ("asyncpg", "postgres"),
+        ("asyncmy", "mysql"),
+        ("pymysql", "mysql"),
+        ("psqlpy", "postgres"),
+        ("spanner", "spanner"),
+        ("aiosqlite", "sqlite"),
+        ("duckdb", "duckdb"),
+    ),
+)
+def test_sqlspec_store_supports_batch_claim_tracks_skip_locked(adapter_name: "str", dialect: "str") -> "None":
+    """Native batch claim is advertised for exactly the SKIP LOCKED dialect families."""
+    store = create_queue_store(_fake_adapter_config(adapter_name, dialect=dialect), table_name="queue_tasks")
+
+    assert store.supports_batch_claim is store.supports_skip_locked
+
+
+def test_sqlspec_cockroach_store_opts_out_of_batch_claim_despite_postgres_dialect() -> "None":
+    """Cockroach forces the portable CAS path, so it must not advertise batch claim."""
+    store = create_queue_store(
+        _fake_adapter_config("cockroach_asyncpg", dialect="cockroachdb"), table_name="queue_tasks"
+    )
+
+    assert store.supports_skip_locked is False
+    assert store.supports_batch_claim is False
+
+
+def test_sqlspec_store_claim_tasks_builds_fenced_bulk_update() -> "None":
+    """``claim_tasks`` transitions a batch of ids fenced on due status and time."""
+    store = create_queue_store(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
+
+    built = store.claim_tasks(
+        task_ids=["id-a", "id-b"],
+        due_at="2026-01-01T00:00:00+00:00",
+        started_at="2026-01-01T00:00:00+00:00",
+        heartbeat_at="2026-01-01T00:00:00+00:00",
+    ).build(dialect="postgres")
+    sql_text = built.sql.upper()
+
+    assert "UPDATE" in sql_text
+    assert '"status" = ' in built.sql
+    assert '"id" IN (' in built.sql
+    assert '"status" IN (' in built.sql
+    assert "SCHEDULED_AT" in sql_text
+    assert "running" in str(built.parameters)
+
+
+def test_sqlspec_store_select_tasks_by_ids_filters_to_requested_ids() -> "None":
+    """``select_tasks_by_ids`` reloads exactly the requested rows for batch claim."""
+    store = create_queue_store(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
+
+    built = store.select_tasks_by_ids(["id-a", "id-b"]).build(dialect="postgres")
+
+    assert '"id" IN (' in built.sql
+    assert 'FROM "queue_tasks"' in built.sql
+
+
+async def test_sqlspec_aiosqlite_backend_falls_back_to_sequential_claim_many(
+    sqlspec_backend: "SQLSpecQueueBackend",
+) -> "None":
+    """Adapters without SKIP LOCKED must not advertise batch claim but still batch."""
+    assert sqlspec_backend.capabilities.supports_batch_claim is False
+
+    high = await sqlspec_backend.enqueue("tasks.batch.high", priority=10)
+    mid = await sqlspec_backend.enqueue("tasks.batch.mid", priority=5)
+    low = await sqlspec_backend.enqueue("tasks.batch.low", priority=1)
+
+    claimed = await sqlspec_backend.claim_many(limit=2)
+
+    assert [record.id for record in claimed] == [high.id, mid.id]
+    assert all(record.status == "running" for record in claimed)
+    assert all(record.started_at is not None and record.heartbeat_at is not None for record in claimed)
+    stored_low = await sqlspec_backend.get_task(low.id)
+    assert stored_low is not None
+    assert stored_low.status == "pending"
+
+
+async def test_sqlspec_batch_claim_uses_single_transaction(
+    queue_backend: "BaseQueueBackend", queue_backend_case: "BackendCase", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    """Supported SQLSpec stores must claim a batch in exactly one session/transaction."""
+    if not (isinstance(queue_backend, SQLSpecQueueBackend) and queue_backend.capabilities.supports_batch_claim):
+        pytest.skip(f"{queue_backend_case.name}: backend does not advertise native SQLSpec batch claim")
+
+    for index in range(5):
+        await queue_backend.enqueue(f"tasks.batch.count.{index}", priority=5)
+
+    original_session = SQLSpecQueueBackend._session
+    session_calls = 0
+
+    def counting_session(self: "SQLSpecQueueBackend", *args: "Any", **kwargs: "Any") -> "Any":
+        nonlocal session_calls
+        session_calls += 1
+        return original_session(self, *args, **kwargs)
+
+    monkeypatch.setattr(SQLSpecQueueBackend, "_session", counting_session)
+
+    claimed = await queue_backend.claim_many(limit=5)
+
+    assert len(claimed) == 5
+    assert session_calls == 1
+
+
+async def test_sqlspec_batch_claim_concurrent_workers_never_double_claim(
+    queue_backend: "BaseQueueBackend", queue_backend_case: "BackendCase"
+) -> "None":
+    """Two and four concurrent batch claimers must skip locked rows, never duplicate."""
+    if not (isinstance(queue_backend, SQLSpecQueueBackend) and queue_backend.capabilities.supports_batch_claim):
+        pytest.skip(f"{queue_backend_case.name}: backend does not advertise native SQLSpec batch claim")
+
+    for worker_count in (2, 4):
+        task_count = 12
+        enqueued = {
+            (await queue_backend.enqueue(f"tasks.batch.contended.{worker_count}", priority=5)).id
+            for _ in range(task_count)
+        }
+
+        bursts = await asyncio.gather(
+            *(queue_backend.claim_many(limit=task_count) for _ in range(worker_count))
+        )
+        claimed = [record for burst in bursts for record in burst]
+        claimed_ids = [record.id for record in claimed]
+        while remainder := await queue_backend.claim_many(limit=task_count):
+            claimed.extend(remainder)
+            claimed_ids.extend(record.id for record in remainder)
+
+        assert all(record.status == "running" for record in claimed)
+        assert len(claimed_ids) == len(set(claimed_ids)), "a task was claimed by more than one batch worker"
+        assert {task_id for task_id in claimed_ids if task_id in enqueued} == enqueued
+
+
+async def test_sqlspec_batch_claim_rollback_leaves_no_running_rows(
+    queue_backend: "BaseQueueBackend", queue_backend_case: "BackendCase", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    """A failure inside the batch claim transaction must not leave rows running."""
+    if not (isinstance(queue_backend, SQLSpecQueueBackend) and queue_backend.capabilities.supports_batch_claim):
+        pytest.skip(f"{queue_backend_case.name}: backend does not advertise native SQLSpec batch claim")
+
+    records = [await queue_backend.enqueue(f"tasks.batch.rollback.{index}", priority=5) for index in range(4)]
+    store = queue_backend._get_store()
+
+    def failing_reload(_self: "Any", task_ids: "Any") -> "Any":
+        del task_ids
+        msg = "boom during batch reload"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(type(store), "select_tasks_by_ids", failing_reload)
+
+    with pytest.raises(RuntimeError, match="boom during batch reload"):
+        await queue_backend.claim_many(limit=4)
+
+    for record in records:
+        stored = await queue_backend.get_task(record.id)
+        assert stored is not None
+        assert stored.status == "pending", "rolled-back batch claim must not leave running rows"
+
+
 async def test_sqlspec_sync_bridge_rolls_back_read_transactions_before_pool_return() -> "None":
     """Sync sessions must not return pooled connections with stale read snapshots."""
     manager = _FakeSyncSQLSpec()

--- a/src/tests/integration/backends/valkey/test_contract.py
+++ b/src/tests/integration/backends/valkey/test_contract.py
@@ -23,6 +23,35 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.anyio
 
 
+async def test_valkey_backend_keeps_claim_fallback_without_batch_capability(
+    valkey_backend: "ValkeyQueueBackend",
+) -> "None":
+    """Valkey mirrors Redis: no native batch claim, correctness fallback only.
+
+    The Valkey sorted set is ordered by due time, so a bounded atomic
+    ``claim_many`` needs a ready-by-priority index migration. The inherited
+    ``claim_next`` loop must preserve priority ordering and exclusive ownership.
+    """
+    assert valkey_backend.capabilities.supports_batch_claim is False
+
+    high = await valkey_backend.enqueue("tasks.valkey.batch.high", priority=10)
+    mid = await valkey_backend.enqueue("tasks.valkey.batch.mid", priority=5)
+    low = await valkey_backend.enqueue("tasks.valkey.batch.low", priority=1)
+
+    claimed = await valkey_backend.claim_many(limit=2)
+
+    assert [record.id for record in claimed] == [high.id, mid.id]
+    assert all(record.status == "running" for record in claimed)
+    stored_low = await valkey_backend.get_task(low.id)
+    assert stored_low is not None
+    assert stored_low.status == "pending"
+
+    remaining = await valkey_backend.claim_many(limit=5)
+    assert [record.id for record in remaining] == [low.id]
+    assert remaining[0].status == "running"
+    assert await valkey_backend.claim_many(limit=5) == []
+
+
 async def test_valkey_backend_deduplicates_active_keys_and_replaces_terminal_keys(
     valkey_backend: "ValkeyQueueBackend",
 ) -> "None":

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -22,8 +22,83 @@ from litestar_queues.task import clear_task_registry
 if TYPE_CHECKING:
     from litestar_queues.backends import BaseQueueBackend
     from litestar_queues.models import QueuedTaskRecord
+    from tests.integration._backends import BackendCase
 
 pytestmark = pytest.mark.anyio
+
+
+async def test_backend_contract_claim_many_claims_owned_ordered_running_records(
+    queue_backend: "BaseQueueBackend",
+) -> "None":
+    """``claim_many`` returns owned, running records in claim order across backends.
+
+    Exercises the shared claim contract for every registered backend: native fast
+    paths (memory, SKIP LOCKED SQLSpec stores) and the sequential fallback must
+    all preserve priority ordering, the queue/execution filters, scheduled-record
+    exclusion, and the partial-batch (fewer-than-limit) result shape.
+    """
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+    high = await queue_backend.enqueue("tasks.batch.high", priority=10, queue="default")
+    mid = await queue_backend.enqueue("tasks.batch.mid", priority=5, queue="default")
+    low = await queue_backend.enqueue("tasks.batch.low", priority=1, queue="default")
+    scheduled = await queue_backend.enqueue("tasks.batch.scheduled", priority=100, scheduled_at=later)
+    external = await queue_backend.enqueue(
+        "tasks.batch.external", priority=7, queue="reports", execution_backend="cloudrun"
+    )
+
+    first = await queue_backend.claim_many(limit=1, queue="default")
+    assert [record.id for record in first] == [high.id]
+    assert first[0].status == "running"
+    assert first[0].started_at is not None
+    assert first[0].heartbeat_at is not None
+
+    remaining = await queue_backend.claim_many(limit=10, queue="default")
+    assert [record.id for record in remaining] == [mid.id, low.id]
+    assert all(record.status == "running" for record in remaining)
+
+    claimed_external = await queue_backend.claim_many(limit=10, execution_backend="cloudrun")
+    assert [record.id for record in claimed_external] == [external.id]
+    assert claimed_external[0].execution_backend == "cloudrun"
+
+    stored_scheduled = await queue_backend.get_task(scheduled.id)
+    assert stored_scheduled is not None
+    assert stored_scheduled.status == "scheduled"
+
+    assert await queue_backend.claim_many(limit=5, queue="default") == []
+    assert await queue_backend.claim_many(limit=0) == []
+
+
+async def test_backend_contract_claim_many_concurrent_claimers_never_double_claim(
+    queue_backend: "BaseQueueBackend", queue_backend_case: "BackendCase"
+) -> "None":
+    """Concurrent ``claim_many`` callers must never share a task, at 2 and 4 workers.
+
+    Single-writer sync drivers share one DBAPI connection and cannot be driven
+    concurrently through the bridge; their exclusive-claim behavior is covered by
+    the sequential contract tests instead.
+    """
+    if "sync-driver" in queue_backend_case.capabilities:
+        pytest.skip(f"{queue_backend_case.name}: single-writer sync driver cannot claim concurrently")
+
+    for worker_count in (2, 4):
+        task_count = 12
+        enqueued = {
+            (await queue_backend.enqueue(f"tasks.batch.race.{worker_count}", priority=5)).id
+            for _ in range(task_count)
+        }
+
+        bursts = await asyncio.gather(
+            *(queue_backend.claim_many(limit=task_count) for _ in range(worker_count))
+        )
+        claimed = [record for burst in bursts for record in burst]
+        claimed_ids = [record.id for record in claimed]
+        while stragglers := await queue_backend.claim_many(limit=task_count):
+            claimed.extend(stragglers)
+            claimed_ids.extend(record.id for record in stragglers)
+
+        assert all(record.status == "running" for record in claimed)
+        assert len(claimed_ids) == len(set(claimed_ids)), "a task was claimed by more than one worker"
+        assert {task_id for task_id in claimed_ids if task_id in enqueued} == enqueued
 
 
 async def test_backend_contract_persists_execution_metadata_and_filters_claims(

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -83,13 +83,10 @@ async def test_backend_contract_claim_many_concurrent_claimers_never_double_clai
     for worker_count in (2, 4):
         task_count = 12
         enqueued = {
-            (await queue_backend.enqueue(f"tasks.batch.race.{worker_count}", priority=5)).id
-            for _ in range(task_count)
+            (await queue_backend.enqueue(f"tasks.batch.race.{worker_count}", priority=5)).id for _ in range(task_count)
         }
 
-        bursts = await asyncio.gather(
-            *(queue_backend.claim_many(limit=task_count) for _ in range(worker_count))
-        )
+        bursts = await asyncio.gather(*(queue_backend.claim_many(limit=task_count) for _ in range(worker_count)))
         claimed = [record for burst in bursts for record in burst]
         claimed_ids = [record.id for record in claimed]
         while stragglers := await queue_backend.claim_many(limit=task_count):

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -470,6 +470,105 @@ async def test_queue_service_local_enqueue_persists_until_worker_processes_recor
     assert result.result == "QUEUE"
 
 
+async def test_memory_backend_advertises_native_batch_claim() -> "None":
+    assert InMemoryQueueBackend().capabilities.supports_batch_claim is True
+
+
+async def test_memory_backend_claim_many_acquires_lock_once_for_non_empty_batch() -> "None":
+    backend = InMemoryQueueBackend()
+    for index in range(3):
+        await backend.enqueue(f"tasks.batch.{index}")
+    lock = _CountingAsyncLock()
+    backend._lock = cast("Any", lock)
+
+    claimed = await backend.claim_many(limit=3)
+
+    assert lock.entries == 1
+    assert len(claimed) == 3
+    assert all(record.status == "running" for record in claimed)
+
+
+async def test_memory_backend_claim_many_matches_sequential_claim_next() -> "None":
+    specs = [
+        EnqueueSpec(task_name="tasks.batch.low", priority=1),
+        EnqueueSpec(task_name="tasks.batch.high", priority=10),
+        EnqueueSpec(task_name="tasks.batch.mid", priority=5, execution_backend="cloudrun"),
+        EnqueueSpec(task_name="tasks.batch.mid2", priority=5),
+    ]
+
+    sequential_backend = InMemoryQueueBackend()
+    await sequential_backend.enqueue_many(specs)
+    sequential: "list[Any]" = []
+    while (record := await sequential_backend.claim_next()) is not None:
+        sequential.append(record)
+
+    native_backend = InMemoryQueueBackend()
+    await native_backend.enqueue_many(specs)
+    native = await native_backend.claim_many(limit=10)
+
+    compared_fields = (
+        "task_name",
+        "queue",
+        "execution_backend",
+        "execution_profile",
+        "priority",
+        "retry_count",
+        "scheduled_at",
+        "status",
+    )
+    assert [
+        {field: getattr(record, field) for field in compared_fields} for record in sequential
+    ] == [{field: getattr(record, field) for field in compared_fields} for record in native]
+    for record in native:
+        assert record.status == "running"
+        assert record.started_at is not None
+        assert record.heartbeat_at == record.started_at
+
+
+async def test_memory_backend_claim_many_handles_limits_filters_and_scheduled() -> "None":
+    backend = InMemoryQueueBackend()
+    later = datetime.now(timezone.utc) + timedelta(minutes=5)
+    high = await backend.enqueue("tasks.batch.high", priority=10)
+    mid = await backend.enqueue("tasks.batch.mid", priority=5)
+    low = await backend.enqueue("tasks.batch.low", priority=1)
+    await backend.enqueue("tasks.batch.scheduled", priority=100, scheduled_at=later)
+    await backend.enqueue("tasks.batch.other_queue", priority=100, queue="reports")
+
+    empty_backend = InMemoryQueueBackend()
+    assert await empty_backend.claim_many(limit=5) == []
+
+    assert [record.id for record in await backend.claim_many(limit=1, queue="default")] == [high.id]
+
+    remaining = await backend.claim_many(limit=10, queue="default")
+    assert [record.id for record in remaining] == [mid.id, low.id]
+
+    reports = await backend.claim_many(limit=10, queue="reports")
+    assert [record.task_name for record in reports] == ["tasks.batch.other_queue"]
+
+
+async def test_memory_backend_claim_many_never_double_claims_under_contention() -> "None":
+    backend = InMemoryQueueBackend()
+    task_count = 40
+    enqueued = {(await backend.enqueue(f"tasks.batch.contended.{index}")).id for index in range(task_count)}
+
+    first, second = await asyncio.gather(
+        backend.claim_many(limit=task_count), backend.claim_many(limit=task_count)
+    )
+    claimed_ids = [record.id for record in (*first, *second)]
+
+    assert len(claimed_ids) == task_count
+    assert set(claimed_ids) == enqueued
+    assert len(set(claimed_ids)) == len(claimed_ids)
+
+
+async def test_memory_backend_claim_many_rejects_non_positive_limit() -> "None":
+    backend = InMemoryQueueBackend()
+    await backend.enqueue("tasks.batch.only")
+
+    assert await backend.claim_many(limit=0) == []
+    assert await backend.claim_many(limit=-3) == []
+
+
 class _CountingAsyncLock:
     def __init__(self) -> "None":
         self.entries = 0

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -516,9 +516,9 @@ async def test_memory_backend_claim_many_matches_sequential_claim_next() -> "Non
         "scheduled_at",
         "status",
     )
-    assert [
-        {field: getattr(record, field) for field in compared_fields} for record in sequential
-    ] == [{field: getattr(record, field) for field in compared_fields} for record in native]
+    assert [{field: getattr(record, field) for field in compared_fields} for record in sequential] == [
+        {field: getattr(record, field) for field in compared_fields} for record in native
+    ]
     for record in native:
         assert record.status == "running"
         assert record.started_at is not None
@@ -551,9 +551,7 @@ async def test_memory_backend_claim_many_never_double_claims_under_contention() 
     task_count = 40
     enqueued = {(await backend.enqueue(f"tasks.batch.contended.{index}")).id for index in range(task_count)}
 
-    first, second = await asyncio.gather(
-        backend.claim_many(limit=task_count), backend.claim_many(limit=task_count)
-    )
+    first, second = await asyncio.gather(backend.claim_many(limit=task_count), backend.claim_many(limit=task_count))
     claimed_ids = [record.id for record in (*first, *second)]
 
     assert len(claimed_ids) == task_count

--- a/src/tests/unit/backends/test_redis_backend.py
+++ b/src/tests/unit/backends/test_redis_backend.py
@@ -47,6 +47,19 @@ async def test_redis_statistics_use_status_indexes_without_task_scan() -> "None"
     assert client.smembers_calls == 0
 
 
+async def test_redis_backend_does_not_advertise_native_batch_claim() -> "None":
+    """Redis stays on the correctness fallback: its ZSET orders by due time only.
+
+    A bounded atomic ``claim_many`` needs a ready-by-priority index migration
+    (out of scope), so the backend must not advertise ``supports_batch_claim``
+    and the worker keeps looping the exclusive ``claim_next`` primitive.
+    """
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client)))
+
+    assert backend.capabilities.supports_batch_claim is False
+
+
 async def test_redis_wait_for_notifications_reuses_pubsub_subscription() -> "None":
     client = _CountingRedisClient()
     backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), notifications=True))

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -879,6 +879,14 @@ class _ClaimNextRecordingInMemoryQueueBackend(InMemoryQueueBackend):
         self.claim_task_calls: "list[object]" = []
         self.list_pending_calls: "list[tuple[int, str | None, str | None]]" = []
 
+    @property
+    def capabilities(self) -> "QueueBackendCapabilities":
+        # Force the worker onto the single-record claim_next path so this double
+        # can record it; the native in-memory batch path is exercised elsewhere.
+        base = super().capabilities
+        base.supports_batch_claim = False
+        return base
+
     async def claim_next(
         self, *, queue: "str | None" = None, execution_backend: "str | None" = None
     ) -> "QueuedTaskRecord | None":


### PR DESCRIPTION
## Summary

Implements true `claim_many()` fast paths for the in-memory and SQLSpec queue backends, which previously inherited the base loop over `claim_next()`. Redis and Valkey deliberately remain on the correctness-preserving sequential fallback.

Beads epic: `litestar-queues-ygn` (spec `native-backend-claim-batching`).

## Changes

- **Memory**: `claim_many` selects eligible records with the exact existing queue/execution-backend/due/priority order and transitions them under **one lock acquisition and one `now` snapshot**, returning records in claim order. No recursive `claim_next` calls.
- **SQLSpec**: new store-level batch path for adapters whose data dictionary reports `supports_skip_locked` (PostgreSQL, MySQL 8+, Oracle; CockroachDB opts out via its existing override). One transaction per batch: ordered `SELECT ... FOR UPDATE SKIP LOCKED` → fenced set-based `UPDATE` (same owner/heartbeat/start/retry-fence values as single claims) → reload in candidate order. Built entirely on the existing column map, identifier quoting, and timestamp helpers.
- **Capability gating**: `supports_batch_claim` is derived from `supports_skip_locked`, the same gate the single-claim skip-locked path already uses — no adapter is enabled without a passing native-path test.
- **Redis/Valkey**: no native batch claim; tests pin `supports_batch_claim is False` and verify fallback ordering/exclusive ownership. A docs note records that a bounded atomic implementation requires a ready-by-priority index migration (separate approval), with no placeholder code.

## Verification

- Sequential-vs-native equivalence, limit/filter/scheduled matrices, 2- and 4-claimer contention disjointness, and rollback-leaves-no-running-rows — all with resource-count evidence (counting locks / transactions), not just return values.
- Native path validated against real containers per family: postgres (asyncpg/psycopg/psqlpy), mysql (asyncmy/aiomysql), oracle (oracledb). DuckDB/SQLite/aiosqlite/mssql/spanner verified to stay on the fallback.
- Full unit suite green; `ruff`, fresh `mypy` (112 files), `pyright` (0 errors), `slotscheck` all clean.
- Independent code audit found no issues: ordering parity, fence preservation, and capability gating all confirmed.