### PR TITLE
feat(backends): persist backend-native notification waits across worker intervals

### DIFF
--- a/src/litestar_queues/backends/_notification_wait.py
+++ b/src/litestar_queues/backends/_notification_wait.py
@@ -1,0 +1,67 @@
+"""Backend-native notification read ownership shared across queue backends.
+
+A native backend (memory event, Redis/Valkey pub/sub, SQLSpec event stream,
+Advanced Alchemy asyncpg listener) owns at most one in-flight notification
+read. An ordinary worker poll timeout must retain that read so the next wait
+resumes the same subscription instead of re-establishing driver resources.
+Only backend close or worker shutdown cancels and awaits the pending read.
+
+This helper carries no driver, decoding, or durability policy: it only owns
+the single-task race/retain/cancel lifecycle that every native backend shares.
+"""
+
+import asyncio
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+__all__ = ("PendingNativeRead",)
+
+
+class PendingNativeRead:
+    """Owns at most one in-flight backend-native notification read."""
+
+    __slots__ = ("_task",)
+
+    def __init__(self) -> "None":
+        self._task: "asyncio.Task[Any] | None" = None
+
+    @property
+    def has_pending(self) -> "bool":
+        """Whether a native read is currently retained."""
+        return self._task is not None
+
+    async def race(
+        self, factory: "Callable[[], Awaitable[Any]]", timeout: "float | None"
+    ) -> "asyncio.Task[Any] | None":
+        """Race the retained read against ``timeout``.
+
+        A new read is created via ``factory`` only when none is retained;
+        otherwise the existing read is reused. A timeout leaves the read
+        pending for the next call.
+
+        Returns:
+            The completed read task, which the caller must consume via
+            ``result()``/``exception()``, or ``None`` when the timeout
+            expired with the read still pending.
+        """
+        task = self._task
+        if task is None:
+            task = asyncio.ensure_future(factory())
+            self._task = task
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+        if task not in done:
+            return None
+        self._task = None
+        return task
+
+    async def aclose(self) -> "None":
+        """Cancel and await the retained read, leaving no task behind."""
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError as SQLAlchemyIntegrityError
 
+from litestar_queues.backends._notification_wait import PendingNativeRead
 from litestar_queues.backends.advanced_alchemy.config import SQLAlchemyBackendConfig
 from litestar_queues.backends.advanced_alchemy.event_log import AdvancedAlchemyQueueEventLog
 from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
@@ -559,13 +560,14 @@ class SQLAlchemyBackend(BaseQueueBackend):
 class _AsyncpgNotificationListener:
     """Dedicated asyncpg LISTEN connection for Advanced Alchemy wakeups."""
 
-    __slots__ = ("_channel", "_connection", "_dsn", "_event")
+    __slots__ = ("_channel", "_connection", "_dsn", "_event", "_pending_read")
 
     def __init__(self, *, dsn: "str", channel: "str") -> "None":
         self._dsn = dsn
         self._channel = channel
         self._event = asyncio.Event()
         self._connection: "Any | None" = None
+        self._pending_read = PendingNativeRead()
 
     async def start(self) -> "None":
         connection = self._connection
@@ -578,17 +580,18 @@ class _AsyncpgNotificationListener:
 
     async def wait(self, timeout: "float | None") -> "bool":
         await self.start()
-        if self._event.is_set():
+        if not self._pending_read.has_pending and self._event.is_set():
             self._event.clear()
             return True
