### PR TITLE
feat(sqlspec): cut over event transport contract

### DIFF
--- a/docs/usage/migration.rst
+++ b/docs/usage/migration.rst
@@ -31,3 +31,12 @@ When moving from memory to a persistent backend:
 
 See :doc:`backends` for the current support matrix and :doc:`event-history`
 for event-history ownership.
+
+SQLSpec event transport names
+=============================
+
+SQLSpec 0.55 removed the old ``listen_notify``, ``listen_notify_durable``, and
+``table_queue`` event transport names. Litestar Queues removes them in the same
+release rather than retaining aliases. Update configuration to ``notify``,
+``notify_queue``, or ``poll_queue`` respectively. Oracle ``aq`` and
+``txeventq`` names are unchanged.

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -3,7 +3,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from datetime import datetime, timedelta, timezone
-from inspect import isawaitable
+from inspect import isawaitable, iscoroutinefunction
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, cast, overload
 from uuid import UUID
@@ -69,32 +69,13 @@ _EVENT_EXTENSION_NAME = "events"
 _QUEUE_SETTING_EVENT_SETTINGS = ("event_settings", "events")
 
 _NOTIFY_TRANSPORT_POLLING = "polling"
-_CANONICAL_NOTIFY_TRANSPORTS = frozenset({"aq", "notify", "notify_queue", "poll_queue", "polling", "txeventq"})
-_LEGACY_NOTIFY_TRANSPORTS = frozenset({"listen_notify", "listen_notify_durable", "table_queue"})
-_SQLSPEC_EVENT_BACKENDS = {
-    "aq": "aq",
-    "notify": "notify",
-    "notify_queue": "notify_queue",
-    "poll_queue": "poll_queue",
-    "polling": "polling",
-    "txeventq": "txeventq",
-}
-_CANONICAL_EVENT_BACKENDS = {
-    "aq": "aq",
-    "listen_notify": "notify",
-    "listen_notify_durable": "notify_queue",
-    "notify": "notify",
-    "notify_queue": "notify_queue",
-    "poll_queue": "poll_queue",
-    "polling": "polling",
-    "table_queue": "poll_queue",
-    "txeventq": "txeventq",
-}
+_CANONICAL_EVENT_BACKENDS = frozenset({"aq", "notify", "notify_queue", "poll_queue", "txeventq"})
+_CANONICAL_NOTIFY_TRANSPORTS = _CANONICAL_EVENT_BACKENDS | {_NOTIFY_TRANSPORT_POLLING}
 # Adapter families that can push worker wakeups. Postgres-over-asyncpg ships the
-# durable LISTEN/NOTIFY hybrid; psycopg/psqlpy fall back to the durable table
-# queue until their LISTEN/NOTIFY path lands upstream. Everything else polls.
+# durable LISTEN/NOTIFY hybrid; psycopg/psqlpy and DuckDB use the durable table
+# queue. Everything else polls.
 _NOTIFY_DURABLE_ADAPTERS = frozenset({"asyncpg"})
-_NOTIFY_TABLE_QUEUE_ADAPTERS = frozenset({"psycopg", "psqlpy"})
+_NOTIFY_TABLE_QUEUE_ADAPTERS = frozenset({"duckdb", "psycopg", "psqlpy"})
 # psqlpy's ``QueryResult`` exposes no command-tag/status metadata and
 # arrow-odbc's cursor exposes no portable rowcount API, so SQLSpec's
 # rows-affected extraction can only ever report ``0`` for non-SELECT
@@ -125,8 +106,8 @@ def _adapter_notify_transport(adapter_name: "str | None") -> "str":
     advertise push wakeups where the driver can deliver them.
 
     Returns:
-        ``"notify_queue"`` for asyncpg, ``"poll_queue"`` for psycopg/psqlpy,
-        otherwise ``"polling"``.
+        ``"notify_queue"`` for asyncpg, ``"poll_queue"`` for DuckDB,
+        psycopg, and psqlpy, otherwise ``"polling"``.
     """
     if adapter_name in _NOTIFY_DURABLE_ADAPTERS:
         return "notify_queue"
@@ -136,23 +117,12 @@ def _adapter_notify_transport(adapter_name: "str | None") -> "str":
 
 
 def _canonical_notify_transport(backend_name: "str | None") -> "str | None":
-    """Map a SQLSpec event backend name to the queue transport vocabulary.
+    """Return a canonical SQLSpec event backend name.
 
     Returns:
-        The canonical queue transport name, if one can be resolved.
+        The canonical queue transport name, if the backend is supported.
     """
