### PR TITLE
feat: align heartbeat, progress, and Cloud Run lifecycle parity

### DIFF
--- a/examples/htmx_realtime_sse/app.py
+++ b/examples/htmx_realtime_sse/app.py
@@ -31,12 +31,14 @@ DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -48,17 +50,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_sse/resources/main.ts
+++ b/examples/htmx_realtime_sse/resources/main.ts
@@ -71,10 +71,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_sse/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse/templates/partials/stream_mount.html
@@ -12,7 +12,7 @@
   aria-hidden="true"
   hx-ext="sse"
   sse-connect="{{ task_sse_url }}"
-  sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
+  sse-swap="task.started,task.progress,task.log,crawl.page_discovered,task.completed,task.failed"
   hx-swap="none"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_advanced_alchemy/app.py
+++ b/examples/htmx_realtime_sse_advanced_alchemy/app.py
@@ -34,12 +34,14 @@ QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-advanced-alchemy.db"
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -51,17 +53,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_sse_advanced_alchemy/resources/main.ts
+++ b/examples/htmx_realtime_sse_advanced_alchemy/resources/main.ts
@@ -71,10 +71,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_sse_advanced_alchemy/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_advanced_alchemy/templates/partials/stream_mount.html
@@ -12,7 +12,7 @@
   aria-hidden="true"
   hx-ext="sse"
   sse-connect="{{ task_sse_url }}"
-  sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
+  sse-swap="task.started,task.progress,task.log,crawl.page_discovered,task.completed,task.failed"
   hx-swap="none"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_redis/app.py
+++ b/examples/htmx_realtime_sse_redis/app.py
@@ -44,12 +44,14 @@ SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -61,17 +63,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_sse_redis/resources/main.ts
+++ b/examples/htmx_realtime_sse_redis/resources/main.ts
@@ -71,10 +71,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_sse_redis/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_redis/templates/partials/stream_mount.html
@@ -12,7 +12,7 @@
   aria-hidden="true"
   hx-ext="sse"
   sse-connect="{{ task_sse_url }}"
-  sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
+  sse-swap="task.started,task.progress,task.log,crawl.page_discovered,task.completed,task.failed"
   hx-swap="none"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_sqlspec/app.py
+++ b/examples/htmx_realtime_sse_sqlspec/app.py
@@ -33,12 +33,14 @@ DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-sqlspec.db"
 sqlspec_config = AiosqliteConfig(connection_config={"database": str(QUEUE_DB_PATH)})
@@ -53,17 +55,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_sse_sqlspec/resources/main.ts
+++ b/examples/htmx_realtime_sse_sqlspec/resources/main.ts
@@ -71,10 +71,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_sse_sqlspec/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_sqlspec/templates/partials/stream_mount.html
@@ -12,7 +12,7 @@
   aria-hidden="true"
   hx-ext="sse"
   sse-connect="{{ task_sse_url }}"
-  sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
+  sse-swap="task.started,task.progress,task.log,crawl.page_discovered,task.completed,task.failed"
   hx-swap="none"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_sse_valkey/app.py
+++ b/examples/htmx_realtime_sse_valkey/app.py
@@ -44,12 +44,14 @@ SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -61,17 +63,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_sse_valkey/resources/main.ts
+++ b/examples/htmx_realtime_sse_valkey/resources/main.ts
@@ -71,10 +71,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_sse_valkey/templates/partials/stream_mount.html
+++ b/examples/htmx_realtime_sse_valkey/templates/partials/stream_mount.html
@@ -12,7 +12,7 @@
   aria-hidden="true"
   hx-ext="sse"
   sse-connect="{{ task_sse_url }}"
-  sse-swap="task.started,task.progress,task.log,task.event,task.completed,task.failed"
+  sse-swap="task.started,task.progress,task.log,crawl.page_discovered,task.completed,task.failed"
   hx-swap="none"
   data-task-id="{{ task_id }}"
 ></div>