-        try:
-            await asyncio.wait_for(self._event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
+        task = await self._pending_read.race(self._event.wait, timeout)
+        if task is None:
             return False
+        task.result()
         self._event.clear()
         return True
 
     async def close(self) -> "None":
+        await self._pending_read.aclose()
         connection = self._connection
         self._connection = None
         if connection is None:

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
+from litestar_queues.backends._notification_wait import PendingNativeRead
 from litestar_queues.backends.base import (
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
@@ -31,7 +32,7 @@ __all__ = ("InMemoryQueueBackend",)
 class InMemoryQueueBackend(BaseQueueBackend):
     """In-process queue backend for tests, local development, and examples."""
 
-    __slots__ = ("_event_log", "_keys", "_lock", "_notification_event", "_records")
+    __slots__ = ("_event_log", "_keys", "_lock", "_notification_event", "_pending_read", "_records")
 
     def __init__(self, config: "QueueConfig | None" = None) -> "None":
         super().__init__(config=config)
@@ -39,6 +40,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
         self._keys: "dict[str, UUID]" = {}
         self._lock = asyncio.Lock()
         self._notification_event = asyncio.Event()
+        self._pending_read = PendingNativeRead()
         self._event_log: "QueueEventLog | None" = None
 
     @property
@@ -389,15 +391,19 @@ class InMemoryQueueBackend(BaseQueueBackend):
             self._notification_event.set()
 
     async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
-        if self._notification_event.is_set():
+        if not self._pending_read.has_pending and self._notification_event.is_set():
             self._notification_event.clear()
             return True
-        try:
-            await asyncio.wait_for(self._notification_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
+        task = await self._pending_read.race(self._notification_event.wait, timeout)
+        if task is None:
             return False
+        task.result()
         self._notification_event.clear()
         return True
+
+    async def close(self) -> "None":
+        """Cancel any retained notification wait."""
+        await self._pending_read.aclose()
 
     async def clear(self) -> "None":
         """Clear all in-memory records."""
@@ -405,6 +411,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
             self._records.clear()
             self._keys.clear()
             self._notification_event.clear()
+        await self._pending_read.aclose()
         if self._event_log is not None:
             clear = getattr(self._event_log, "clear", None)
             if clear is not None:

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 from uuid import UUID, uuid4
 
+from litestar_queues.backends._notification_wait import PendingNativeRead
 from litestar_queues.backends.base import (
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
@@ -106,6 +107,7 @@ class RedisQueueBackend(BaseQueueBackend):
         "_notification_channel",
         "_notifications",
         "_owns_client",
+        "_pending_read",
         "_poll_interval",
         "_pubsub",
         "_url",
@@ -123,6 +125,7 @@ class RedisQueueBackend(BaseQueueBackend):
         self._notifications = backend_config.notifications
         self._notification_channel = backend_config.notification_channel
         self._pubsub: "RedisPubSubLike | None" = None
+        self._pending_read = PendingNativeRead()
         self._lock_timeout = backend_config.lock_timeout
         self._poll_interval = backend_config.poll_interval
         self._event_log: "RedisQueueEventLog | None" = None
@@ -151,6 +154,7 @@ class RedisQueueBackend(BaseQueueBackend):
         """Close owned Redis-protocol client resources."""
         if self._event_log is not None:
             await self._event_log.flush_events()
+        await self._pending_read.aclose()
         if self._pubsub is not None:
             await _close_pubsub(self._pubsub, self._notification_channel)
             self._pubsub = None
@@ -674,13 +678,31 @@ class RedisQueueBackend(BaseQueueBackend):
     async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
         """Wait for a Redis-protocol pub/sub message when notifications are enabled.
 
+        A single pub/sub receive is retained across worker poll timeouts; only
+        a real message, a read failure, or backend close ends it.
+
         Returns:
             True when a notification was observed.
         """
         if not self._notifications:
             return await super().wait_for_notifications(timeout=timeout)
         pubsub = await self._get_pubsub()
-        return await _wait_for_pubsub_message(pubsub, timeout=timeout)
+        task = await self._pending_read.race(lambda: _receive_pubsub_message(pubsub), timeout)
+        if task is None:
+            return False
+        exc = task.exception()
+        if exc is not None:
+            await self._reset_pubsub()
+            raise exc
+        return bool(task.result())
+
+    async def _reset_pubsub(self) -> "None":
+        """Drop the pub/sub subscription so the next wait re-establishes it."""
+        await self._pending_read.aclose()
+        pubsub = self._pubsub
+        self._pubsub = None
+        if pubsub is not None:
+            await _close_pubsub(pubsub, self._notification_channel)
 
     def _create_client(self, url: "str") -> "RedisClientLike":
         from redis import asyncio as redis_asyncio
@@ -1064,27 +1086,22 @@ def _coerce_status(value: "Any") -> "TaskStatus":
     return cast("TaskStatus", status)
 
 
-async def _wait_for_pubsub_message(pubsub: "RedisPubSubLike", *, timeout: "float | None") -> "bool":
-    """Drain pubsub responses until a real ``message`` arrives or timeout.
+async def _receive_pubsub_message(pubsub: "RedisPubSubLike") -> "bool":
+    """Block until a real published ``message`` arrives on the subscription.
 
-    ``pubsub.get_message(ignore_subscribe_messages=True)`` returns ``None``
-    for both "no message in this read window" AND "subscribe-confirmation
-    was filtered". Looping with a deadline distinguishes the two cases.
+    ``get_message(timeout=None)`` blocks indefinitely; subscribe/unsubscribe
+    confirmations are filtered to ``None`` by ``ignore_subscribe_messages``, so
+    they are skipped without ending the retained read. This coroutine carries
+    no deadline of its own — worker poll timeouts race it via
+    :class:`PendingNativeRead`, leaving it pending until a message lands.
 
     Returns:
-        True when a real published message was observed before the deadline.
+        True once a real published message is observed.
     """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout if timeout is not None else None
     while True:
-        remaining = None if deadline is None else max(0.0, deadline - loop.time())
-        if remaining is not None and remaining <= 0.0:
-            return False
-        message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=remaining)
+        message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=None)
         if message is not None:
             return True
-        if deadline is None:
-            return False
 
 
 async def _close_pubsub(pubsub: "RedisPubSubLike", channel: "str") -> "None":

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1,6 +1,5 @@
 """SQLSpec queue backend."""
 
-import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from datetime import datetime, timedelta, timezone
@@ -14,6 +13,7 @@ from sqlspec.exceptions import SerializationConflictError
 from sqlspec.extensions.events import normalize_event_channel_name, resolve_adapter_name
 from sqlspec.utils.sync_tools import async_
 
+from litestar_queues.backends._notification_wait import PendingNativeRead
 from litestar_queues.backends.base import (
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
@@ -175,6 +175,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         "_event_poll_interval",
         "_event_queue_table",
         "_event_settings",
+        "_event_stream",
         "_heartbeat_pool_config",
         "_heartbeat_pool_enabled",
         "_heartbeat_pool_registered",
@@ -188,6 +189,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         "_opened",
         "_owns_event_channel",
         "_owns_sqlspec",
+        "_pending_read",
         "_queue_observability",
         "_queue_table_name",
         "_sqlspec",
@@ -236,6 +238,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         self._event_log_store: "Any | None" = None
         self._event_log: "SQLSpecQueueEventLog | None" = None
         self._store: "SQLSpecQueueStore | None" = None
+        self._event_stream: "Any | None" = None
+        self._pending_read = PendingNativeRead()
         self._opened = False
 
     async def open(self) -> "bool":
@@ -258,6 +262,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         """Close SQLSpec resources."""
         if self._event_log is not None:
             await self._event_log.flush_events()
+        await self._close_notification_stream()
         await self._close_heartbeat_pool()
         if self._owns_event_channel and self._event_channel is not None:
             await self._event_channel.shutdown()
@@ -1039,27 +1044,41 @@ class SQLSpecQueueBackend(BaseQueueBackend):
     async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
         """Wait for a SQLSpec event when queue notifications are configured.
 
+        One ``iter_events`` stream and its pending ``anext`` read are retained
+        across worker poll timeouts; only an event, a driver failure, or
+        backend close ends them.
+
         Returns:
             True when a notification was received.
         """
         if not self._notifications_enabled or self._event_channel is None:
             return await super().wait_for_notifications(timeout=timeout)
 
-        stream = self._event_channel.iter_events(
-            self._resolve_notification_channel(), poll_interval=self._event_poll_interval
-        )
-        try:
-            if timeout is None:
-                event = await anext(stream)
-            else:
-                event = await asyncio.wait_for(anext(stream), timeout=timeout)
-        except asyncio.TimeoutError:
+        stream = self._event_stream
+        if stream is None:
+            stream = self._event_channel.iter_events(
+                self._resolve_notification_channel(), poll_interval=self._event_poll_interval
+            )
+            self._event_stream = stream
+        task = await self._pending_read.race(lambda: anext(cast("Any", stream)), timeout)
+        if task is None:
             return False
-        finally:
-            await cast("Any", stream).aclose()
-
+        exc = task.exception()
+        if exc is not None:
+            await self._close_notification_stream()
+            raise exc
+        event = task.result()
         await self._event_channel.ack(event.event_id)
         return True
+
+    async def _close_notification_stream(self) -> "None":
+        """Cancel the retained event read and close the iterator."""
+        await self._pending_read.aclose()
+        stream = self._event_stream
+        self._event_stream = None
+        if stream is not None:
+            with suppress(Exception):
+                await cast("Any", stream).aclose()
 
     @staticmethod
     def _default_sqlspec_config() -> "SQLSpecConfig":

--- a/src/litestar_queues/worker.py
+++ b/src/litestar_queues/worker.py
@@ -380,13 +380,27 @@ class Worker:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
         for task in done:
-            with contextlib.suppress(asyncio.TimeoutError):
-                task.result()
+            await self._consume_wait_task(task)
         self._service.observability_runtime.record_duration(
             "litestar_queues.worker.idle.duration",
             time.perf_counter() - started_at,
             attributes={**self._worker_metric_base_attributes(), "worker.wakeup": str(notification_task in done)},
         )
+
+    async def _consume_wait_task(self, task: "asyncio.Task[bool]") -> "None":
+        try:
+            task.result()
+        except asyncio.TimeoutError:
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # A native read failure must not kill the run loop; durable polling
+            # (run_once) still discovers work, and the next wait re-establishes
+            # the listener from a clean state.
+            self._record_counter("litestar_queues.worker.loop.error.count", {"worker.error.type": type(exc).__name__})
+            logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
+            await self._backoff_after_loop_error()
 
     async def _backoff_after_loop_error(self) -> "None":
         timeout = min(max(self._poll_interval, 0.01), 1.0)

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -412,6 +412,54 @@ async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_serv
         await backend.close()
 
 
+async def test_advanced_alchemy_postgres_notification_after_timeout_reuses_listener(
+    postgres_service: "PostgresService",
+) -> "None":
+    pytest.importorskip("asyncpg")
+    table_name = f"aa_notify_reuse_{uuid4().hex}"
+    model_class = _dynamic_queue_model(table_name)
+    sqlalchemy_config = SQLAlchemyAsyncConfig(
+        connection_string=(
+            f"postgresql+asyncpg://{postgres_service.user}:{postgres_service.password}"
+            f"@{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
+        )
+    )
+    await create_tables(sqlalchemy_config, model_class)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=sqlalchemy_config,
+            model_class=model_class,
+            notifications=True,
+            notification_channel=f"lq_reuse_{uuid4().hex}",
+        )
+    )
+    await backend.open()
+    try:
+        # A first empty wait establishes the LISTEN connection and retains its read.
+        assert await backend.wait_for_notifications(timeout=0.2) is False
+        listener = backend._notification_listener
+        assert listener is not None
+        connection = listener._connection
+        assert connection is not None
+        assert listener._pending_read.has_pending is True
+
+        # A concurrent waiter reuses the retained read; the enqueue's NOTIFY wakes it.
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=2.0))
+        await asyncio.sleep(0.1)
+        await backend.enqueue("tasks.pg.reuse")
+
+        assert await waiter is True
+        assert listener._connection is connection
+        assert bool(listener._pending_read.has_pending) is False
+        # Identity check last: ``is`` widens ``listener`` back to the attribute's type.
+        assert backend._notification_listener is listener
+    finally:
+        with suppress(Exception):
+            await _drop_dynamic_queue_model(backend, model_class)
+        await backend.close()
+        assert backend._notification_listener is None
+
+
 async def test_advanced_alchemy_backend_claims_due_tasks_by_priority(
     advanced_alchemy_backend: "SQLAlchemyBackend",
 ) -> "None":

--- a/src/tests/integration/backends/redis/test_notifications.py
+++ b/src/tests/integration/backends/redis/test_notifications.py
@@ -47,3 +47,33 @@ async def test_redis_backend_enqueue_many_publishes_one_batch_notification(
     assert await waiter is True
     assert len(records) == 5
     assert await redis_backend.wait_for_notifications(timeout=0.05) is False
+
+
+async def test_redis_backend_reuses_subscription_after_timeout(redis_backend: "RedisQueueBackend") -> "None":
+    assert await redis_backend.wait_for_notifications(timeout=0.1) is False
+    pubsub = redis_backend._pubsub
+    assert pubsub is not None
+    assert redis_backend._pending_read.has_pending is True
+
+    assert await redis_backend.wait_for_notifications(timeout=0.1) is False
+    # No re-subscription across empty poll timeouts.
+    assert redis_backend._pubsub is pubsub
+    assert redis_backend._pending_read.has_pending is True
+
+    await redis_backend.enqueue("tasks.reuse", execution_backend="local")
+
+    # The notification wakes the retained receive on the same subscription.
+    assert await redis_backend.wait_for_notifications(timeout=2.0) is True
+    assert redis_backend._pubsub is pubsub
+    assert bool(redis_backend._pending_read.has_pending) is False
+
+
+async def test_redis_backend_close_while_reading_leaves_no_task(redis_backend: "RedisQueueBackend") -> "None":
+    assert await redis_backend.wait_for_notifications(timeout=0.1) is False
+    assert redis_backend._pending_read.has_pending is True
+
+    await redis_backend.close()
+    assert bool(redis_backend._pending_read.has_pending) is False
+    assert redis_backend._pubsub is None
+    # Double close is idempotent.
+    await redis_backend.close()

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -67,6 +67,40 @@ class RecordingPollIntervalEventChannel(StubAsyncEventChannel):
             yield event
 
 
+class CountingIterEventsChannel(StubAsyncEventChannel):
+    """Stub channel that counts how many event iterators are created."""
+
+    __slots__ = ("iter_events_calls",)
+
+    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+        super().__init__(backend_name=backend_name)
+        self.iter_events_calls = 0
+
+    async def iter_events(self, channel: "str", *, poll_interval: "float | None" = None) -> "Any":
+        self.iter_events_calls += 1
+        async for event in super().iter_events(channel, poll_interval=poll_interval):
+            yield event
+
+
+class FailingIterEventsChannel(CountingIterEventsChannel):
+    """Stub channel whose first ``anext`` raises to model a driver read failure."""
+
+    __slots__ = ("fail_next",)
+
+    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+        super().__init__(backend_name=backend_name)
+        self.fail_next = True
+
+    async def iter_events(self, channel: "str", *, poll_interval: "float | None" = None) -> "Any":
+        self.iter_events_calls += 1
+        if self.fail_next:
+            self.fail_next = False
+            msg = "event stream boom"
+            raise RuntimeError(msg)
+        async for event in StubAsyncEventChannel.iter_events(self, channel, poll_interval=poll_interval):
+            yield event
+
+
 def _oracle_sync_config(
     oracle_service: "OracleService", *, user: "str | None" = None, password: "str | None" = None
 ) -> "Any":
@@ -279,6 +313,90 @@ async def test_sqlspec_backend_event_channel_notifications_wake_waiters(
             ("queue_notifications", {"event": "task_available"}, {"event_type": "litestar_queues.task_available"})
         ]
         assert event_channel.acked == ["event-1"]
+    finally:
+        await backend.close()
+
+
+async def test_sqlspec_backend_reuses_one_event_stream_across_timeouts(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    event_channel = CountingIterEventsChannel()
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlite_config_factory(tmp_path / "reuse.db"),
+            event_channel=cast("AsyncEventChannel", event_channel),
+            notification_channel="reuse",
+        )
+    )
+
+    await backend.open()
+    await backend.create_schema()
+    try:
+        assert await backend.wait_for_notifications(timeout=0.05) is False
+        assert await backend.wait_for_notifications(timeout=0.05) is False
+        assert await backend.wait_for_notifications(timeout=0.05) is False
+        assert event_channel.iter_events_calls == 1
+        assert backend._pending_read.has_pending is True
+
+        await backend.enqueue("tasks.reuse", queue="critical", execution_backend="local")
+
+        # A notification arriving after timeouts wakes the retained read without a new iterator.
+        assert await backend.wait_for_notifications(timeout=1) is True
+        assert event_channel.iter_events_calls == 1
+        assert event_channel.acked == ["event-1"]
+        assert bool(backend._pending_read.has_pending) is False
+    finally:
+        await backend.close()
+
+
+async def test_sqlspec_backend_close_while_reading_leaves_no_stream(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    event_channel = CountingIterEventsChannel()
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlite_config_factory(tmp_path / "close-reading.db"),
+            event_channel=cast("AsyncEventChannel", event_channel),
+            notification_channel="close_reading",
+        )
+    )
+
+    await backend.open()
+    await backend.create_schema()
+    assert await backend.wait_for_notifications(timeout=0.05) is False
+    assert backend._pending_read.has_pending is True
+
+    await backend.close()
+    assert bool(backend._pending_read.has_pending) is False
+    assert backend._event_stream is None
+    # Double close is idempotent.
+    await backend.close()
+
+
+async def test_sqlspec_backend_read_error_resets_stream_and_recovers(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    event_channel = FailingIterEventsChannel()
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlite_config_factory(tmp_path / "read-error.db"),
+            event_channel=cast("AsyncEventChannel", event_channel),
+            notification_channel="read_error",
+        )
+    )
+
+    await backend.open()
+    await backend.create_schema()
+    try:
+        with pytest.raises(RuntimeError, match="event stream boom"):
+            await backend.wait_for_notifications(timeout=1)
+        assert backend._event_stream is None
+        assert bool(backend._pending_read.has_pending) is False
+
+        # A bounded re-establishment builds a fresh stream that reconciles normally.
+        await backend.enqueue("tasks.recover", execution_backend="local")
+        assert await backend.wait_for_notifications(timeout=1) is True
+        assert event_channel.iter_events_calls == 2
     finally:
         await backend.close()
 

--- a/src/tests/integration/backends/valkey/test_notifications.py
+++ b/src/tests/integration/backends/valkey/test_notifications.py
@@ -46,3 +46,33 @@ async def test_valkey_backend_enqueue_many_publishes_one_batch_notification(
     assert await waiter is True
     assert len(records) == 5
     assert await valkey_backend.wait_for_notifications(timeout=0.05) is False
+
+
+async def test_valkey_backend_reuses_subscription_after_timeout(valkey_backend: "ValkeyQueueBackend") -> "None":
+    assert await valkey_backend.wait_for_notifications(timeout=0.1) is False
+    pubsub = valkey_backend._pubsub
+    assert pubsub is not None
+    assert valkey_backend._pending_read.has_pending is True
+
+    assert await valkey_backend.wait_for_notifications(timeout=0.1) is False
+    # No re-subscription across empty poll timeouts.
+    assert valkey_backend._pubsub is pubsub
+    assert valkey_backend._pending_read.has_pending is True
+
+    await valkey_backend.enqueue("tasks.reuse", execution_backend="local")
+
+    # The notification wakes the retained receive on the same subscription.
+    assert await valkey_backend.wait_for_notifications(timeout=2.0) is True
+    assert valkey_backend._pubsub is pubsub
+    assert bool(valkey_backend._pending_read.has_pending) is False
+
+
+async def test_valkey_backend_close_while_reading_leaves_no_task(valkey_backend: "ValkeyQueueBackend") -> "None":
+    assert await valkey_backend.wait_for_notifications(timeout=0.1) is False
+    assert valkey_backend._pending_read.has_pending is True
+
+    await valkey_backend.close()
+    assert bool(valkey_backend._pending_read.has_pending) is False
+    assert valkey_backend._pubsub is None
+    # Double close is idempotent.
+    await valkey_backend.close()

--- a/src/tests/unit/backends/test_advanced_alchemy_config.py
+++ b/src/tests/unit/backends/test_advanced_alchemy_config.py
@@ -1,9 +1,14 @@
 """Advanced Alchemy backend configuration tests."""
 
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
 pytest.importorskip("advanced_alchemy")
 pytest.importorskip("sqlalchemy")
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def test_advanced_alchemy_config_defaults_to_singular_queue_task_model() -> "None":
@@ -14,3 +19,65 @@ def test_advanced_alchemy_config_defaults_to_singular_queue_task_model() -> "Non
 
     assert config.model_class is QueueTaskModel
     assert QueueTaskModel.__tablename__ == "litestar_queue_task"
+
+
+class _FakeAsyncpgConnection:
+    """Minimal asyncpg connection double for listener lifecycle tests."""
+
+    __slots__ = ("added", "closed", "removed")
+
+    def __init__(self) -> "None":
+        self.added: "list[tuple[str, Callable[..., None]]]" = []
+        self.removed: "list[tuple[str, Callable[..., None]]]" = []
+        self.closed = False
+
+    def is_closed(self) -> "bool":
+        return self.closed
+
+    async def add_listener(self, channel: "str", callback: "Callable[..., None]") -> "None":
+        self.added.append((channel, callback))
+
+    async def remove_listener(self, channel: "str", callback: "Callable[..., None]") -> "None":
+        self.removed.append((channel, callback))
+
+    async def close(self) -> "None":
+        self.closed = True
+
+
+@pytest.mark.anyio
+async def test_asyncpg_listener_retains_one_read_across_timeouts() -> "None":
+    from litestar_queues.backends.advanced_alchemy.backend import _AsyncpgNotificationListener
+
+    connections: "list[_FakeAsyncpgConnection]" = []
+
+    class _FakeConnectListener(_AsyncpgNotificationListener):
+        async def _connect(self) -> "_FakeAsyncpgConnection":
+            connection = _FakeAsyncpgConnection()
+            connections.append(connection)
+            return connection
+
+    listener = _FakeConnectListener(dsn="postgresql://ignored/db", channel="lq")
+
+    assert await listener.wait(timeout=0.01) is False
+    assert await listener.wait(timeout=0.01) is False
+    assert _has_pending(listener) is True
+    # One connection, one LISTEN registration, one retained event read.
+    assert len(connections) == 1
+    assert len(connections[0].added) == 1
+
+    # A notification delivered between waits wakes the retained read exactly once.
+    listener._handle_notification(connections[0], 0, "lq", "tasks")
+    assert await listener.wait(timeout=0.01) is True
+    assert _has_pending(listener) is False
+    assert len(connections[0].added) == 1
+    assert await listener.wait(timeout=0.01) is False
+
+    await listener.close()
+    assert _has_pending(listener) is False
+    assert connections[0].closed is True
+    assert len(connections[0].removed) == 1
+
+
+def _has_pending(listener: "Any") -> "bool":
+    # Read through a function so mypy does not narrow the property to a literal.
+    return bool(listener._pending_read.has_pending)

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -402,6 +402,47 @@ async def test_memory_backend_null_heartbeats_is_fenced_by_retry_count() -> "Non
     assert stored.heartbeat_at == second_heartbeat
 
 
+async def test_memory_backend_repeated_timeouts_reuse_one_notification_read() -> "None":
+    backend = InMemoryQueueBackend()
+    event = _CountingEvent()
+    backend._notification_event = cast("Any", event)
+
+    assert await backend.wait_for_notifications(timeout=0.01) is False
+    assert await backend.wait_for_notifications(timeout=0.01) is False
+    assert await backend.wait_for_notifications(timeout=0.01) is False
+
+    assert event.waits == 1
+    assert backend._pending_read.has_pending is True
+    await backend.close()
+
+
+async def test_memory_backend_notification_after_timeout_is_consumed_once() -> "None":
+    backend = InMemoryQueueBackend()
+    event = _CountingEvent()
+    backend._notification_event = cast("Any", event)
+
+    assert await backend.wait_for_notifications(timeout=0.01) is False
+    await backend.enqueue("tasks.after_timeout")
+
+    assert await backend.wait_for_notifications(timeout=0.01) is True
+    assert event.waits == 1
+    assert backend._pending_read.has_pending is False
+    # The consumed wakeup must not linger for a second waiter.
+    assert await backend.wait_for_notifications(timeout=0.01) is False
+    assert event.waits == 2
+    await backend.close()
+
+
+async def test_memory_backend_close_cancels_retained_notification_read() -> "None":
+    backend = InMemoryQueueBackend()
+
+    assert await backend.wait_for_notifications(timeout=0.01) is False
+    assert backend._pending_read.has_pending is True
+
+    await backend.close()
+    assert backend._pending_read.has_pending is False
+
+
 async def test_queue_service_memory_fixture_yields_running_service(queue_service_memory: "QueueService") -> "None":
     """The unit-tier `queue_service_memory` fixture yields a running QueueService."""
     assert queue_service_memory.config.queue_backend == "memory"
@@ -444,6 +485,7 @@ class _CountingEvent:
     def __init__(self) -> "None":
         self.clears = 0
         self.sets = 0
+        self.waits = 0
         self._event = asyncio.Event()
 
     def is_set(self) -> "bool":
@@ -458,4 +500,5 @@ class _CountingEvent:
         self._event.clear()
 
     async def wait(self) -> "bool":
+        self.waits += 1
         return await self._event.wait()

--- a/src/tests/unit/backends/test_notification_wait.py
+++ b/src/tests/unit/backends/test_notification_wait.py
@@ -1,0 +1,111 @@
+"""Ownership invariants for the shared native-notification read helper."""
+
+import asyncio
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+import pytest
+
+from litestar_queues.backends._notification_wait import PendingNativeRead
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+pytestmark = pytest.mark.anyio
+
+
+def _has_pending(read: "PendingNativeRead") -> "bool":
+    # Read through a function so mypy does not narrow the property to a literal.
+    return read.has_pending
+
+
+def _event_read_factory(event: "asyncio.Event", reads: "list[int]") -> "Callable[[], Awaitable[bool]]":
+    def factory() -> "asyncio.Future[bool]":
+        reads[0] += 1
+        return asyncio.ensure_future(event.wait())
+
+    return factory
+
+
+async def test_repeated_timeouts_reuse_one_read() -> "None":
+    event = asyncio.Event()
+    reads = [0]
+    factory = _event_read_factory(event, reads)
+    pending = PendingNativeRead()
+
+    assert await pending.race(factory, timeout=0.01) is None
+    assert await pending.race(factory, timeout=0.01) is None
+    assert await pending.race(factory, timeout=0.01) is None
+    assert _has_pending(pending) is True
+    assert reads[0] == 1
+
+    event.set()
+    task = await pending.race(factory, timeout=0.01)
+    assert task is not None
+    assert task.result() is True
+    assert _has_pending(pending) is False
+    assert reads[0] == 1
+
+    await pending.aclose()
+
+
+async def test_completed_read_is_consumed_exactly_once() -> "None":
+    event = asyncio.Event()
+    reads = [0]
+    factory = _event_read_factory(event, reads)
+    pending = PendingNativeRead()
+
+    assert await pending.race(factory, timeout=0.01) is None
+    event.set()
+
+    first = await pending.race(factory, timeout=0.01)
+    assert first is not None
+    assert first.result() is True
+    assert reads[0] == 1
+
+    # The next wait must build a fresh read rather than re-consume the old one.
+    event.clear()
+    assert await pending.race(factory, timeout=0.01) is None
+    assert reads[0] == 2
+    await pending.aclose()
+
+
+async def test_aclose_cancels_and_awaits_retained_read() -> "None":
+    event = asyncio.Event()
+    reads = [0]
+    factory = _event_read_factory(event, reads)
+    pending = PendingNativeRead()
+
+    assert await pending.race(factory, timeout=0.01) is None
+    assert _has_pending(pending) is True
+
+    await pending.aclose()
+    assert _has_pending(pending) is False
+
+
+async def test_outer_cancellation_retains_the_native_read() -> "None":
+    event = asyncio.Event()
+    reads = [0]
+    factory = _event_read_factory(event, reads)
+    pending = PendingNativeRead()
+
+    async def waiter() -> "None":
+        await pending.race(factory, timeout=None)
+
+    task = asyncio.create_task(waiter())
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+    # Poll-boundary/shutdown cancellation of the caller must not destroy the read.
+    assert _has_pending(pending) is True
+    assert reads[0] == 1
+
+    event.set()
+    completed = await pending.race(factory, timeout=0.5)
+    assert completed is not None
+    assert completed.result() is True
+    # The retained read was reused rather than rebuilt.
+    assert reads[0] == 1
+    await pending.aclose()

--- a/src/tests/unit/backends/test_redis_backend.py
+++ b/src/tests/unit/backends/test_redis_backend.py
@@ -1,3 +1,4 @@
+import asyncio
 import builtins
 import json
 from contextlib import asynccontextmanager
@@ -56,8 +57,30 @@ async def test_redis_wait_for_notifications_reuses_pubsub_subscription() -> "Non
 
     assert client.pubsub_calls == 1
     assert client.pubsubs[0].subscribe_calls == 1
+    # Ten empty waits must not create ten receive reads on the subscription.
+    assert client.pubsubs[0].get_message_calls == 1
     assert client.pubsubs[0].unsubscribe_calls == 1
     assert client.pubsubs[0].close_calls == 1
+
+
+async def test_redis_wait_for_notifications_wakes_after_prior_timeout() -> "None":
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), notifications=True))
+
+    assert await backend.wait_for_notifications(timeout=0.001) is False
+    pubsub = client.pubsubs[0]
+    pubsub.deliver()
+
+    # The retained receive resumes on the same subscription without re-subscribing.
+    assert await backend.wait_for_notifications(timeout=1.0) is True
+    assert pubsub.subscribe_calls == 1
+    assert pubsub.get_message_calls == 1
+    assert backend._pending_read.has_pending is False
+
+    # The consumed message does not linger for the next waiter.
+    assert await backend.wait_for_notifications(timeout=0.001) is False
+    assert pubsub.get_message_calls == 2
+    await backend.close()
 
 
 async def test_redis_enqueue_many_persists_unkeyed_batch_with_one_pipeline_and_one_notification() -> "None":
@@ -437,6 +460,8 @@ class _CountingPubSub:
         self.close_calls = 0
         self.subscribe_calls = 0
         self.unsubscribe_calls = 0
+        self.get_message_calls = 0
+        self._message: "asyncio.Queue[object]" = asyncio.Queue()
 
     async def subscribe(self, channel: "str") -> "None":
         del channel
@@ -446,9 +471,19 @@ class _CountingPubSub:
         del channel
         self.unsubscribe_calls += 1
 
-    async def get_message(self, *, ignore_subscribe_messages: "bool", timeout: "float | None") -> "None":
-        del ignore_subscribe_messages, timeout
-        return None
+    async def get_message(self, *, ignore_subscribe_messages: "bool", timeout: "float | None") -> "object | None":
+        del ignore_subscribe_messages
+        self.get_message_calls += 1
+        # Model the real client: ``timeout=None`` blocks until a message lands.
+        if timeout is None:
+            return await self._message.get()
+        try:
+            return await asyncio.wait_for(self._message.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    def deliver(self) -> "None":
+        self._message.put_nowait({"type": "message", "data": "task_available"})
 
     async def aclose(self) -> "None":
         self.close_calls += 1

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -4,7 +4,7 @@ import os
 import threading
 from contextlib import suppress
 from datetime import timedelta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from litestar import Litestar
@@ -272,6 +272,93 @@ async def test_worker_start_wakes_from_backend_notifications() -> "None":
         with suppress(asyncio.CancelledError):
             await asyncio.wait_for(worker_task, timeout=1)
 
+    assert result.status == "completed"
+    assert result.result == 42
+
+
+async def test_worker_repeated_idle_polls_reuse_one_native_read() -> "None":
+    backend = InMemoryQueueBackend()
+    event = _CountingWaitEvent()
+    backend._notification_event = cast("Any", event)
+    async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
+        worker = Worker(service, poll_interval=0.001)
+
+        for _ in range(10):
+            await worker._wait_for_work()
+
+        assert event.waits == 1
+        assert backend._pending_read.has_pending is True
+
+
+async def test_worker_stop_interrupts_blocked_native_read_promptly() -> "None":
+    async with QueueService(QueueConfig(execution_backend="local")) as service:
+        backend = cast("InMemoryQueueBackend", service.get_queue_backend())
+        # Large intervals ensure a prompt stop cannot be attributed to a poll/reconcile tick.
+        worker = Worker(service, poll_interval=60, reconcile_interval=3600)
+        worker_task = asyncio.create_task(worker.start())
+        await asyncio.sleep(0.05)
+        assert backend._pending_read.has_pending is True
+
+        started = asyncio.get_running_loop().time()
+        await worker.stop()
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait_for(worker_task, timeout=1)
+        elapsed = asyncio.get_running_loop().time() - started
+
+    assert elapsed < 1.0
+    # Backend close (on service exit) cancels and awaits the retained read.
+    # ``bool(...)`` keeps mypy from narrowing the property across the earlier assertion.
+    assert bool(backend._pending_read.has_pending) is False
+
+
+async def test_worker_survives_native_read_failure_and_reconciles() -> "None":
+    @task("tasks.after_read_failure")
+    async def after_read_failure(value: "int") -> "int":
+        return value + 1
+
+    backend = _FailingReadInMemoryQueueBackend()
+    async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
+        worker = Worker(service, poll_interval=0.01)
+
+        with pytest.raises(RuntimeError):
+            await worker._wait_for_work()
+        assert backend.read_starts == 1
+        assert backend._pending_read.has_pending is False
+
+        # The durable claim scan still discovers work after a listener failure.
+        result = await service.enqueue(after_read_failure, 41)
+        assert await worker.run_once() == 1
+        await _wait_for_worker_tasks_done(worker)
+        await result.refresh()
+        assert result.status == "completed"
+
+        # The next wait re-establishes the native read from a clean listener state.
+        backend._notification_event.clear()
+        await worker._wait_for_work()
+        assert backend.read_starts == 2
+
+
+async def test_worker_processes_task_when_notification_is_dropped() -> "None":
+    @task("tasks.dropped_notification")
+    async def dropped_notification(value: "int") -> "int":
+        return value + 1
+
+    backend = _DroppedNotificationInMemoryQueueBackend()
+    async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
+        worker = Worker(service, poll_interval=0.01)
+        worker_task = asyncio.create_task(worker.start())
+        await asyncio.sleep(0)
+
+        result = await service.enqueue(dropped_notification, 41)
+        await result.wait(timeout=2, poll_interval=0.01)
+
+        await worker.stop()
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait_for(worker_task, timeout=1)
+
+    # The wakeup was attempted but never signalled the waiter; durable polling still ran.
+    assert backend.notify_calls >= 1
+    assert backend._notification_event.is_set() is False
     assert result.status == "completed"
     assert result.result == 42
 
@@ -712,6 +799,73 @@ async def _wait_for_worker_tasks_done(worker: "Worker", *, timeout: "float" = 1.
             return
         await asyncio.sleep(0.01)
     pytest.fail("worker tasks did not finish")
+
+
+class _CountingWaitEvent:
+    """Asyncio-event double that counts how many native reads are created."""
+
+    def __init__(self) -> "None":
+        self.waits = 0
+        self._event = asyncio.Event()
+
+    def is_set(self) -> "bool":
+        return self._event.is_set()
+
+    def set(self) -> "None":
+        self._event.set()
+
+    def clear(self) -> "None":
+        self._event.clear()
+
+    async def wait(self) -> "bool":
+        self.waits += 1
+        return await self._event.wait()
+
+
+class _FailingReadInMemoryQueueBackend(InMemoryQueueBackend):
+    """Memory backend whose first native read raises to model a listener failure."""
+
+    __slots__ = ("_fail_pending", "read_starts")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.read_starts = 0
+        self._fail_pending = True
+
+    async def _native_read(self) -> "bool":
+        self.read_starts += 1
+        if self._fail_pending:
+            self._fail_pending = False
+            msg = "listener boom"
+            raise RuntimeError(msg)
+        return await self._notification_event.wait()
+
+    async def wait_for_notifications(self, timeout: "float | None" = None) -> "bool":
+        if not self._pending_read.has_pending and self._notification_event.is_set():
+            self._notification_event.clear()
+            return True
+        task = await self._pending_read.race(self._native_read, timeout)
+        if task is None:
+            return False
+        exc = task.exception()
+        if exc is not None:
+            raise exc
+        task.result()
+        self._notification_event.clear()
+        return True
+
+
+class _DroppedNotificationInMemoryQueueBackend(InMemoryQueueBackend):
+    """Memory backend that never emits wakeups, forcing durable polling."""
+
+    __slots__ = ("notify_calls",)
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.notify_calls = 0
+
+    async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
+        self.notify_calls += 1
 
 
 class _ClaimNextRecordingInMemoryQueueBackend(InMemoryQueueBackend):

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -311,7 +311,7 @@ async def test_worker_stop_interrupts_blocked_native_read_promptly() -> "None":
     assert bool(backend._pending_read.has_pending) is False
 
 
-async def test_worker_survives_native_read_failure_and_reconciles() -> "None":
+async def test_worker_survives_native_read_failure_and_reconciles(caplog: "pytest.LogCaptureFixture") -> "None":
     @task("tasks.after_read_failure")
     async def after_read_failure(value: "int") -> "int":
         return value + 1
@@ -320,22 +320,24 @@ async def test_worker_survives_native_read_failure_and_reconciles() -> "None":
     async with QueueService(QueueConfig(execution_backend="local"), queue_backend=backend) as service:
         worker = Worker(service, poll_interval=0.01)
 
-        with pytest.raises(RuntimeError):
-            await worker._wait_for_work()
-        assert backend.read_starts == 1
-        assert backend._pending_read.has_pending is False
+        with caplog.at_level(logging.ERROR, logger="litestar_queues.worker"):
+            worker_task = asyncio.create_task(worker.start())
+            await asyncio.sleep(0)
 
-        # The durable claim scan still discovers work after a listener failure.
-        result = await service.enqueue(after_read_failure, 41)
-        assert await worker.run_once() == 1
-        await _wait_for_worker_tasks_done(worker)
-        await result.refresh()
-        assert result.status == "completed"
+            # The first native read raises a driver-style error; the run loop must
+            # survive it and keep discovering work via durable polling.
+            result = await service.enqueue(after_read_failure, 41)
+            await result.wait(timeout=2, poll_interval=0.01)
 
-        # The next wait re-establishes the native read from a clean listener state.
-        backend._notification_event.clear()
-        await worker._wait_for_work()
-        assert backend.read_starts == 2
+            await worker.stop()
+            with suppress(asyncio.CancelledError):
+                await asyncio.wait_for(worker_task, timeout=1)
+
+    assert result.status == "completed"
+    assert result.result == 42
+    assert backend.read_starts >= 1
+    assert worker.is_running is False
+    assert "Queue worker loop iteration failed" in caplog.text
 
 
 async def test_worker_processes_task_when_notification_is_dropped() -> "None":


### PR DESCRIPTION
## Summary

Keeps each backend-native notification wait alive across ordinary worker reconciliation intervals. Previously the worker created a wait task per loop, raced it with shutdown, and cancelled it; SQLSpec also created and closed an `iter_events()` iterator per call — repeatedly subscribing, allocating, and tearing down driver resources even when no job arrived.

Beads epic: `litestar-queues-px5` (spec `persistent-native-worker-waits`).

## Changes

- **New `PendingNativeRead` helper** (`backends/_notification_wait.py`): owns at most one in-flight native read; races the retained task against a timeout via `asyncio.wait` (never `asyncio.wait_for`, which would cancel generators/driver waits); `aclose()` cancels and awaits. Contains no driver or durability policy.
- **Memory**: retains one event wait; the event is cleared only after consumption (exactly-once).
- **Redis/Valkey**: retain one pub/sub receive on the existing subscription; a read failure resets pub/sub state and allows re-establishment on the next wait.
- **SQLSpec**: retains one `iter_events()` stream and one `anext()` read until an event, driver failure, or close; the pending read is cancelled and awaited *before* `aclose()` to avoid the "async generator already running" hazard.
- **Advanced Alchemy**: the asyncpg listener retains one event wait on its LISTEN connection (psycopg parity stays in its own flow).
- **Worker**: a native-read failure is now handled like any other loop error — counted, logged, backed off — instead of escaping the run loop; durable reconciliation still runs after every timeout, and a timeout means "reconcile now", not "destroy listener". Prompt shutdown via the stop-event race is unchanged; close is idempotent across before-setup/during-read/after-failure/double-close.

## Verification

- Resource-count evidence throughout: ten consecutive empty waits create one native read (spy-counted), wake-after-timeout without resubscription, consumed-exactly-once, dropped-notification durable discovery, and a close/error lifecycle matrix per backend.
- 376+ unit tests green; real-container integration runs: redis+valkey notifications (8) plus full suites (27), sqlspec notifications (35, incl. Postgres LISTEN/NOTIFY durable mode) and full suite (259), advanced_alchemy (75, incl. real asyncpg NOTIFY).
- `ruff`, fresh `mypy` (241 files), `pyright` (0 errors), `slotscheck` clean.
- Independent concurrency-focused audit verified single-read retention, strong task references, exactly-once consumption, and cancel/close ordering; its one major finding (a re-raised read error could kill the worker loop) is fixed in `f5cdfb6` with a regression test that drives the real `worker.start()` loop.