### PR TITLE
feat(advanced-alchemy): add psycopg listener wakeups + driver-parity matrix

### DIFF
--- a/src/litestar_queues/backends/advanced_alchemy/_notifications.py
+++ b/src/litestar_queues/backends/advanced_alchemy/_notifications.py
@@ -1,0 +1,240 @@
+"""Driver-specific PostgreSQL LISTEN/NOTIFY listeners for Advanced Alchemy wakeups.
+
+A queue backend that has opted into PostgreSQL notifications owns exactly one
+dedicated listener connection per driver. The listener protocol below is the
+only seam the backend knows about: it owns setup, a single retained wait,
+reconnect-on-failure, and deterministic close. It does not own task
+persistence, marker publication (``SELECT pg_notify(...)`` stays in the
+backend), retry policy, or public configuration.
+
+Notifications are hints. The backend reconciles the durable task table after
+every :meth:`NotificationListener.start` (including reconnects), so a duplicate
+or lost marker affects only wakeup latency, never correctness.
+
+Connection strings are treated as secrets: they are never placed in exception
+messages, and listeners carry no ``__dict__``/``repr`` that would leak them.
+"""
+
+import asyncio
+from contextlib import suppress
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+
+from sqlalchemy.engine import make_url
+
+from litestar_queues.backends._notification_wait import PendingNativeRead
+from litestar_queues.exceptions import QueueConfigurationError
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import URL
+
+__all__ = ("SUPPORTED_NOTIFY_DRIVERS", "NotificationListener", "create_notification_listener")
+
+_ASYNCPG_DRIVER = "postgresql+asyncpg"
+_PSYCOPG_DRIVER = "postgresql+psycopg"
+
+SUPPORTED_NOTIFY_DRIVERS: "frozenset[str]" = frozenset({_ASYNCPG_DRIVER, _PSYCOPG_DRIVER})
+"""Exact SQLAlchemy driver names that expose a dedicated wakeup listener."""
+
+
+@runtime_checkable
+class NotificationListener(Protocol):
+    """Structural protocol for a dedicated PostgreSQL wakeup listener.
+
+    Implementations own a single driver connection plus at most one retained
+    notification read. ``start`` is idempotent and re-establishes ``LISTEN``
+    after a lost connection; ``wait`` reuses the retained read across timeouts;
+    ``close`` tears the connection and pending read down deterministically.
+    """
+
+    async def start(self) -> "None":
+        """Ensure the dedicated connection is open and subscribed."""
+        ...
+
+    async def wait(self, timeout: "float | None") -> "bool":
+        """Wait up to ``timeout`` seconds for one wakeup marker.
+
+        Returns:
+            True when a marker was observed; False on timeout or a recovered
+            pump failure.
+        """
+        ...
+
+    async def close(self) -> "None":
+        """Close the connection and cancel any retained read."""
+        ...
+
+
+def create_notification_listener(*, connection_string: "str", channel: "str") -> "NotificationListener":
+    """Return the dedicated listener for the connection string's exact driver.
+
+    Args:
+        connection_string: The adopter's SQLAlchemy connection string. Only its
+            driver name selects the listener; the value is otherwise treated as
+            a secret.
+        channel: The PostgreSQL ``LISTEN``/``NOTIFY`` channel identifier.
+
+    Returns:
+        A driver-specific :class:`NotificationListener`.
+
+    Raises:
+        QueueConfigurationError: If the driver has no dedicated listener.
+    """
+    url = make_url(connection_string)
+    driver = url.drivername
+    if driver == _ASYNCPG_DRIVER:
+        return _AsyncpgNotificationListener(dsn=_neutral_conninfo(url), channel=channel)
+    if driver == _PSYCOPG_DRIVER:
+        return _PsycopgNotificationListener(conninfo=_neutral_conninfo(url), channel=channel)
+    msg = "SQLAlchemyBackend PostgreSQL notifications require a postgresql+asyncpg or postgresql+psycopg driver."
+    raise QueueConfigurationError(msg)
+
+
+def _neutral_conninfo(url: "URL") -> "str":
+    """Render a driver-neutral ``postgresql://`` connection string.
+
+    The driver suffix is stripped so both asyncpg (``connect(dsn=...)``) and
+    psycopg (``AsyncConnection.connect(conninfo)``) accept the same value.
+
+    Returns:
+        A ``postgresql://`` connection string with the driver suffix removed.
+    """
+    return url.set(drivername="postgresql").render_as_string(hide_password=False)
+
+
+class _AsyncpgNotificationListener:
+    """Dedicated asyncpg LISTEN connection for Advanced Alchemy wakeups."""
+
+    __slots__ = ("_channel", "_connection", "_dsn", "_event", "_pending_read")
+
+    def __init__(self, *, dsn: "str", channel: "str") -> "None":
+        self._dsn = dsn
+        self._channel = channel
+        self._event = asyncio.Event()
+        self._connection: "Any | None" = None
+        self._pending_read = PendingNativeRead()
+
+    async def start(self) -> "None":
+        connection = self._connection
+        if connection is not None and not connection.is_closed():
+            return
+        await self.close()
+        connection = await self._connect()
+        await connection.add_listener(self._channel, self._handle_notification)
+        self._connection = connection
+
+    async def wait(self, timeout: "float | None") -> "bool":
+        await self.start()
+        if not self._pending_read.has_pending and self._event.is_set():
+            self._event.clear()
+            return True
+        task = await self._pending_read.race(self._event.wait, timeout)
+        if task is None:
+            return False
+        task.result()
+        self._event.clear()
+        return True
+
+    async def close(self) -> "None":
+        await self._pending_read.aclose()
+        connection = self._connection
+        self._connection = None
+        if connection is None:
+            return
+        with suppress(Exception):
+            await connection.remove_listener(self._channel, self._handle_notification)
+        with suppress(Exception):
+            await connection.close()
+
+    async def _connect(self) -> "Any":
+        try:
+            asyncpg = import_module("asyncpg")
+        except ImportError as exc:
+            msg = "SQLAlchemyBackendConfig.notifications=True for postgresql+asyncpg requires asyncpg."
+            raise QueueConfigurationError(msg) from exc
+        return await cast("Any", asyncpg).connect(dsn=self._dsn)
+
+    def _handle_notification(self, _connection: "Any", _pid: "int", _channel: "str", _payload: "str") -> "None":
+        self._event.set()
+
+
+class _PsycopgNotificationListener:
+    """Dedicated autocommit psycopg ``AsyncConnection`` for Advanced Alchemy wakeups.
+
+    LISTEN/NOTIFY delivery requires the connection to be outside a transaction,
+    so the connection is opened with ``autocommit=True``. Exactly one
+    ``connection.notifies(stop_after=1)`` pump is retained across waits by the
+    shared :class:`PendingNativeRead`; a pump failure resets the connection so
+    the next :meth:`start` reconnects and re-subscribes.
+    """
+
+    __slots__ = ("_channel", "_connection", "_conninfo", "_pending_read")
+
+    def __init__(self, *, conninfo: "str", channel: "str") -> "None":
+        self._conninfo = conninfo
+        self._channel = channel
+        self._connection: "Any | None" = None
+        self._pending_read = PendingNativeRead()
+
+    async def start(self) -> "None":
+        connection = self._connection
+        if connection is not None and not connection.closed:
+            return
+        await self.close()
+        connection = await self._connect()
+        try:
+            await connection.execute(self._listen_statement())
+        except BaseException:
+            with suppress(Exception):
+                await connection.close()
+            raise
+        self._connection = connection
+
+    async def wait(self, timeout: "float | None") -> "bool":
+        await self.start()
+        task = await self._pending_read.race(self._read_one, timeout)
+        if task is None:
+            return False
+        if task.exception() is not None:
+            # The pump failed (dropped connection). Reset so the next start()
+            # reconnects and re-LISTENs; the backend reconciles the durable
+            # table before the next wait, so no marker is lost.
+            await self.close()
+            return False
+        return True
+
+    async def close(self) -> "None":
+        await self._pending_read.aclose()
+        connection = self._connection
+        self._connection = None
+        if connection is None:
+            return
+        with suppress(Exception):
+            await connection.execute(self._unlisten_statement())
+        with suppress(Exception):
+            await connection.close()
+
+    async def _connect(self) -> "Any":
+        try:
+            psycopg = import_module("psycopg")
+        except ImportError as exc:
+            msg = "SQLAlchemyBackendConfig.notifications=True for postgresql+psycopg requires psycopg."
+            raise QueueConfigurationError(msg) from exc
+        return await cast("Any", psycopg).AsyncConnection.connect(self._conninfo, autocommit=True)
+
+    async def _read_one(self) -> "None":
+        connection = self._connection
+        if connection is None:
+            return
+        async for _notify in connection.notifies(stop_after=1):
+            return
+
+    def _listen_statement(self) -> "Any":
+        return self._compose("LISTEN {}")
+
+    def _unlisten_statement(self) -> "Any":
+        return self._compose("UNLISTEN {}")
+
+    def _compose(self, template: "str") -> "Any":
+        psycopg_sql = import_module("psycopg.sql")
+        return cast("Any", psycopg_sql).SQL(template).format(cast("Any", psycopg_sql).Identifier(self._channel))

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -1,8 +1,6 @@
 """Advanced Alchemy queue backend."""
 