-    if backend_name is None:
-        return None
-    return _CANONICAL_EVENT_BACKENDS.get(backend_name, backend_name)
-
-
-def _sqlspec_event_backend(transport: "str") -> "str":
-    """Map a canonical queue transport to the SQLSpec Events backend name.
-
-    Returns:
-        The SQLSpec Events backend name.
-    """
-    return _SQLSPEC_EVENT_BACKENDS.get(transport, transport)
+    return backend_name if backend_name in _CANONICAL_EVENT_BACKENDS else None
 
 
 def _validate_queue_notify_transport(transport: "str") -> "str":
@@ -164,10 +134,7 @@ def _validate_queue_notify_transport(transport: "str") -> "str":
     if transport in _CANONICAL_NOTIFY_TRANSPORTS:
         return transport
     valid = ", ".join(sorted(_CANONICAL_NOTIFY_TRANSPORTS))
-    if transport in _LEGACY_NOTIFY_TRANSPORTS:
-        msg = f"Invalid notify_transport {transport!r}; use canonical queue transport names: {valid}."
-    else:
-        msg = f"Invalid notify_transport {transport!r}; expected one of: {valid}."
+    msg = f"Invalid notify_transport {transport!r}; expected one of: {valid}."
     raise QueueConfigurationError(msg)
 
 
@@ -274,7 +241,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         await self._close_notification_stream()
         await self._close_heartbeat_pool()
         if self._owns_event_channel and self._event_channel is not None:
-            await self._event_channel.shutdown()
+            await _invoke_event_channel_method(self._event_channel, "shutdown")
             self._event_channel = None
         if self._owns_sqlspec and self._sqlspec is not None:
             await self._sqlspec.close_all_pools()
@@ -1118,7 +1085,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             and record.is_due
         ):
             with self._observe_queue_operation("notify", queue=record.queue):
-                await self._event_channel.publish(
+                await _invoke_event_channel_method(
+                    self._event_channel,
+                    "publish",
                     self._resolve_notification_channel(),
                     {"event": "task_available"},
                     {"event_type": "litestar_queues.task_available"},
@@ -1144,7 +1113,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 self._resolve_notification_channel(), poll_interval=self._event_poll_interval
             )
             self._event_stream = stream
-        task = await self._pending_read.race(lambda: anext(cast("Any", stream)), timeout)
+        task = await self._pending_read.race(lambda: _next_event(stream), timeout)
         if task is None:
             return False
         exc = task.exception()
@@ -1152,7 +1121,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             await self._close_notification_stream()
             raise exc
         event = task.result()
-        await self._event_channel.ack(event.event_id)
+        await _invoke_event_channel_method(self._event_channel, "ack", event.event_id)
         return True
 
     async def _close_notification_stream(self) -> "None":
@@ -1162,7 +1131,11 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         self._event_stream = None
         if stream is not None:
             with suppress(Exception):
-                await cast("Any", stream).aclose()
+                close = getattr(stream, "aclose", None) or getattr(stream, "close", None)
+                if close is not None:
+                    result = close()
+                    if isawaitable(result):
+                        await result
 
     @staticmethod
     def _default_sqlspec_config() -> "SQLSpecConfig":
@@ -1244,7 +1217,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             self._event_backend or _setting(queue_settings, "event_backend") or events_settings.get("backend")
         )
         if configured_backend is not None:
-            return _canonical_notify_transport(str(configured_backend)) or _NOTIFY_TRANSPORT_POLLING
+            return _validate_queue_notify_transport(str(configured_backend))
         return _adapter_notify_transport(resolve_adapter_name(sqlspec_config))
 
     def _notifications_should_enable(
@@ -1305,7 +1278,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             if isinstance(configured_events, dict):
                 merged_event_settings.update(configured_events)
         merged_event_settings.update(self._event_settings)
-        merged_event_settings["backend"] = _sqlspec_event_backend(transport)
+        merged_event_settings["backend"] = transport
 
         configured_queue_table = self._event_queue_table or _setting(queue_settings, "event_queue_table")
         if configured_queue_table is not None:
@@ -1986,6 +1959,47 @@ def _events_extension_settings(sqlspec_config: "SQLSpecStoreConfig | None") -> "
         return {}
     extension_config = sqlspec_config.extension_config or {}
     return dict(extension_config.get(_EVENT_EXTENSION_NAME, {}) or {})
+
+
+async def _invoke_event_channel_method(event_channel: "Any", method_name: "str", *args: "Any") -> "Any":
+    """Invoke a SQLSpec sync or async event-channel method without blocking the loop.
+
+    Returns:
+        The event-channel method result.
+    """
+    method = getattr(event_channel, method_name)
+    if iscoroutinefunction(method):
+        return await method(*args)
+    result = await async_(method)(*args)
+    if isawaitable(result):
+        return await result
+    return result
+
+
+async def _next_event(stream: "Any") -> "Any":
+    """Read from a SQLSpec sync or async event iterator.
+
+    Returns:
+        The next event message.
+    """
+    if hasattr(stream, "__anext__"):
+        return await anext(stream)
+    has_event, event = await async_(_next_sync_event)(stream)
+    if not has_event:
+        raise StopAsyncIteration
+    return event
+
+
+def _next_sync_event(stream: "Iterator[Any]") -> "tuple[bool, Any]":
+    """Read one sync event without leaking ``StopIteration`` through a future.
+
+    Returns:
+        A pair indicating whether an event was read and the event value.
+    """
+    try:
+        return True, next(stream)
+    except StopIteration:
+        return False, None
 
 
 def _setting(queue_settings: "dict[str, Any]", *names: "str") -> "Any":

--- a/src/litestar_queues/events/_typing.py
+++ b/src/litestar_queues/events/_typing.py
@@ -19,16 +19,16 @@ class ChannelsPublishBackend(Protocol):
     def publish(self, data: bytes | str, channels: "Sequence[str]") -> object: ...
 
 
+class ChannelsPublishManyBackend(Protocol):
+    """Backend that publishes multiple channel payloads in one operation."""
+
+    async def publish_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None: ...
+
+
 class ChannelsWaitPublishedBackend(Protocol):
     """Channels plugin variant that waits until publication completes."""
 
     def wait_published(self, data: bytes | str, channels: "Sequence[str]") -> object: ...
-
-
-class ChannelsWaitPublishedManyBackend(Protocol):
-    """Channels plugin variant that waits until batch publication completes."""
-
-    def wait_published_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> object: ...
 
 
 class ChannelsSubscriptionBackend(Protocol):
@@ -50,5 +50,9 @@ class ChannelsStreamBackend(Protocol):
 
 
 ChannelsLike: TypeAlias = (
-    ChannelsPublishBackend | ChannelsWaitPublishedBackend | ChannelsSubscriptionBackend | ChannelsStreamBackend
+    ChannelsPublishBackend
+    | ChannelsPublishManyBackend
+    | ChannelsWaitPublishedBackend
+    | ChannelsSubscriptionBackend
+    | ChannelsStreamBackend
 )

--- a/src/litestar_queues/events/litestar.py
+++ b/src/litestar_queues/events/litestar.py
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
     from litestar_queues.typing import (
         ChannelsLike,
         ChannelsPublishBackend,
+        ChannelsPublishManyBackend,
         ChannelsStreamBackend,
         ChannelsSubscriptionBackend,
         ChannelsWaitPublishedBackend,
-        ChannelsWaitPublishedManyBackend,
     )
 
 __all__ = ("ChannelsQueueEventSink",)
@@ -71,11 +71,9 @@ class ChannelsQueueEventSink:
         return split_event_batch_by_size(event, max_bytes=self._max_payload_bytes, size_estimator=estimator)
 
     async def _publish_group(self, events: "Sequence[QueueEvent]", *, channels: "Sequence[str]") -> "None":
-        if hasattr(self._channels_backend, "wait_published_many"):
-            wait_backend = cast("ChannelsWaitPublishedManyBackend", self._channels_backend)
-            result = wait_backend.wait_published_many([event.to_json() for event in events], list(channels))
-            if inspect.isawaitable(result):
-                await result
+        if hasattr(self._channels_backend, "publish_many"):
+            batch_backend = cast("ChannelsPublishManyBackend", self._channels_backend)
+            await batch_backend.publish_many([event.to_json() for event in events], list(channels))
             return
         for event in events:
             await self._publish_one(event, channels=channels)

--- a/src/litestar_queues/events/sqlspec.py
+++ b/src/litestar_queues/events/sqlspec.py
@@ -1,5 +1,6 @@
 """SQLSpec event-channel sink for external queue event producers."""
 
+import asyncio
 import inspect
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, cast
@@ -17,7 +18,7 @@ _POLLING_TRANSPORT = "polling"
 
 
 class SQLSpecQueueEventSink:
-    """Publish queue events through a SQLSpec ``AsyncEventChannel``."""
+    """Publish queue events through a SQLSpec sync or async event channel."""
 
     __slots__ = (
         "_backend_config",
@@ -52,9 +53,7 @@ class SQLSpecQueueEventSink:
     async def close(self) -> "None":
         """Close only SQLSpec resources owned by this sink."""
         if self._owns_channel and self._channel is not None:
-            result = self._channel.shutdown()
-            if inspect.isawaitable(result):
-                await result
+            await _invoke_channel_method(self._channel, "shutdown")
             self._channel = None
         if self._owns_sqlspec and self._sqlspec is not None:
             result = self._sqlspec.close_all_pools()
@@ -69,14 +68,15 @@ class SQLSpecQueueEventSink:
                 await self._publish_one(event_chunk, channel=channel)
 
     async def publish_many(self, batch: "Sequence[tuple[QueueEvent, Sequence[str]]]") -> "None":
-        """Publish a producer batch without introducing a second event envelope."""
-        grouped: "dict[tuple[str, ...], list[QueueEvent]]" = {}
+        """Publish an ordered producer batch through one SQLSpec operation."""
+        events: "list[tuple[str, dict[str, Any], dict[str, object]]]" = []
         for event, channels in batch:
-            grouped.setdefault(tuple(channels), []).extend(self._event_chunks(event))
-        for channels, events in grouped.items():
-            for event in events:
-                for channel in channels:
-                    await self._publish_one(event, channel=channel)
+            for event_chunk in self._event_chunks(event):
+                payload = event_chunk.to_dict()
+                metadata = _metadata_for(event_chunk)
+                events.extend((channel, payload, metadata) for channel in channels)
+        if events:
+            await _invoke_channel_method(self._get_event_channel(), "publish_many", events)
 
     def _event_chunks(self, event: "QueueEvent") -> "Sequence[QueueEvent]":
         if self._max_payload_bytes is None:
@@ -88,7 +88,7 @@ class SQLSpecQueueEventSink:
 
     async def _publish_one(self, event: "QueueEvent", *, channel: "str") -> "None":
         event_channel = self._get_event_channel()
-        await event_channel.publish(channel, event.to_dict(), _metadata_for(event))
+        await _invoke_channel_method(event_channel, "publish", channel, event.to_dict(), _metadata_for(event))
 
     def _get_event_channel(self) -> "Any":
         if self._channel is None:
@@ -165,3 +165,18 @@ def _event_backend_name(backend_config: "object", event_settings: "dict[str, Any
 
 def _metadata_for(event: "QueueEvent") -> "dict[str, object]":
     return {"event_type": event.type, "queue_event_id": event.id, "queue_event_scope": event.scope}
+
+
+async def _invoke_channel_method(channel: "Any", method_name: "str", *args: "Any") -> "Any":
+    """Invoke a sync or async SQLSpec channel method without blocking the event loop.
+
+    Returns:
+        The event-channel method result.
+    """
+    method = getattr(channel, method_name)
+    if inspect.iscoroutinefunction(method):
+        return await method(*args)
+    result = await asyncio.to_thread(method, *args)
+    if inspect.isawaitable(result):
+        return await result
+    return result

--- a/src/litestar_queues/typing.py
+++ b/src/litestar_queues/typing.py
@@ -19,11 +19,11 @@ from litestar_queues._typing import (
 from litestar_queues.events._typing import (
     ChannelsLike,
     ChannelsPublishBackend,
+    ChannelsPublishManyBackend,
     ChannelsStreamBackend,
     ChannelsSubscriber,
     ChannelsSubscriptionBackend,
     ChannelsWaitPublishedBackend,
-    ChannelsWaitPublishedManyBackend,
 )
 
 __all__ = (
@@ -31,11 +31,11 @@ __all__ = (
     "PROMETHEUS_INSTALLED",
     "ChannelsLike",
     "ChannelsPublishBackend",
+    "ChannelsPublishManyBackend",
     "ChannelsStreamBackend",
     "ChannelsSubscriber",
     "ChannelsSubscriptionBackend",
     "ChannelsWaitPublishedBackend",
-    "ChannelsWaitPublishedManyBackend",
     "OtelMeter",
     "OtelSpan",
     "OtelSpanKind",

--- a/src/tests/integration/backends/sqlspec/conftest.py
+++ b/src/tests/integration/backends/sqlspec/conftest.py
@@ -85,7 +85,7 @@ class StubAsyncEventChannel:
 
     __slots__ = ("_backend_name", "_events", "acked", "published")
 
-    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+    def __init__(self, backend_name: "str" = "poll_queue") -> "None":
         self._backend_name = backend_name
         self.acked: "list[str]" = []
         self.published: "list[tuple[str, EventPayload, EventMetadata | None]]" = []

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -57,7 +57,7 @@ class RecordingPollIntervalEventChannel(StubAsyncEventChannel):
 
     __slots__ = ("poll_intervals",)
 
-    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+    def __init__(self, backend_name: "str" = "poll_queue") -> "None":
         super().__init__(backend_name=backend_name)
         self.poll_intervals: "list[float | None]" = []
 
@@ -72,7 +72,7 @@ class CountingIterEventsChannel(StubAsyncEventChannel):
 
     __slots__ = ("iter_events_calls",)
 
-    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+    def __init__(self, backend_name: "str" = "poll_queue") -> "None":
         super().__init__(backend_name=backend_name)
         self.iter_events_calls = 0
 
@@ -87,7 +87,7 @@ class FailingIterEventsChannel(CountingIterEventsChannel):
 
     __slots__ = ("fail_next",)
 
-    def __init__(self, backend_name: "str" = "table_queue") -> "None":
+    def __init__(self, backend_name: "str" = "poll_queue") -> "None":
         super().__init__(backend_name=backend_name)
         self.fail_next = True
 
@@ -453,7 +453,7 @@ async def test_sqlspec_backend_event_poll_interval_is_passed_to_event_channel(
 async def test_sqlspec_backend_derives_sqlspec_event_channel_from_config(tmp_path: "Path") -> "None":
     sqlspec_config = AiosqliteConfig(
         connection_config={"database": str(tmp_path / "derived-notifications.db")},
-        extension_config={"events": {"backend": "table_queue", "poll_interval": 0.01, "queue_table": "queue_events"}},
+        extension_config={"events": {"backend": "poll_queue", "poll_interval": 0.01, "queue_table": "queue_events"}},
     )
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(
@@ -542,7 +542,7 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
         ("cockroach_psycopg", "polling"),
         ("aiosqlite", "polling"),
         ("sqlite", "polling"),
-        ("duckdb", "polling"),
+        ("duckdb", "poll_queue"),
         ("asyncmy", "polling"),
         ("aiomysql", "polling"),
         ("pymysql", "polling"),
@@ -554,9 +554,8 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
 def test_adapter_notify_transport_capability_gate(adapter_name: "str | None", expected_transport: "str") -> "None":
     """The wakeup transport is gated by adapter knowledge.
 
-    Postgres-over-asyncpg gets ``notify_queue``; psycopg/psqlpy fall back to
-    ``poll_queue`` until their native NOTIFY path lands upstream; every other
-    family reports ``polling``.
+    Postgres-over-asyncpg gets ``notify_queue``; DuckDB, psycopg, and psqlpy
+    use ``poll_queue``; every other family reports ``polling``.
     """
     assert _adapter_notify_transport(adapter_name) == expected_transport
 
@@ -582,6 +581,28 @@ def test_queue_plugin_registers_sqlspec_migrations_for_cli() -> "None":
 def test_notify_transport_config_rejects_legacy_public_names(transport: "str") -> "None":
     with pytest.raises(QueueConfigurationError):
         SQLSpecBackendConfig(notify_transport=transport)
+
+
+@pytest.mark.parametrize("transport", ("listen_notify", "listen_notify_durable", "table_queue"))
+async def test_sqlspec_backend_rejects_legacy_extension_event_backend(transport: "str", tmp_path: "Path") -> "None":
+    sqlspec_config = AiosqliteConfig(
+        connection_config={"database": str(tmp_path / f"legacy-{transport}.db")},
+        extension_config={"events": {"backend": transport}},
+    )
+    backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config, notifications=True))
+
+    with pytest.raises(QueueConfigurationError, match="expected one of"):
+        await backend.open()
+
+
+@pytest.mark.parametrize("transport", ("aq", "notify", "notify_queue", "poll_queue", "txeventq"))
+def test_sqlspec_backend_forwards_canonical_extension_event_backend(transport: "str") -> "None":
+    sqlspec_config = AiosqliteConfig(
+        connection_config={"database": ":memory:"}, extension_config={"events": {"backend": transport}}
+    )
+    backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config, notifications=True))
+
+    assert backend._select_notify_transport(sqlspec_config, {}, {"backend": transport}) == transport
 
 
 @pytest.mark.parametrize("transport", ("aq", "txeventq"))
@@ -718,11 +739,41 @@ async def test_sqlspec_backend_notify_transport_override_enables_poll_queue(tmp_
         await backend.close()
 
 
+async def test_sqlspec_backend_duckdb_defaults_to_poll_queue(tmp_path: "Path") -> "None":
+    """DuckDB uses SQLSpec's durable table-backed event transport when requested."""
+    pytest.importorskip("duckdb")
+    from sqlspec.adapters.duckdb import DuckDBConfig
+
+    sqlspec_config = DuckDBConfig(connection_config={"database": str(tmp_path / "duckdb-poll-queue.db")})
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlspec_config,
+            notifications=True,
+            notification_channel="duckdb_poll_queue",
+            event_poll_interval=0.01,
+        )
+    )
+
+    await backend.open()
+    await backend.create_schema()
+    await run_queue_migrations(sqlspec_config)
+    try:
+        assert backend.capabilities.supports_notifications is True
+        assert backend.capabilities.notification_backend == "poll_queue"
+        assert backend.capabilities.notifications_durable is True
+
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=2))
+        await backend.enqueue("tasks.duckdb_poll_queue")
+        assert await waiter is True
+    finally:
+        await backend.close()
+
+
 async def test_sqlspec_backend_notify_transport_polling_overrides_extension_config(tmp_path: "Path") -> "None":
     """``queue_backend_config`` polling override beats an ``extension_config`` events default."""
     sqlspec_config = AiosqliteConfig(
         connection_config={"database": str(tmp_path / "override-polling.db")},
-        extension_config={"events": {"backend": "table_queue", "poll_interval": 0.01}},
+        extension_config={"events": {"backend": "poll_queue", "poll_interval": 0.01}},
     )
     backend = SQLSpecQueueBackend(
         backend_config=SQLSpecBackendConfig(config=sqlspec_config, notify_transport="polling")
@@ -737,7 +788,7 @@ async def test_sqlspec_backend_notify_transport_polling_overrides_extension_conf
         await backend.close()
 
 
-async def test_sqlspec_backend_postgres_listen_notify_durable_wakes(
+async def test_sqlspec_backend_postgres_notify_queue_wakes(
     postgres_service: "PostgresService", tmp_path: "Path"
 ) -> "None":
     """Postgres workers wake via NOTIFY with a durable fallback, no missed bursts."""
@@ -800,4 +851,71 @@ async def test_sqlspec_backend_postgres_listen_notify_durable_wakes(
                     'DROP TABLE IF EXISTS "ddl_migrations"',
                 ):
                     await driver.execute_script(ddl)
+            await backend.close()
+
+
+@pytest.mark.parametrize(("adapter_name", "expected_transport"), [("psycopg", "poll_queue"), ("psqlpy", "poll_queue")])
+async def test_sqlspec_backend_postgres_poll_queue_defaults_wake(
+    adapter_name: "str", expected_transport: "str", postgres_service: "PostgresService"
+) -> "None":
+    """PostgreSQL async adapters without native listeners use the canonical table queue."""
+    sqlspec_config: "Any"
+    if adapter_name == "psycopg":
+        pytest.importorskip("psycopg")
+        from sqlspec.adapters.psycopg import PsycopgAsyncConfig
+
+        sqlspec_config = PsycopgAsyncConfig(
+            connection_config={
+                "host": postgres_service.host,
+                "port": postgres_service.port,
+                "user": postgres_service.user,
+                "password": postgres_service.password,
+                "dbname": postgres_service.database,
+            }
+        )
+    else:
+        pytest.importorskip("psqlpy")
+        from sqlspec.adapters.psqlpy import PsqlpyConfig
+
+        sqlspec_config = PsqlpyConfig(
+            connection_config={
+                "host": postgres_service.host,
+                "port": postgres_service.port,
+                "username": postgres_service.user,
+                "password": postgres_service.password,
+                "db_name": postgres_service.database,
+            }
+        )
+
+    table_name = f"lq_notify_{adapter_name}"
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            config=sqlspec_config,
+            queue_table_name=table_name,
+            notifications=True,
+            notification_channel=f"lq_{adapter_name}_wake",
+            event_poll_interval=0.01,
+        )
+    )
+
+    await backend.open()
+    await backend.create_schema()
+    await run_queue_migrations(sqlspec_config, queue_table_name=table_name)
+    try:
+        assert backend.capabilities.notification_backend == expected_transport
+        assert backend.capabilities.notifications_durable is True
+
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=5))
+        await backend.enqueue(f"tasks.{adapter_name}_wake")
+        assert await waiter is True
+    finally:
+        from litestar_queues.backends.sqlspec.backend import _bridge_session
+
+        with suppress(Exception):
+            assert backend._sqlspec is not None
+            assert backend._sqlspec_config is not None
+            async with _bridge_session(
+                cast("SQLSpecManager", backend._sqlspec), cast("SQLSpecSessionConfig", backend._sqlspec_config)
+            ) as driver:
+                await driver.execute_script(f'DROP TABLE IF EXISTS "{table_name}"')
         await backend.close()