--- a/examples/htmx_realtime_websocket/app.py
+++ b/examples/htmx_realtime_websocket/app.py
@@ -31,12 +31,14 @@ DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -48,17 +50,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_websocket/resources/main.ts
+++ b/examples/htmx_realtime_websocket/resources/main.ts
@@ -72,10 +72,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_websocket_advanced_alchemy/app.py
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/app.py
@@ -34,12 +34,14 @@ QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-advanced-alchemy.db"
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -51,17 +53,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_websocket_advanced_alchemy/resources/main.ts
+++ b/examples/htmx_realtime_websocket_advanced_alchemy/resources/main.ts
@@ -72,10 +72,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_websocket_redis/app.py
+++ b/examples/htmx_realtime_websocket_redis/app.py
@@ -44,12 +44,14 @@ SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -61,17 +63,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_websocket_redis/resources/main.ts
+++ b/examples/htmx_realtime_websocket_redis/resources/main.ts
@@ -72,10 +72,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_websocket_sqlspec/app.py
+++ b/examples/htmx_realtime_websocket_sqlspec/app.py
@@ -33,12 +33,14 @@ DEMO_KEY = "demo:current"
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 QUEUE_DB_PATH = EXAMPLE_ROOT / "queue-sqlspec.db"
 sqlspec_config = AiosqliteConfig(connection_config={"database": str(QUEUE_DB_PATH)})
@@ -53,17 +55,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_websocket_sqlspec/resources/main.ts
+++ b/examples/htmx_realtime_websocket_sqlspec/resources/main.ts
@@ -72,10 +72,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/examples/htmx_realtime_websocket_valkey/app.py
+++ b/examples/htmx_realtime_websocket_valkey/app.py
@@ -44,12 +44,14 @@ SHARED_CHANNELS = os.getenv("LITESTAR_QUEUES_EXAMPLE_SHARED_CHANNELS", "0") == "
 
 CRAWL_LINES = (
     "The task started.",
-    "The task sent an event from the backend.",
-    "The task is sleeping before the next event.",
-    "The task sent another event.",
-    "The page received the event.",
-    "The task finished.",
+    "The task is visiting the next page.",
+    "The task is sleeping before the next page.",
+    "The task is visiting another page.",
+    "The task is almost done.",
+    "The task finished the crawl.",
 )
+DISCOVERED_PAGE_STEP = DEMO_STEPS // 2
+DISCOVERED_PAGE_URL = "https://example.invalid/articles/queues-101"
 
 
 # -- docs-task-start --
@@ -61,17 +63,17 @@ async def run_crawl(*, _task_context: TaskExecutionContext) -> dict[str, str]:
     for step in range(1, DEMO_STEPS + 1):
         line = CRAWL_LINES[(step - 1) % len(CRAWL_LINES)]
         message = f"{step}/{DEMO_STEPS} - {line}"
-        ctx.beat(message)
         await ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})
-        await ctx.event(
-            "task.event",
-            message=message,
-            payload={"task_id": ctx.task_id, "line": message, "step": step},
-            immediate=step == DEMO_STEPS,
-        )
+        if step == DISCOVERED_PAGE_STEP:
+            # One meaningful domain event at a real transition, with a payload
+            # distinct from the generic per-step progress text above.
+            await ctx.event(
+                "crawl.page_discovered",
+                message=f"Discovered {DISCOVERED_PAGE_URL}",
+                payload={"url": DISCOVERED_PAGE_URL},
+            )
         await asyncio.sleep(DEMO_STEP_DELAY)
 
-    await publish_task_log("The task finished", payload={"task_id": ctx.task_id}, immediate=True)
     return {"task_id": ctx.task_id, "status": "complete"}
 
 

--- a/examples/htmx_realtime_websocket_valkey/resources/main.ts
+++ b/examples/htmx_realtime_websocket_valkey/resources/main.ts
@@ -72,10 +72,9 @@ function markBackendMessage(event: QueueEvent): void {
 }
 
 // The one adapter the extensions cannot replace: queue frames are JSON, so they
-// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, drop
-// back-to-back duplicates (progress and custom events share a message), and
-// append the event line. The terminal event only flips the readout — the task's
-// own closing log line is the on-screen finale.
+// cannot be swapped as HTML. Parse each frame, ignore ping heartbeats, and
+// append the event line. The terminal event only flips the readout — the last
+// progress line is already the on-screen finale.
 function handleQueueEvent(raw: string): void {
   const event = parseQueueEvent(raw)
   if (!event || event.type === "ping") return

--- a/src/litestar_queues/_heartbeat.py
+++ b/src/litestar_queues/_heartbeat.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
         ) -> "object": ...
 
 
-__all__ = ("WorkerHeartbeatManager",)
+__all__ = ("SingleTaskBeatSink", "WorkerHeartbeatManager")
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,45 @@ logger = logging.getLogger(__name__)
 class _HeartbeatRegistration:
     expected_retry_count: "int | None"
     consecutive_misses: "int" = 0
+
+
+class SingleTaskBeatSink:
+    """Beat-detail sink for one externally executed task.
+
+    Shares ``record_beat()``'s truncation and last-value-wins semantics with
+    ``WorkerHeartbeatManager`` but never touches the backend itself. The owning
+    heartbeat loop peeks the pending detail before each touch and clears it
+    only once that touch succeeds, so a missed touch keeps the detail for the
+    next attempt instead of losing it.
+    """
+
+    __slots__ = ("_detail", "_task_id")
+
+    def __init__(self, task_id: "UUID") -> "None":
+        self._task_id = task_id
+        self._detail: "str | None" = None
+
+    def record_beat(self, task_id: "str", detail: "str | None") -> "None":
+        """Store the latest progress detail for the bound task.
+
+        Returns:
+            None.
+        """
+        with contextlib.suppress(ValueError):
+            if UUID(task_id) == self._task_id:
+                self._detail = detail[:256] if isinstance(detail, str) else None
+
+    def peek_detail(self) -> "str | None":
+        """Return the currently pending detail without clearing it."""
+        return self._detail
+
+    def clear_detail(self) -> "None":
+        """Clear the pending detail after a successful heartbeat touch.
+
+        Returns:
+            None.
+        """
+        self._detail = None
 
 
 class WorkerHeartbeatManager:

--- a/src/litestar_queues/consumer.py
+++ b/src/litestar_queues/consumer.py
@@ -17,7 +17,9 @@ from importlib import import_module
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
+from litestar_queues._heartbeat import SingleTaskBeatSink
 from litestar_queues.config import QueueConfig
+from litestar_queues.events.context import _bind_beat_sink, _reset_beat_sink
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import HeartbeatTouch
 from litestar_queues.service import QueueService
@@ -141,7 +143,11 @@ async def _resolve_and_consume(
 
 async def _execute_claimed_record(queue: "QueueService", claimed: "QueuedTaskRecord") -> "TaskExitCode":
     expected_retry_count = claimed.retry_count
-    heartbeat_task = asyncio.create_task(_heartbeat_loop(queue, claimed.id, expected_retry_count=expected_retry_count))
+    beat_sink = SingleTaskBeatSink(claimed.id)
+    beat_token = _bind_beat_sink(beat_sink)
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_loop(queue, claimed.id, expected_retry_count=expected_retry_count, beat_sink=beat_sink)
+    )
     execution_task = asyncio.create_task(queue.execute_record(claimed))
     try:
         done, _pending = await asyncio.wait({heartbeat_task, execution_task}, return_when=asyncio.FIRST_COMPLETED)