-import asyncio
-from contextlib import asynccontextmanager, suppress
-from importlib import import_module
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, cast
 
 from advanced_alchemy.exceptions import DuplicateKeyError
@@ -11,7 +9,10 @@ from sqlalchemy import text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError as SQLAlchemyIntegrityError
 
-from litestar_queues.backends._notification_wait import PendingNativeRead
+from litestar_queues.backends.advanced_alchemy._notifications import (
+    SUPPORTED_NOTIFY_DRIVERS,
+    create_notification_listener,
+)
 from litestar_queues.backends.advanced_alchemy.config import SQLAlchemyBackendConfig
 from litestar_queues.backends.advanced_alchemy.event_log import AdvancedAlchemyQueueEventLog
 from litestar_queues.backends.advanced_alchemy.mixins import QueueEventLogModelMixin, QueueTaskModelMixin
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from litestar_queues.backends.advanced_alchemy._notifications import NotificationListener
     from litestar_queues.config import QueueConfig
     from litestar_queues.events import EventLogConfig, QueueEventLog
     from litestar_queues.models import (
@@ -82,7 +84,7 @@ class SQLAlchemyBackend(BaseQueueBackend):
         self._notifications = backend_config.notifications
         self._notification_channel = backend_config.notification_channel
         self._event_poll_interval = backend_config.event_poll_interval
-        self._notification_listener: "Any | None" = None
+        self._notification_listener: "NotificationListener | None" = None
         self._observability_runtime: "QueueObservabilityRuntimeProtocol | None" = None
         self._event_log: "AdvancedAlchemyQueueEventLog | None" = None
         self._opened = False
@@ -373,21 +375,20 @@ class SQLAlchemyBackend(BaseQueueBackend):
         return make_url(sqlalchemy_config.connection_string).drivername
 
     def _notifications_supported(self) -> "bool":
-        return self._notifications and self._driver_name() == "postgresql+asyncpg"
+        return self._notifications and self._driver_name() in SUPPORTED_NOTIFY_DRIVERS
 
-    def _get_notification_listener(self) -> "Any":
+    def _get_notification_listener(self) -> "NotificationListener":
         if self._notification_listener is None:
             self._notification_listener = self._create_notification_listener()
         return self._notification_listener
 
-    def _create_notification_listener(self) -> "Any":
+    def _create_notification_listener(self) -> "NotificationListener":
         sqlalchemy_config = self._sqlalchemy_config
         if sqlalchemy_config is None or sqlalchemy_config.connection_string is None:
             msg = "SQLAlchemyBackend requires sqlalchemy_config for PostgreSQL notifications."
             raise QueueConfigurationError(msg)
-        url = make_url(sqlalchemy_config.connection_string).set(drivername="postgresql")
-        return _AsyncpgNotificationListener(
-            dsn=url.render_as_string(hide_password=False), channel=self._notification_channel
+        return create_notification_listener(
+            connection_string=sqlalchemy_config.connection_string, channel=self._notification_channel
         )
 
     async def _send_notification_marker(self) -> "None":
@@ -566,59 +567,3 @@ class SQLAlchemyBackend(BaseQueueBackend):
         else:
             async with self._heartbeat_session_maker() as session, session.begin():
                 yield self._service_class(session=session)
-
-
-class _AsyncpgNotificationListener:
-    """Dedicated asyncpg LISTEN connection for Advanced Alchemy wakeups."""
-
-    __slots__ = ("_channel", "_connection", "_dsn", "_event", "_pending_read")
-
-    def __init__(self, *, dsn: "str", channel: "str") -> "None":
-        self._dsn = dsn
-        self._channel = channel
-        self._event = asyncio.Event()
-        self._connection: "Any | None" = None
-        self._pending_read = PendingNativeRead()
-
-    async def start(self) -> "None":
-        connection = self._connection
-        if connection is not None and not connection.is_closed():
-            return
-        await self.close()
-        connection = await self._connect()
-        await connection.add_listener(self._channel, self._handle_notification)
-        self._connection = connection
-
-    async def wait(self, timeout: "float | None") -> "bool":
-        await self.start()
-        if not self._pending_read.has_pending and self._event.is_set():
-            self._event.clear()
-            return True
-        task = await self._pending_read.race(self._event.wait, timeout)
-        if task is None:
-            return False
-        task.result()
-        self._event.clear()
-        return True
-
-    async def close(self) -> "None":
-        await self._pending_read.aclose()
-        connection = self._connection
-        self._connection = None
-        if connection is None:
-            return
-        with suppress(Exception):
-            await connection.remove_listener(self._channel, self._handle_notification)
-        with suppress(Exception):
-            await connection.close()
-
-    async def _connect(self) -> "Any":
-        try:
-            asyncpg = import_module("asyncpg")
-        except ImportError as exc:
-            msg = "SQLAlchemyBackendConfig.notifications=True for postgresql+asyncpg requires asyncpg."
-            raise QueueConfigurationError(msg) from exc
-        return await cast("Any", asyncpg).connect(dsn=self._dsn)
-
-    def _handle_notification(self, _connection: "Any", _pid: "int", _channel: "str", _payload: "str") -> "None":
-        self._event.set()

--- a/src/tests/integration/backends/advanced_alchemy/_aa_engines.py
+++ b/src/tests/integration/backends/advanced_alchemy/_aa_engines.py
@@ -51,6 +51,16 @@ def _config_postgres_asyncpg(ctx: "FixtureCtx") -> "SQLAlchemyAsyncConfig":
     )
 
 
+def _config_postgres_psycopg(ctx: "FixtureCtx") -> "SQLAlchemyAsyncConfig":
+    from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
+
+    svc = cast("PostgresService", ctx.service)
+    assert svc is not None
+    return SQLAlchemyAsyncConfig(
+        connection_string=f"postgresql+psycopg://{svc.user}:{svc.password}@{svc.host}:{svc.port}/{svc.database}"
+    )
+
+
 def _config_mysql_asyncmy(ctx: "FixtureCtx") -> "SQLAlchemyAsyncConfig":
     from advanced_alchemy.extensions.litestar import SQLAlchemyAsyncConfig
 
@@ -86,7 +96,14 @@ AA_ENGINES: "tuple[AAEngineCase, ...]" = (
         frozenset({"asyncpg", "sqlalchemy", "advanced_alchemy"}),
         "postgres_service",
         _config_postgres_asyncpg,
-        frozenset({"json-column"}),
+        frozenset({"json-column", "listen-notify"}),
+    ),
+    AAEngineCase(
+        "aa-postgres-psycopg",
+        frozenset({"psycopg", "sqlalchemy", "advanced_alchemy"}),
+        "postgres_service",
+        _config_postgres_psycopg,
+        frozenset({"json-column", "listen-notify"}),
     ),
     AAEngineCase(
         "aa-mysql-asyncmy",

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -40,6 +40,22 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.anyio
 
+# Both async PostgreSQL drivers share the same dedicated LISTEN/NOTIFY listener
+# seam and the same durable reconciliation. Notification behavior is proven on
+# each against the SAME real PostgreSQL service.
+_PG_NOTIFY_DRIVERS = (
+    pytest.param(("postgresql+asyncpg", "asyncpg"), id="asyncpg"),
+    pytest.param(("postgresql+psycopg", "psycopg"), id="psycopg"),
+)
+
+
+def _pg_notify_config(driver: "str", service: "PostgresService") -> "SQLAlchemyAsyncConfig":
+    return SQLAlchemyAsyncConfig(
+        connection_string=(
+            f"{driver}://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
+        )
+    )
+
 
 @pytest.fixture(autouse=True)
 def clean_task_registry() -> "None":
@@ -103,6 +119,7 @@ def test_advanced_alchemy_claim_statement_uses_skip_locked_for_locking_dialects(
     from litestar_queues.backends.advanced_alchemy.service import (
         _build_claim_candidate_statement,
         _build_claim_lock_statement,
+        _supports_batch_claim,
         _supports_skip_locked_claim,
     )
 
@@ -137,6 +154,13 @@ def test_advanced_alchemy_claim_statement_uses_skip_locked_for_locking_dialects(
     assert "FOR UPDATE SKIP LOCKED" in oracle_lock_sql
     assert not _supports_skip_locked_claim("mysql")
     assert not _supports_skip_locked_claim("mariadb")
+    # Batch claim is gated on the PostgreSQL dialect, so both async PostgreSQL
+    # drivers (asyncpg and psycopg share ``dialect.name == "postgresql"``)
+    # advertise it while other dialects do not.
+    assert _supports_batch_claim("postgresql")
+    assert not _supports_batch_claim("oracle")
+    assert not _supports_batch_claim("mysql")
+    assert not _supports_batch_claim("sqlite")
 
 
 async def test_advanced_alchemy_cas_claim_scans_past_first_failed_batch() -> "None":
@@ -320,6 +344,13 @@ async def test_advanced_alchemy_capabilities_are_polling_only_without_postgres_n
             notifications=True,
         )
     )
+    postgres_psycopg_backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="postgresql+psycopg://user:pass@localhost/db"),
+            model_class=ContractQueueTask,
+            notifications=True,
+        )
+    )
     mysql_backend = SQLAlchemyBackend(
         backend_config=SQLAlchemyBackendConfig(
             sqlalchemy_config=SQLAlchemyAsyncConfig(connection_string="mysql+asyncmy://user:pass@localhost/db"),
@@ -341,10 +372,15 @@ async def test_advanced_alchemy_capabilities_are_polling_only_without_postgres_n
     assert sqlite_backend.capabilities.notification_backend is None
     assert sqlite_backend.capabilities.notifications_durable is False
     assert mysql_backend.capabilities.supports_notifications is False
+    # Oracle stays polling: Advanced Alchemy exposes no AQ/TxEventQ transport.
     assert oracle_backend.capabilities.supports_notifications is False
-    assert postgres_backend.capabilities.supports_notifications is True
-    assert postgres_backend.capabilities.notification_backend == "postgres-listen-notify"
-    assert postgres_backend.capabilities.notifications_durable is False
+    assert oracle_backend.capabilities.notification_backend not in {"aq", "txeventq"}
+    assert oracle_backend.capabilities.notification_backend is None
+    # Both async PostgreSQL drivers advertise transient LISTEN/NOTIFY wakeups.
+    for pg_backend in (postgres_backend, postgres_psycopg_backend):
+        assert pg_backend.capabilities.supports_notifications is True
+        assert pg_backend.capabilities.notification_backend == "postgres-listen-notify"
+        assert pg_backend.capabilities.notifications_durable is False
 
 
 async def test_advanced_alchemy_wait_for_notifications_uses_dedicated_listener(tmp_path: "Path") -> "None":
@@ -372,16 +408,15 @@ async def test_advanced_alchemy_wait_for_notifications_uses_dedicated_listener(t
     assert backend.listener.closed is True
 
 
-async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_service: "PostgresService") -> "None":
-    pytest.importorskip("asyncpg")
+@pytest.mark.parametrize("pg_notify_driver", _PG_NOTIFY_DRIVERS)
+async def test_advanced_alchemy_postgres_notifications_wake_waiter(
+    postgres_service: "PostgresService", pg_notify_driver: "tuple[str, str]"
+) -> "None":
+    driver, extra = pg_notify_driver
+    pytest.importorskip(extra)
     table_name = f"aa_notify_{uuid4().hex}"
     model_class = _dynamic_queue_model(table_name)
-    sqlalchemy_config = SQLAlchemyAsyncConfig(
-        connection_string=(
-            f"postgresql+asyncpg://{postgres_service.user}:{postgres_service.password}"
-            f"@{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
-        )
-    )
+    sqlalchemy_config = _pg_notify_config(driver, postgres_service)
     await create_tables(sqlalchemy_config, model_class)
     backend = SQLAlchemyBackend(
         backend_config=SQLAlchemyBackendConfig(
@@ -412,18 +447,15 @@ async def test_advanced_alchemy_postgres_notifications_wake_waiter(postgres_serv
         await backend.close()
 
 
+@pytest.mark.parametrize("pg_notify_driver", _PG_NOTIFY_DRIVERS)
 async def test_advanced_alchemy_postgres_notification_after_timeout_reuses_listener(
-    postgres_service: "PostgresService",
+    postgres_service: "PostgresService", pg_notify_driver: "tuple[str, str]"
 ) -> "None":
-    pytest.importorskip("asyncpg")
+    driver, extra = pg_notify_driver
+    pytest.importorskip(extra)
     table_name = f"aa_notify_reuse_{uuid4().hex}"
     model_class = _dynamic_queue_model(table_name)
-    sqlalchemy_config = SQLAlchemyAsyncConfig(
-        connection_string=(
-            f"postgresql+asyncpg://{postgres_service.user}:{postgres_service.password}"
-            f"@{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
-        )
-    )
+    sqlalchemy_config = _pg_notify_config(driver, postgres_service)
     await create_tables(sqlalchemy_config, model_class)
     backend = SQLAlchemyBackend(
         backend_config=SQLAlchemyBackendConfig(
@@ -437,7 +469,7 @@ async def test_advanced_alchemy_postgres_notification_after_timeout_reuses_liste
     try:
         # A first empty wait establishes the LISTEN connection and retains its read.
         assert await backend.wait_for_notifications(timeout=0.2) is False
-        listener = backend._notification_listener
+        listener = cast("Any", backend._notification_listener)
         assert listener is not None
         connection = listener._connection
         assert connection is not None
@@ -458,6 +490,97 @@ async def test_advanced_alchemy_postgres_notification_after_timeout_reuses_liste
             await _drop_dynamic_queue_model(backend, model_class)
         await backend.close()
         assert backend._notification_listener is None
+
+
+@pytest.mark.parametrize("pg_notify_driver", _PG_NOTIFY_DRIVERS)
+async def test_advanced_alchemy_postgres_dropped_marker_is_reconciled_from_durable_table(
+    postgres_service: "PostgresService", pg_notify_driver: "tuple[str, str]"
+) -> "None":
+    """A committed task enqueued before anyone listens is still claimed.
+
+    The NOTIFY marker fires while no listener is subscribed (it is "dropped"),
+    proving durable reconciliation on ``start()`` closes the startup race.
+    """
+    driver, extra = pg_notify_driver
+    pytest.importorskip(extra)
+    table_name = f"aa_notify_drop_{uuid4().hex}"
+    model_class = _dynamic_queue_model(table_name)
+    sqlalchemy_config = _pg_notify_config(driver, postgres_service)
+    await create_tables(sqlalchemy_config, model_class)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=sqlalchemy_config,
+            model_class=model_class,
+            notifications=True,
+            notification_channel=f"lq_drop_{uuid4().hex}",
+        )
+    )
+    await backend.open()
+    try:
+        # Commit + NOTIFY happen here, before any listener exists: the marker is lost.
+        record = await backend.enqueue("tasks.pg.dropped")
+
+        # The very first wait subscribes, then reconciles the durable table and
+        # discovers the committed due row without any live notification.
+        assert await backend.wait_for_notifications(timeout=1.0) is True
+        claimed = await backend.claim_task(record.id)
+        assert claimed is not None
+        assert claimed.status == "running"
+    finally:
+        with suppress(Exception):
+            await _drop_dynamic_queue_model(backend, model_class)
+        await backend.close()
+
+
+@pytest.mark.parametrize("pg_notify_driver", _PG_NOTIFY_DRIVERS)
+async def test_advanced_alchemy_postgres_uncommitted_row_does_not_wake_committed_does(
+    postgres_service: "PostgresService", pg_notify_driver: "tuple[str, str]"
+) -> "None":
+    """An uncommitted enqueue produces no actionable wakeup; the commit does."""
+    driver, extra = pg_notify_driver
+    pytest.importorskip(extra)
+    table_name = f"aa_notify_commit_{uuid4().hex}"
+    model_class = _dynamic_queue_model(table_name)
+    sqlalchemy_config = _pg_notify_config(driver, postgres_service)
+    await create_tables(sqlalchemy_config, model_class)
+    backend = SQLAlchemyBackend(
+        backend_config=SQLAlchemyBackendConfig(
+            sqlalchemy_config=sqlalchemy_config,
+            model_class=model_class,
+            notifications=True,
+            notification_channel=f"lq_commit_{uuid4().hex}",
+        )
+    )
+    await backend.open()
+    session_maker = sqlalchemy_config.create_session_maker()
+    try:
+        async with session_maker() as session, session.begin():
+            service = backend._service_class(session=session)
+            await service.enqueue(
+                "tasks.pg.uncommitted",
+                args=(),
+                kwargs={},
+                queue="default",
+                priority=0,
+                max_retries=0,
+                scheduled_at=None,
+                key=None,
+                execution_backend="local",
+                execution_profile=None,
+                metadata={},
+            )
+            await session.flush()
+            # Reconciliation runs on a separate connection under READ
+            # COMMITTED; the still-open insert is invisible and no marker
+            # was published, so the waiter must not wake.
+            assert await backend.wait_for_notifications(timeout=0.4) is False
+            # Transaction committed on block exit.
+        # The committed due row is now visible to durable reconciliation.
+        assert await backend.wait_for_notifications(timeout=1.0) is True
+    finally:
+        with suppress(Exception):
+            await _drop_dynamic_queue_model(backend, model_class)
+        await backend.close()
 
 
 async def test_advanced_alchemy_backend_claims_due_tasks_by_priority(

--- a/src/tests/unit/backends/test_advanced_alchemy_config.py
+++ b/src/tests/unit/backends/test_advanced_alchemy_config.py
@@ -1,4 +1,4 @@
-"""Advanced Alchemy backend configuration tests."""
+"""Advanced Alchemy backend configuration and notification-listener tests."""
 
 from typing import TYPE_CHECKING, Any
 
@@ -8,7 +8,7 @@ pytest.importorskip("advanced_alchemy")
 pytest.importorskip("sqlalchemy")
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import AsyncIterator, Callable
 
 
 def test_advanced_alchemy_config_defaults_to_singular_queue_task_model() -> "None":
@@ -19,6 +19,42 @@ def test_advanced_alchemy_config_defaults_to_singular_queue_task_model() -> "Non
 
     assert config.model_class is QueueTaskModel
     assert QueueTaskModel.__tablename__ == "litestar_queue_task"
+
+
+def test_create_notification_listener_selects_driver_specific_listener() -> "None":
+    """The factory dispatches on the exact SQLAlchemy driver name."""
+    from litestar_queues.backends.advanced_alchemy._notifications import (
+        SUPPORTED_NOTIFY_DRIVERS,
+        _AsyncpgNotificationListener,
+        _PsycopgNotificationListener,
+        create_notification_listener,
+    )
+
+    asyncpg_listener = create_notification_listener(
+        connection_string="postgresql+asyncpg://user:secret@localhost/db", channel="lq"
+    )
+    psycopg_listener = create_notification_listener(
+        connection_string="postgresql+psycopg://user:secret@localhost/db", channel="lq"
+    )
+
+    assert isinstance(asyncpg_listener, _AsyncpgNotificationListener)
+    assert isinstance(psycopg_listener, _PsycopgNotificationListener)
+    assert frozenset({"postgresql+asyncpg", "postgresql+psycopg"}) == SUPPORTED_NOTIFY_DRIVERS
+
+
+def test_create_notification_listener_rejects_unsupported_driver_without_leaking_secret() -> "None":
+    from litestar_queues.backends.advanced_alchemy._notifications import create_notification_listener
+    from litestar_queues.exceptions import QueueConfigurationError
+
+    with pytest.raises(QueueConfigurationError) as exc_info:
+        create_notification_listener(connection_string="mysql+asyncmy://user:secret@localhost/db", channel="lq")
+
+    assert "secret" not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# asyncpg listener (moved behind the shared protocol, semantics unchanged)
+# ---------------------------------------------------------------------------
 
 
 class _FakeAsyncpgConnection:
@@ -46,7 +82,7 @@ class _FakeAsyncpgConnection:
 
 @pytest.mark.anyio
 async def test_asyncpg_listener_retains_one_read_across_timeouts() -> "None":
-    from litestar_queues.backends.advanced_alchemy.backend import _AsyncpgNotificationListener
+    from litestar_queues.backends.advanced_alchemy._notifications import _AsyncpgNotificationListener
 
     connections: "list[_FakeAsyncpgConnection]" = []
 
@@ -76,6 +112,262 @@ async def test_asyncpg_listener_retains_one_read_across_timeouts() -> "None":
     assert _has_pending(listener) is False
     assert connections[0].closed is True
     assert len(connections[0].removed) == 1
+
+
+# ---------------------------------------------------------------------------
+# psycopg listener
+# ---------------------------------------------------------------------------
+
+
+class _FakePumpError(Exception):
+    """Stand-in for a psycopg OperationalError raised by a dropped pump."""
+
+
+class _FakePsycopgConnection:
+    """Minimal psycopg ``AsyncConnection`` double for listener lifecycle tests."""
+
+    __slots__ = ("_auto_deliver", "_fail", "_signal", "autocommit", "closed", "executed")
+
+    def __init__(self, *, fail_pump: "bool" = False, auto_deliver: "bool" = False) -> "None":
+        self.autocommit = False
+        self.closed = False
+        self.executed: "list[str]" = []
+        self._auto_deliver = auto_deliver
+        self._fail = fail_pump
+        self._signal = __import__("asyncio").Event()
+
+    async def execute(self, statement: "Any") -> "None":
+        # ``statement`` is a psycopg ``Composed``; record the rendered SQL so
+        # tests can assert safe identifier quoting.
+        self.executed.append(statement.as_string(None))
+
+    async def notifies(
+        self, *, timeout: "float | None" = None, stop_after: "int | None" = None
+    ) -> "AsyncIterator[Any]":
+        if self._fail:
+            msg = "connection lost"
+            raise _FakePumpError(msg)
+        if not self._auto_deliver:
+            await self._signal.wait()
+            self._signal.clear()
+        yield object()
+
+    async def close(self) -> "None":
+        self.closed = True
+
+    def deliver(self) -> "None":
+        self._signal.set()
+
+
+def _psycopg_connect_factory(
+    connections: "list[_FakePsycopgConnection]", *specs: "dict[str, bool]"
+) -> "Callable[..., Any]":
+    """Return a fake ``AsyncConnection.connect`` yielding fakes per ``specs``."""
+
+    async def connect(conninfo: "str", *, autocommit: "bool" = False, **_kwargs: "Any") -> "_FakePsycopgConnection":
+        spec = specs[len(connections)] if len(connections) < len(specs) else {}
+        connection = _FakePsycopgConnection(
+            fail_pump=spec.get("fail_pump", False), auto_deliver=spec.get("auto_deliver", False)
+        )
+        connection.autocommit = autocommit
+        connections.append(connection)
+        return connection
+
+    return connect
+
+
+@pytest.mark.anyio
+async def test_psycopg_listener_opens_autocommit_and_composes_safe_identifier(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    import psycopg
+
+    from litestar_queues.backends.advanced_alchemy._notifications import _PsycopgNotificationListener
+
+    connections: "list[_FakePsycopgConnection]" = []
+    monkeypatch.setattr(psycopg.AsyncConnection, "connect", staticmethod(_psycopg_connect_factory(connections)))
+
+    listener = _PsycopgNotificationListener(conninfo="postgresql://user:secret@localhost/db", channel="lq-notify")
+    await listener.start()
+
+    assert len(connections) == 1
+    assert connections[0].autocommit is True
+    # Identifier is quoted, never interpolated -- a dash cannot break out.
+    assert connections[0].executed == ['LISTEN "lq-notify"']
+
+
+@pytest.mark.anyio
+async def test_psycopg_listener_retains_one_pump_across_timeouts(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    import psycopg
+
+    from litestar_queues.backends.advanced_alchemy._notifications import _PsycopgNotificationListener
+
+    connections: "list[_FakePsycopgConnection]" = []
+    monkeypatch.setattr(psycopg.AsyncConnection, "connect", staticmethod(_psycopg_connect_factory(connections)))
+
+    listener = _PsycopgNotificationListener(conninfo="postgresql://ignored/db", channel="lq")
+
+    assert await listener.wait(timeout=0.01) is False
+    assert await listener.wait(timeout=0.01) is False
+    assert _has_pending(listener) is True
+    # One connection, one LISTEN, one retained notification pump.
+    assert len(connections) == 1
+    assert connections[0].executed == ['LISTEN "lq"']
+
+    connections[0].deliver()
+    assert await listener.wait(timeout=0.5) is True
+    assert _has_pending(listener) is False
+    assert len(connections) == 1
+
+    await listener.close()
+    assert _has_pending(listener) is False
+    assert connections[0].closed is True
+    assert connections[0].executed[-1] == 'UNLISTEN "lq"'
+
+
+@pytest.mark.anyio
+async def test_psycopg_listener_reconnects_and_relistens_after_pump_failure(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    import psycopg
+
+    from litestar_queues.backends.advanced_alchemy._notifications import _PsycopgNotificationListener
+
+    connections: "list[_FakePsycopgConnection]" = []
+    monkeypatch.setattr(
+        psycopg.AsyncConnection,
+        "connect",
+        staticmethod(_psycopg_connect_factory(connections, {"fail_pump": True}, {"auto_deliver": True})),
+    )
+
+    listener = _PsycopgNotificationListener(conninfo="postgresql://ignored/db", channel="lq")
+
+    # First wait: the pump raises; the dead connection is torn down and False
+    # is returned so the worker reconciles + retries.
+    assert await listener.wait(timeout=0.5) is False
+    assert connections[0].closed is True
+    assert _has_pending(listener) is False
+
+    # Second wait: bounded reconnect rebuilds the connection and re-LISTENs.
+    assert await listener.wait(timeout=0.5) is True
+    assert len(connections) == 2
+    assert connections[1].executed[0] == 'LISTEN "lq"'
+    assert connections[1].closed is False
+
+    await listener.close()
+
+
+@pytest.mark.anyio
+async def test_psycopg_listener_missing_dependency_raises_only_when_path_used(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    import importlib
+
+    from litestar_queues.backends.advanced_alchemy import _notifications
+    from litestar_queues.exceptions import QueueConfigurationError
+
+    real_import_module = importlib.import_module
+
+    def blocked_import(name: "str") -> "Any":
+        if name == "psycopg" or name.startswith("psycopg."):
+            raise ImportError(name)
+        return real_import_module(name)
+
+    monkeypatch.setattr(_notifications, "import_module", blocked_import)
+
+    # Construction is lazy: no psycopg import happens until the pump path runs.
+    listener = _notifications.create_notification_listener(
+        connection_string="postgresql+psycopg://user:secret@localhost/db", channel="lq"
+    )
+
+    with pytest.raises(QueueConfigurationError) as exc_info:
+        await listener.start()
+
+    message = str(exc_info.value)
+    assert "psycopg" in message
+    # Connection secrets must never appear in the error surface.
+    assert "secret" not in message
+    assert "postgresql://" not in message
+
+
+@pytest.mark.anyio
+async def test_psycopg_listener_double_close_and_partial_setup_leave_no_state(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    import psycopg
+
+    from litestar_queues.backends.advanced_alchemy._notifications import _PsycopgNotificationListener
+
+    connections: "list[_FakePsycopgConnection]" = []
+    monkeypatch.setattr(psycopg.AsyncConnection, "connect", staticmethod(_psycopg_connect_factory(connections)))
+
+    listener = _PsycopgNotificationListener(conninfo="postgresql://ignored/db", channel="lq")
+    await listener.wait(timeout=0.01)
+    assert _has_pending(listener) is True
+
+    await listener.close()
+    await listener.close()
+    assert _has_pending(listener) is False
+    assert listener._connection is None
+    assert connections[0].closed is True
+
+    # Partial setup: LISTEN fails -> the just-opened connection is closed and no
+    # listener state (connection or retained pump) survives.
+    failing: "list[_FakePsycopgConnection]" = []
+
+    class _FailingListenConnection(_FakePsycopgConnection):
+        __slots__ = ()
+
+        async def execute(self, statement: "Any") -> "None":
+            msg = "listen failed"
+            raise _FakePumpError(msg)
+
+    async def failing_connect(
+        conninfo: "str", *, autocommit: "bool" = False, **_kwargs: "Any"
+    ) -> "_FakePsycopgConnection":
+        connection = _FailingListenConnection()
+        connection.autocommit = autocommit
+        failing.append(connection)
+        return connection
+
+    monkeypatch.setattr(psycopg.AsyncConnection, "connect", staticmethod(failing_connect))
+    partial = _PsycopgNotificationListener(conninfo="postgresql://ignored/db", channel="lq")
+    with pytest.raises(_FakePumpError):
+        await partial.start()
+
+    assert partial._connection is None
+    assert _has_pending(partial) is False
+    assert failing[0].closed is True
+
+
+@pytest.mark.anyio
+async def test_psycopg_listener_cancel_during_wait_retains_read_then_close_cleans_up(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    import asyncio
+
+    import psycopg
+
+    from litestar_queues.backends.advanced_alchemy._notifications import _PsycopgNotificationListener
+
+    connections: "list[_FakePsycopgConnection]" = []
+    monkeypatch.setattr(psycopg.AsyncConnection, "connect", staticmethod(_psycopg_connect_factory(connections)))
+
+    listener = _PsycopgNotificationListener(conninfo="postgresql://ignored/db", channel="lq")
+    waiter = asyncio.ensure_future(listener.wait(timeout=None))
+    await asyncio.sleep(0.05)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    # Cancelling the outer wait retains the in-flight pump for reuse.
+    assert _has_pending(listener) is True
+    assert len(connections) == 1
+    assert connections[0].closed is False
+
+    await listener.close()
+    assert _has_pending(listener) is False
+    assert connections[0].closed is True
 
 
 def _has_pending(listener: "Any") -> "bool":


### PR DESCRIPTION
## Summary

Advanced Alchemy workers on PostgreSQL now get **instant `LISTEN/NOTIFY` wakeups on the psycopg driver**, not just asyncpg. Before this, psycopg users fell back to slower interval polling.

## What changed

- **psycopg wakes workers instantly** — a dedicated listener (mirroring the existing asyncpg one) wakes a worker the moment a job is enqueued, instead of on the next poll.
- **Both Postgres drivers** (`asyncpg` and `psycopg`) now advertise native notifications and batch claims. SQLite, MySQL, and Oracle keep polling, unchanged.
- **Safe by design** — channel names are quoted (never string-interpolated), the listener reconnects after a failure, and connection strings never appear in logs or errors. The wakeup marker carries no task data.
- **Refactor** — the asyncpg listener moved into a new `_notifications.py` behind a small shared listener protocol, with no behavior change to asyncpg.