--- a/src/tests/integration/backends/sqlspec/test_observability.py
+++ b/src/tests/integration/backends/sqlspec/test_observability.py
@@ -189,7 +189,7 @@ class StubEventChannel:
     __slots__ = ("_backend_name", "published")
 
     def __init__(self) -> "None":
-        self._backend_name = "table_queue"
+        self._backend_name = "poll_queue"
         self.published: "list[tuple[str, dict[str, object], dict[str, object] | None]]" = []
 
     async def publish(

--- a/src/tests/unit/events/test_external_producer.py
+++ b/src/tests/unit/events/test_external_producer.py
@@ -4,6 +4,7 @@ import pytest
 
 from litestar_queues import EventConfig, QueueConfig
 from litestar_queues.events import EventBufferConfig, QueueChannels, QueueEvent
+from litestar_queues.events.sqlspec import SQLSpecQueueEventSink
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -96,6 +97,57 @@ async def test_factory_sqlspec_transport_drains_buffer_before_close() -> None:
         assert event_channel.published == []
 
     assert [payload["type"] for _, payload, _ in event_channel.published] == ["task.log", "task.progress"]
+    assert event_channel.publish_calls == 0
+    assert event_channel.publish_many_calls == 1
+
+
+async def test_sqlspec_sink_publish_many_flattens_ordered_events_into_one_call() -> None:
+    event_channel = _RecordingSqlSpecEventChannel()
+    sink = SQLSpecQueueEventSink(_SqlSpecBackendConfig(event_channel=event_channel))
+    first = QueueEvent(type="task.progress", scope="task", task_id="task-1")
+    second = QueueEvent(type="task.log", scope="task", task_id="task-2")
+
+    await sink.publish_many(((first, ("task-1", "global")), (second, ("task-2",))))
+
+    assert event_channel.publish_calls == 0
+    assert event_channel.publish_many_calls == 1
+    assert [(channel, payload["type"]) for channel, payload, _ in event_channel.published] == [
+        ("task-1", "task.progress"),
+        ("global", "task.progress"),
+        ("task-2", "task.log"),
+    ]
+
+
+async def test_sqlspec_sink_publish_many_supports_sync_event_channel() -> None:
+    event_channel = _RecordingSyncSqlSpecEventChannel()
+    sink = SQLSpecQueueEventSink(_SqlSpecBackendConfig(event_channel=event_channel))
+    event = QueueEvent(type="task.log", scope="task", task_id="task-1")
+
+    await sink.publish_many(((event, ("task-1",)),))
+
+    assert event_channel.publish_many_calls == 1
+    assert [(channel, payload["type"]) for channel, payload, _ in event_channel.published] == [("task-1", "task.log")]
+
+
+async def test_sqlspec_sink_publish_many_empty_batch_does_not_create_channel() -> None:
+    sqlspec = _RecordingSQLSpec()
+    sink = SQLSpecQueueEventSink(_SqlSpecBackendConfig(sqlspec=sqlspec, config=_RecordingSQLSpecConfig()))
+
+    await sink.publish_many(())
+
+    assert sqlspec.channel_calls == 0
+
+
+async def test_sqlspec_sink_publish_many_propagates_batch_failure() -> None:
+    event_channel = _FailingSqlSpecEventChannel()
+    sink = SQLSpecQueueEventSink(_SqlSpecBackendConfig(event_channel=event_channel))
+    event = QueueEvent(type="task.log", scope="task", task_id="task-1")
+
+    with pytest.raises(RuntimeError, match="batch publish failed"):
+        await sink.publish_many(((event, ("task-1",)),))
+
+    assert event_channel.publish_calls == 0
+    assert event_channel.publish_many_calls == 1
 
 
 async def test_factory_sqlspec_transport_builds_channel_lazily_and_closes_owned_channel() -> None:
@@ -200,14 +252,14 @@ class _SqlSpecBackendConfig:
     def __init__(
         self,
         *,
-        event_channel: "_RecordingSqlSpecEventChannel | None" = None,
+        event_channel: "object | None" = None,
         sqlspec: "_RecordingSQLSpec | None" = None,
         config: "_RecordingSQLSpecConfig | None" = None,
     ) -> None:
         self.event_channel = event_channel
         self.sqlspec = sqlspec
         self.config = config
-        self.event_backend = "table_queue"
+        self.event_backend = "poll_queue"
         self.event_queue_table = "litestar_queue_events"
         self.event_poll_interval = None
         self.event_settings: "dict[str, object]" = {}
@@ -240,14 +292,45 @@ class _RecordingSQLSpec:
 class _RecordingSqlSpecEventChannel:
     def __init__(self) -> None:
         self.published: "list[tuple[str, dict[str, object], dict[str, object] | None]]" = []
+        self.publish_calls = 0
+        self.publish_many_calls = 0
         self.shutdown_count = 0
 
     async def publish(
         self, channel: "str", payload: "dict[str, object]", metadata: "dict[str, object] | None" = None
     ) -> "str":
+        self.publish_calls += 1
         event_id = f"event-{len(self.published) + 1}"
         self.published.append((channel, payload, metadata))
         return event_id
 
+    async def publish_many(
+        self, events: "Sequence[tuple[str, dict[str, object], dict[str, object] | None]]"
+    ) -> "list[str]":
+        self.publish_many_calls += 1
+        event_ids = [f"event-{len(self.published) + index + 1}" for index in range(len(events))]
+        self.published.extend(events)
+        return event_ids
+
     async def shutdown(self) -> None:
         self.shutdown_count += 1
+
+
+class _FailingSqlSpecEventChannel(_RecordingSqlSpecEventChannel):
+    async def publish_many(
+        self, events: "Sequence[tuple[str, dict[str, object], dict[str, object] | None]]"
+    ) -> "list[str]":
+        self.publish_many_calls += 1
+        msg = "batch publish failed"
+        raise RuntimeError(msg)
+
+
+class _RecordingSyncSqlSpecEventChannel:
+    def __init__(self) -> None:
+        self.published: "list[tuple[str, dict[str, object], dict[str, object] | None]]" = []
+        self.publish_many_calls = 0
+
+    def publish_many(self, events: "Sequence[tuple[str, dict[str, object], dict[str, object] | None]]") -> "list[str]":
+        self.publish_many_calls += 1
+        self.published.extend(events)
+        return [f"event-{index + 1}" for index in range(len(events))]

--- a/src/tests/unit/events/test_litestar_streams.py
+++ b/src/tests/unit/events/test_litestar_streams.py
@@ -107,7 +107,7 @@ class _BatchPublishingChannelsBackend:
     def __init__(self) -> None:
         self.published_many: "list[tuple[tuple[bytes | str, ...], tuple[str, ...]]]" = []
 
-    def wait_published_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None:
+    async def publish_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None:
         self.published_many.append((tuple(data), tuple(channels)))
 
 
@@ -118,9 +118,9 @@ class _RedisPipelineChannelsBackend(_BatchPublishingChannelsBackend):
         super().__init__()
         self.pipeline_count = 0
 
-    def wait_published_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None:
+    async def publish_many(self, data: "Sequence[bytes | str]", channels: "Sequence[str]") -> None:
         self.pipeline_count += 1
-        super().wait_published_many(data, channels)
+        await super().publish_many(data, channels)
 
 
 class _ValkeyPipelineChannelsBackend(_RedisPipelineChannelsBackend):

--- a/src/tests/unit/events/test_typing.py
+++ b/src/tests/unit/events/test_typing.py
@@ -1,7 +1,7 @@
 from typing import get_args
 
-from litestar_queues.typing import ChannelsLike, ChannelsWaitPublishedManyBackend
+from litestar_queues.typing import ChannelsLike, ChannelsPublishManyBackend
 
 
-def test_channels_like_requires_single_event_publish_capability() -> None:
-    assert ChannelsWaitPublishedManyBackend not in get_args(ChannelsLike)
+def test_channels_like_accepts_public_batch_publish_capability() -> None:
+    assert ChannelsPublishManyBackend in get_args(ChannelsLike)


### PR DESCRIPTION
## Summary

- remove legacy SQLSpec transport aliases and forward only notify, notify_queue, poll_queue, aq, and txeventq
- use the public SQLSpec and Channels publish_many APIs with ordered one-call batches
- support sync and async SQLSpec event channels, including DuckDB poll_queue
- cover asyncpg, psycopg, psqlpy, DuckDB, and Oracle transport behavior and document the migration

## Validation

- make lint
- make type-check
- make docs
- uv lock --check
- focused event unit tests
- SQLSpec notification, streaming, and observability integration tests

## Dependency

PR #63 has merged. This branch is rebased directly onto main.