@@ -158,6 +164,7 @@ async def _execute_claimed_record(queue: "QueueService", claimed: "QueuedTaskRec
         heartbeat_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
+        _reset_beat_sink(beat_token)
         await queue.get_queue_backend().null_heartbeats([claimed.id], expected_retry_count=expected_retry_count)
 
     if updated.status == "completed":
@@ -167,15 +174,23 @@ async def _execute_claimed_record(queue: "QueueService", claimed: "QueuedTaskRec
     return TaskExitCode.FAILURE
 
 
-async def _heartbeat_loop(queue: "QueueService", task_id: "UUID", *, expected_retry_count: "int") -> "bool":
+async def _heartbeat_loop(
+    queue: "QueueService", task_id: "UUID", *, expected_retry_count: "int", beat_sink: "SingleTaskBeatSink"
+) -> "bool":
     interval = queue.config.worker_heartbeat_interval
     while True:
         await asyncio.sleep(interval)
+        detail = beat_sink.peek_detail()
         result = await queue.get_queue_backend().touch_heartbeats([
-            HeartbeatTouch(task_id=task_id, expected_retry_count=expected_retry_count)
+            HeartbeatTouch(
+                task_id=task_id,
+                expected_retry_count=expected_retry_count,
+                metadata_patch={"progress_detail": detail} if detail else None,
+            )
         ])
         if task_id not in result.touched_task_ids:
             return False
+        beat_sink.clear_detail()
 
 
 @contextlib.asynccontextmanager

--- a/src/tests/e2e/test_realtime_browser.py
+++ b/src/tests/e2e/test_realtime_browser.py
@@ -48,9 +48,9 @@ def _frames(page: Any) -> list[str]:
     return [frame for frame in page.evaluate("() => window.__queueE2EFrames ?? []") if isinstance(frame, str)]
 
 
-def _assert_task_event(frames: list[str]) -> None:
+def _assert_custom_event(frames: list[str]) -> None:
     payloads = [json.loads(frame) for frame in frames]
-    assert any(payload.get("type") == "task.event" for payload in payloads), frames
+    assert any(payload.get("type") == "crawl.page_discovered" for payload in payloads), frames
 
 
 def _assert_clean_browser(
@@ -126,7 +126,7 @@ def test_sse_browser_contract(example_server: Any, browser_page: Any, browser_di
     events = _events(page)
     assert "htmx:sseOpen" in events
     assert "htmx:sseBeforeMessage" in events
-    _assert_task_event(_frames(page))
+    _assert_custom_event(_frames(page))
     assert not _ERROR_EVENTS.intersection(events), events
     _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode)
 
@@ -154,7 +154,7 @@ def test_websocket_browser_contract(
     events = _events(page)
     assert "htmx:wsOpen" in events
     assert "htmx:wsBeforeMessage" in events
-    _assert_task_event(_frames(page))
+    _assert_custom_event(_frames(page))
     assert not _ERROR_EVENTS.intersection(events), events
     _assert_clean_browser(browser_diagnostics, server_mode=example_server.mode)
 
@@ -190,7 +190,7 @@ def test_replacing_stream_mount_reconnects_cleanly(
     mount = page.locator("#stream-mount")
     assert mount.get_attribute("data-task-id") == second_task_id
     _wait_for_completion(page)
-    _assert_task_event(_frames(page))
+    _assert_custom_event(_frames(page))
 
     events = _events(page)
     close_event = f"htmx:{event_prefix}Close"

--- a/src/tests/e2e/test_realtime_topology.py
+++ b/src/tests/e2e/test_realtime_topology.py
@@ -9,7 +9,7 @@ import pytest
 from .server_manager import ExampleServer, QueueWorker
 from .test_realtime_browser import (
     _assert_clean_browser,
-    _assert_task_event,
+    _assert_custom_event,
     _events,
     _frames,
     _install_event_collector,
@@ -88,7 +88,7 @@ def test_shared_channels_deliver_from_a_standalone_worker(
                 f"queue keys: {list(client.scan_iter(match=f'{queue_prefix}*'))}"
             )
             raise AssertionError(message) from exc
-        _assert_task_event(_frames(page))
+        _assert_custom_event(_frames(page))
         assert "htmx:sseError" not in _events(page)
         assert "htmx:wsError" not in _events(page)
         _assert_clean_browser(browser_diagnostics, server_mode="production")

--- a/src/tests/integration/execution/cloudrun/test_emulator.py
+++ b/src/tests/integration/execution/cloudrun/test_emulator.py
@@ -21,7 +21,10 @@ from tests.integration.execution.cloudrun.helpers import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from litestar_queues.execution.cloudrun._typing import CloudRunJobsClient
+    from litestar_queues.models import HeartbeatTouch, HeartbeatTouchResult
 
 pytestmark = pytest.mark.anyio
 
@@ -29,6 +32,24 @@ pytestmark = pytest.mark.anyio
 @pytest.fixture(autouse=True)
 def clean_task_registry() -> "None":
     clear_task_registry()
+
+
+class _BeatDetailRecordingBackend(InMemoryQueueBackend):
+    """Records every heartbeat touch and signals once one carries beat detail."""
+
+    __slots__ = ("beat_delivered", "touch_calls")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.touch_calls: "list[tuple[HeartbeatTouch, ...]]" = []
+        self.beat_delivered = asyncio.Event()
+
+    async def touch_heartbeats(self, touches: "Sequence[HeartbeatTouch]") -> "HeartbeatTouchResult":
+        self.touch_calls.append(tuple(touches))
+        result = await super().touch_heartbeats(touches)
+        if any(touch.metadata_patch for touch in touches):
+            self.beat_delivered.set()
+        return result
 
 
 def test_load_task_modules_force_reload_imports_never_imported_module(tmp_path: "Any", monkeypatch: "Any") -> "None":
@@ -149,6 +170,44 @@ async def test_cloudrun_dispatch_env_has_no_legacy_task_fields() -> "None":
         f"LITESTAR_QUEUES_{suffix}" for suffix in ("TASK_DISPATCH", "TASK_NAME", "TASK_ARGS", "TASK_KWARGS")
     }
     assert legacy_names.isdisjoint(env)
+
+
+async def test_cloudrun_dispatch_env_excludes_large_and_sensitive_task_args() -> "None":
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    secret = "super-secret-token-do-not-leak"
+    large_payload = "x" * 10_000
+
+    @task("tasks.remote_sensitive_args")
+    async def remote_sensitive_args(payload: str, token: str) -> str:
+        return f"{payload[:1]}{token[:1]}"
+
+    queue_backend = InMemoryQueueBackend()
+    jobs_client = FakeJobsClient()
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        jobs_client=cast("CloudRunJobsClient", jobs_client),
+    )
+    async with QueueService(
+        QueueConfig(execution_backend="cloudrun"), queue_backend=queue_backend, execution_backend=backend
+    ) as service:
+        result = await service.enqueue(remote_sensitive_args.using(execution_backend="cloudrun"), large_payload, secret)
+        record = result.record
+        assert record is not None
+        await backend.dispatch(service, record)
+
+    request = jobs_client.requests[0]
+    env = env_map(request)
+
+    # Only the record id travels; the live record (fetched by id) stays the
+    # source of truth for args, so neither the task name nor its arguments --
+    # however large or sensitive -- ever reach the Cloud Run Jobs API request.
+    assert set(env) == {"LITESTAR_QUEUES_TASK_ID"}
+    assert task_id_from_request(request) == str(record.id)
+    serialized_request = repr(request)
+    assert secret not in serialized_request
+    assert large_payload not in serialized_request
+    assert remote_sensitive_args.name not in serialized_request
 
 
 async def test_cloudrun_dispatch_env_respects_custom_prefix() -> "None":
@@ -470,6 +529,64 @@ async def test_worker_reconciles_running_external_records() -> "None":
     assert reconciled == 1
     assert stored is not None
     assert stored.status == "failed"
+
+
+async def test_cloudrun_dispatched_task_delivers_beat_detail_through_consumer() -> "None":
+    """A Cloud Run Job container runs the dispatched record through ``consume_one``.
+
+    This exercises the same code path ``litestar queues run-task`` uses inside
+    the job container, proving beat-detail parity with the local worker: a
+    ``beat()`` call made from task code lands in the next heartbeat touch's
+    ``metadata_patch`` without the task ever writing to the backend itself.
+    """
+    from litestar_queues import beat
+    from litestar_queues.consumer import TaskExitCode, consume_one
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    ready = asyncio.Event()
+    release = asyncio.Event()
+
+    @task("tasks.cloudrun_beat_parity")
+    async def cloudrun_beat_parity() -> "str":
+        beat("phase one")
+        ready.set()
+        await release.wait()
+        return "ok"
+
+    queue_backend = _BeatDetailRecordingBackend()
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        jobs_client=cast("CloudRunJobsClient", FakeJobsClient()),
+    )
+    service = QueueService(
+        QueueConfig(execution_backend="cloudrun", worker_heartbeat_interval=0.01),
+        queue_backend=queue_backend,
+        execution_backend=backend,
+    )
+    await service.open()
+    try:
+        result = await service.enqueue(cloudrun_beat_parity.using(execution_backend="cloudrun"))
+        record = result.record
+        assert record is not None
+        await backend.dispatch(service, record)
+
+        # The Cloud Run Job container re-fetches the persisted record by id and
+        # runs it through the generic external-executor consumer.
+        runner = asyncio.create_task(consume_one(service, record.id))
+        await asyncio.wait_for(ready.wait(), timeout=1)
+        await asyncio.wait_for(queue_backend.beat_delivered.wait(), timeout=1)
+        release.set()
+        exit_code = await runner
+        stored = await queue_backend.get_task(record.id)
+    finally:
+        await service.close()
+
+    delivered = [touch.metadata_patch for calls in queue_backend.touch_calls for touch in calls if touch.metadata_patch]
+    assert exit_code == TaskExitCode.SUCCESS
+    assert delivered == [{"progress_detail": "phase one"}]
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.metadata["progress_detail"] == "phase one"
 
 
 def test_cloudrun_factory_registration_and_import_boundary() -> "None":

--- a/src/tests/unit/examples/test_htmx_realtime_example.py
+++ b/src/tests/unit/examples/test_htmx_realtime_example.py
@@ -136,6 +136,16 @@ def test_htmx_realtime_examples_keep_simple_queue_and_vite_config() -> None:
         assert "MISSION_CONTROL" not in app_source
         assert "publish_mission_control" not in app_source
 
+        # Heartbeat timestamps are automatic and interval-driven; the canonical
+        # task never calls ctx.beat() or duplicates progress through a generic
+        # "task.event". A single demonstrative domain event is allowed only at
+        # one real transition, and the task does not publish its own "finished"
+        # log/event -- completion is automatic (task.completed).
+        assert "ctx.beat(" not in app_source
+        assert 'ctx.event("task.event"' not in app_source
+        assert "crawl.page_discovered" in app_source
+        assert app_source.count("publish_task_log(") == 1
+
         for marker in config["backend_markers"]:
             assert marker in app_source
 

--- a/src/tests/unit/test_consumer.py
+++ b/src/tests/unit/test_consumer.py
@@ -43,6 +43,42 @@ class _RecordingHeartbeatBackend(InMemoryQueueBackend):
         return await super().touch_heartbeats(touches)
 
 
+class _BeatDetailRecordingBackend(InMemoryQueueBackend):
+    """Records every heartbeat touch and signals once one carries beat detail."""
+
+    __slots__ = ("beat_delivered", "touch_calls")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.touch_calls: "list[tuple[HeartbeatTouch, ...]]" = []
+        self.beat_delivered = asyncio.Event()
+
+    async def touch_heartbeats(self, touches: "Sequence[HeartbeatTouch]") -> "HeartbeatTouchResult":
+        self.touch_calls.append(tuple(touches))
+        result = await super().touch_heartbeats(touches)
+        if any(touch.metadata_patch for touch in touches):
+            self.beat_delivered.set()
+        return result
+
+
+class _MultiTouchRecordingBackend(InMemoryQueueBackend):
+    """Records heartbeat touches and signals once at least ``required`` occurred."""
+
+    __slots__ = ("_required", "enough_touches", "touch_calls")
+
+    def __init__(self, *, required: "int") -> "None":
+        super().__init__()
+        self.touch_calls: "list[tuple[HeartbeatTouch, ...]]" = []
+        self.enough_touches = asyncio.Event()
+        self._required = required
+
+    async def touch_heartbeats(self, touches: "Sequence[HeartbeatTouch]") -> "HeartbeatTouchResult":
+        self.touch_calls.append(tuple(touches))
+        if len(self.touch_calls) >= self._required:
+            self.enough_touches.set()
+        return await super().touch_heartbeats(touches)
+
+
 async def test_consume_one_claims_and_executes_persisted_record() -> "None":
     from litestar_queues import QueueConfig, QueueService, task
     from litestar_queues.consumer import TaskExitCode, consume_one
@@ -165,3 +201,137 @@ async def test_run_task_missing_and_invalid_task_id() -> "None":
 
     assert missing == TaskExitCode.MISSING_TASK_ID
     assert invalid == TaskExitCode.INVALID_TASK_ID
+
+
+async def test_consume_one_delivers_beat_detail_on_next_heartbeat_touch() -> "None":
+    from litestar_queues import QueueConfig, QueueService, beat, task
+    from litestar_queues.consumer import TaskExitCode, consume_one
+
+    ready = asyncio.Event()
+    release = asyncio.Event()
+
+    @task("tasks.consumer_beat_detail")
+    async def consumer_beat_detail() -> "str":
+        beat("phase one")
+        ready.set()
+        await release.wait()
+        return "ok"
+
+    queue_backend = _BeatDetailRecordingBackend()
+    async with QueueService(
+        QueueConfig(execution_backend="cloudrun", worker_heartbeat_interval=0.01), queue_backend=queue_backend
+    ) as service:
+        result = await service.enqueue(consumer_beat_detail.using(execution_backend="cloudrun"))
+        record = await queue_backend.get_task(result.id)
+        assert record is not None
+        runner = asyncio.create_task(consume_one(service, record.id))
+        await asyncio.wait_for(ready.wait(), timeout=1)
+        await asyncio.wait_for(queue_backend.beat_delivered.wait(), timeout=1)
+        release.set()
+        exit_code = await runner
+        stored = await queue_backend.get_task(result.id)
+
+    delivered = [touch.metadata_patch for calls in queue_backend.touch_calls for touch in calls if touch.metadata_patch]
+    assert exit_code == TaskExitCode.SUCCESS
+    assert delivered == [{"progress_detail": "phase one"}]
+    assert stored is not None
+    assert stored.status == "completed"
+
+
+async def test_consume_one_beat_detail_is_last_value_wins_and_capped_at_256() -> "None":
+    from litestar_queues import QueueConfig, QueueService, beat, task
+    from litestar_queues.consumer import TaskExitCode, consume_one
+
+    ready = asyncio.Event()
+    release = asyncio.Event()
+
+    @task("tasks.consumer_beat_overwrite")
+    async def consumer_beat_overwrite() -> "str":
+        beat("row 1")
+        beat("x" * 500)
+        ready.set()
+        await release.wait()
+        return "ok"
+
+    queue_backend = _BeatDetailRecordingBackend()
+    async with QueueService(
+        QueueConfig(execution_backend="cloudrun", worker_heartbeat_interval=0.01), queue_backend=queue_backend
+    ) as service:
+        result = await service.enqueue(consumer_beat_overwrite.using(execution_backend="cloudrun"))
+        record = await queue_backend.get_task(result.id)
+        assert record is not None
+        runner = asyncio.create_task(consume_one(service, record.id))
+        await asyncio.wait_for(ready.wait(), timeout=1)
+        await asyncio.wait_for(queue_backend.beat_delivered.wait(), timeout=1)
+        release.set()
+        exit_code = await runner
+
+    delivered = [touch.metadata_patch for calls in queue_backend.touch_calls for touch in calls if touch.metadata_patch]
+    assert exit_code == TaskExitCode.SUCCESS
+    assert delivered == [{"progress_detail": "x" * 256}]
+
+
+async def test_consume_one_clears_beat_detail_after_successful_touch() -> "None":
+    from litestar_queues import QueueConfig, QueueService, beat, task
+    from litestar_queues.consumer import TaskExitCode, consume_one
+
+    ready = asyncio.Event()
+    release = asyncio.Event()
+
+    @task("tasks.consumer_beat_clear")
+    async def consumer_beat_clear() -> "str":
+        beat("only once")
+        ready.set()
+        await release.wait()
+        return "ok"
+
+    queue_backend = _MultiTouchRecordingBackend(required=2)
+    async with QueueService(
+        QueueConfig(execution_backend="cloudrun", worker_heartbeat_interval=0.01), queue_backend=queue_backend
+    ) as service:
+        result = await service.enqueue(consumer_beat_clear.using(execution_backend="cloudrun"))
+        record = await queue_backend.get_task(result.id)
+        assert record is not None
+        runner = asyncio.create_task(consume_one(service, record.id))
+        await asyncio.wait_for(ready.wait(), timeout=1)
+        await asyncio.wait_for(queue_backend.enough_touches.wait(), timeout=1)
+        release.set()
+        exit_code = await runner
+
+    assert exit_code == TaskExitCode.SUCCESS
+    assert queue_backend.touch_calls[0][0].metadata_patch == {"progress_detail": "only once"}
+    assert queue_backend.touch_calls[1][0].metadata_patch is None
+
+
+async def test_consume_one_without_beat_calls_stays_healthy_across_intervals() -> "None":
+    from litestar_queues import QueueConfig, QueueService, task
+    from litestar_queues.consumer import TaskExitCode, consume_one
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @task("tasks.consumer_no_beat")
+    async def consumer_no_beat() -> "str":
+        started.set()
+        await release.wait()
+        return "ok"
+
+    queue_backend = _MultiTouchRecordingBackend(required=3)
+    async with QueueService(
+        QueueConfig(execution_backend="cloudrun", worker_heartbeat_interval=0.01), queue_backend=queue_backend
+    ) as service:
+        result = await service.enqueue(consumer_no_beat.using(execution_backend="cloudrun"))
+        record = await queue_backend.get_task(result.id)
+        assert record is not None
+        runner = asyncio.create_task(consume_one(service, record.id))
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await asyncio.wait_for(queue_backend.enough_touches.wait(), timeout=1)
+        release.set()
+        exit_code = await runner
+        stored = await queue_backend.get_task(result.id)
+
+    assert exit_code == TaskExitCode.SUCCESS
+    assert len(queue_backend.touch_calls) >= 3
+    assert all(touch.metadata_patch is None for calls in queue_backend.touch_calls for touch in calls)
+    assert stored is not None
+    assert stored.status == "completed"


### PR DESCRIPTION
## Summary

Externally executed (Cloud Run) tasks now report heartbeat detail the same way in-process workers do, and the realtime examples are trimmed down to one clear pattern.

## What changed

- **Heartbeat parity for external tasks** — a single-task heartbeat sink reuses the same truncation / last-value-wins behavior as the in-process worker, with no extra database writes. Timestamp heartbeats stay fully automatic; `beat()` / `progress()` never hit the backend directly. Detail from a missed heartbeat is kept for the next tick.
- **Simpler realtime examples** — every SSE/WebSocket example (all 10 variants) now emits one `progress()` per step and one domain event (`crawl.page_discovered`), instead of duplicating generic events and a manual "finished" log. Completion is left to the automatic `task.completed` event.
- **SSE fix** — the examples' `sse-swap` allowlist now lists `crawl.page_discovered`; it previously still named the removed `task.event`, so that event wouldn't render in the browser.
