### PR TITLE
feat(sqlspec): default native worker wakeups on for capable adapters

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -25,7 +25,7 @@ events to users.
    * - SQLSpec application
      - ``SQLSpecBackendConfig``
      - ``local`` or Cloud Run
-     - SQLSpec transport when supported, otherwise polling
+     - Native transport by default when supported, otherwise polling
      - Configure Channels separately
      - :doc:`backends/sqlspec`
    * - SQLAlchemy application

--- a/docs/usage/backends/sqlspec.rst
+++ b/docs/usage/backends/sqlspec.rst
@@ -82,14 +82,47 @@ Schema-qualified names keep their schema and add the suffix to the table part.
 Wakeups
 -------
 
-Set ``notifications`` and ``notify_transport`` only for a SQLSpec transport
-supported by the selected adapter. ``notification_channel`` defaults to
-``litestar_queues_tasks``. Canonical PostgreSQL-family choices are ``notify``
-(ephemeral broadcast hint), ``notify_queue`` (durable notify-assisted queue),
-and ``poll_queue`` (durable polled queue). ``polling`` disables push wakeups;
-Oracle can use explicitly provisioned ``aq`` or ``txeventq``. Durable queue
-transports are competing-consumer queues; do not use them as multi-process
-browser fan-out. See :doc:`../worker-wakeups`.
+Native worker wakeups are **on by default whenever the adapter can push them**.
+A bare ``SQLSpecBackendConfig`` needs no notification settings: the backend
+selects each adapter's best wakeup transport from a capability gate and
+provisions everything it needs.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Adapter
+     - Default transport
+     - Wakeup mechanism
+   * - asyncpg, psycopg, psqlpy
+     - ``notify_queue``
+     - Durable events queue table + PostgreSQL ``LISTEN``/``NOTIFY`` push
+   * - DuckDB
+     - ``poll_queue``
+     - Durable events queue table, polled in-process (embedded, no LISTEN/NOTIFY)
+   * - SQLite, MySQL, CockroachDB, SQL Server, Spanner, Oracle
+     - ``polling``
+     - Interval polling (no push transport available by default)
+
+The durable ``notify_queue`` and ``poll_queue`` transports ride a SQLSpec events
+queue table (``sqlspec_event_queue`` by default). It is provisioned the same way
+as the queue table: the packaged migration path registers SQLSpec's events
+migration for capable adapters automatically, and the ``create_schema()``
+bootstrap emits its DDL directly. A zero-config capable backend therefore works
+on a fresh database with no manual step. ``event_queue_table`` overrides the
+table name.
+
+To turn native wakeups off and fall back to interval polling, set
+``notifications=False``. Setting ``notifications=True`` on an adapter that has no
+push transport degrades to polling rather than forcing an unsupported one.
+
+Overrides remain available for advanced setups: ``notify_transport`` pins a
+specific SQLSpec transport, ``notification_channel`` sets the LISTEN/NOTIFY
+channel (default ``litestar_queues_tasks``), and Oracle can opt in to explicitly
+provisioned ``aq`` or ``txeventq`` queues. Oracle stays on polling by default
+because Advanced Queuing requires provisioning that the backend does not create.
+Durable queue transports are competing-consumer queues; do not use them as
+multi-process browser fan-out. See :doc:`../worker-wakeups`.
 
 Heartbeat isolation
 ===================

--- a/docs/usage/worker-wakeups.rst
+++ b/docs/usage/worker-wakeups.rst
@@ -18,10 +18,12 @@ support simply implement the timeout as polling.
 Hints, not state
 ================
 
-Redis and Valkey use pub/sub hints. SQLSpec can use a configured SQLSpec event
-transport. Advanced Alchemy can use PostgreSQL notification hints when enabled.
-The message only tells the worker to check. The saved task record has the real
-state.
+Redis and Valkey use pub/sub hints. SQLSpec turns on its best native wakeup
+transport automatically for any capable adapter (PostgreSQL ``LISTEN``/``NOTIFY``
+for asyncpg, psycopg, and psqlpy; a durable in-process queue for DuckDB) and
+falls back to polling elsewhere. Advanced Alchemy can use PostgreSQL
+notification hints when enabled. The message only tells the worker to check. The
+saved task record has the real state.
 
 Notifications may arrive late or not at all. The worker stays correct by
 checking the saved task state. Do not set the poll interval higher than the

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -71,11 +71,15 @@ _QUEUE_SETTING_EVENT_SETTINGS = ("event_settings", "events")
 _NOTIFY_TRANSPORT_POLLING = "polling"
 _CANONICAL_EVENT_BACKENDS = frozenset({"aq", "notify", "notify_queue", "poll_queue", "txeventq"})
 _CANONICAL_NOTIFY_TRANSPORTS = _CANONICAL_EVENT_BACKENDS | {_NOTIFY_TRANSPORT_POLLING}
-# Adapter families that can push worker wakeups. Postgres-over-asyncpg ships the
-# durable LISTEN/NOTIFY hybrid; psycopg/psqlpy and DuckDB use the durable table
-# queue. Everything else polls.
-_NOTIFY_DURABLE_ADAPTERS = frozenset({"asyncpg"})
-_NOTIFY_TABLE_QUEUE_ADAPTERS = frozenset({"duckdb", "psycopg", "psqlpy"})
+# Adapter families that can push worker wakeups. Every real Postgres driver
+# (asyncpg, psycopg, psqlpy) ships SQLSpec's durable LISTEN/NOTIFY hybrid, so all
+# three advertise ``notify_queue``. DuckDB is embedded with no LISTEN/NOTIFY, so
+# it uses the durable table queue polled in-process. Everything else polls.
+_NOTIFY_DURABLE_ADAPTERS = frozenset({"asyncpg", "psycopg", "psqlpy"})
+_NOTIFY_TABLE_QUEUE_ADAPTERS = frozenset({"duckdb"})
+# Durable event transports that ride the SQLSpec events queue table and must have
+# it provisioned before a worker can publish or consume wakeups.
+_EVENTS_TABLE_BACKENDS = frozenset({"notify_queue", "poll_queue"})
 # psqlpy's ``QueryResult`` exposes no command-tag/status metadata and
 # arrow-odbc's cursor exposes no portable rowcount API, so SQLSpec's
 # rows-affected extraction can only ever report ``0`` for non-SELECT
@@ -106,8 +110,8 @@ def _adapter_notify_transport(adapter_name: "str | None") -> "str":
     advertise push wakeups where the driver can deliver them.
 
     Returns:
-        ``"notify_queue"`` for asyncpg, ``"poll_queue"`` for DuckDB,
-        psycopg, and psqlpy, otherwise ``"polling"``.
+        ``"notify_queue"`` for the Postgres drivers (asyncpg, psycopg, psqlpy),
+        ``"poll_queue"`` for DuckDB, otherwise ``"polling"``.
     """
     if adapter_name in _NOTIFY_DURABLE_ADAPTERS:
         return "notify_queue"
@@ -293,6 +297,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 event_log_store = self._get_event_log_store_if_enabled()
                 if event_log_store is not None:
                     statements.extend(event_log_store.create_statements())
+                if self._should_provision_events_queue():
+                    statements.extend(_events_queue_create_statements(self._get_sqlspec_config()))
                 for statement in statements:
                     await driver.execute_script(statement)
                 await driver.commit()
@@ -1224,9 +1230,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         notifications_requested = self._resolve_notifications_requested(queue_settings)
         transport = self._select_notify_transport(sqlspec_config, queue_settings, events_settings)
 
-        if not self._notifications_should_enable(
-            notifications_requested, transport, sqlspec_config, queue_settings, events_settings
-        ):
+        if not self._notifications_should_enable(notifications_requested, transport):
             self._notifications_enabled = False
             self._notification_backend = None
             return
@@ -1243,6 +1247,20 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             self._resolve_event_poll_interval(queue_settings, events_settings)
         self._notification_backend = _canonical_notify_transport(
             cast("str | None", getattr(self._event_channel, "_backend_name", None))
+        )
+
+    def _should_provision_events_queue(self) -> "bool":
+        """Return whether ``create_schema`` should provision the events queue table.
+
+        Only the durable table-backed transports (``notify_queue`` / ``poll_queue``)
+        that this backend owns ride the SQLSpec events queue table. An injected
+        event channel owns its own storage, and the transient/native-only or
+        Oracle AQ transports never use this table.
+        """
+        return (
+            self._notifications_enabled
+            and self._owns_event_channel
+            and self._notification_backend in _EVENTS_TABLE_BACKENDS
         )
 
     def _resolve_notifications_requested(self, queue_settings: "dict[str, Any]") -> "bool | None":
@@ -1264,33 +1282,24 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             A canonical wakeup transport name (``notify``, ``notify_queue``,
             ``poll_queue``, ``polling``, ``aq``, or ``txeventq``).
         """
-        explicit = self._notify_transport
-        if explicit is not None:
-            return explicit
-        configured_transport = _setting(queue_settings, "notify_transport")
-        if configured_transport is not None:
-            return _validate_queue_notify_transport(str(configured_transport))
-        configured_backend = (
-            self._event_backend or _setting(queue_settings, "event_backend") or events_settings.get("backend")
+        return _resolve_notify_transport(
+            explicit_transport=self._notify_transport,
+            event_backend=self._event_backend,
+            sqlspec_config=sqlspec_config,
+            queue_settings=queue_settings,
+            events_settings=events_settings,
         )
-        if configured_backend is not None:
-            return _validate_queue_notify_transport(str(configured_backend))
-        return _adapter_notify_transport(resolve_adapter_name(sqlspec_config))
 
-    def _notifications_should_enable(
-        self,
-        notifications_requested: "bool | None",
-        transport: "str",
-        sqlspec_config: "SQLSpecConfig",
-        queue_settings: "dict[str, Any]",
-        events_settings: "dict[str, Any]",
-    ) -> "bool":
+    def _notifications_should_enable(self, notifications_requested: "bool | None", transport: "str") -> "bool":
         """Decide whether push wakeups are active for the resolved transport.
 
-        Notifications stay opt-in: a bare backend config never auto-enables an
-        events channel (which keeps the frozen claim/lease contract and the
-        zero-config polling default intact). When a signal is present but the
-        adapter is gated to ``polling``, wakeups degrade to interval polling.
+        Native wakeups are default-on: whenever the resolved transport is
+        capability-native (anything other than ``polling``) an events channel
+        backs worker wakeups with no configuration. ``notifications=False`` is
+        the explicit opt-out, and a capability-gated ``polling`` transport (an
+        adapter that cannot push, with no explicit override) stays on interval
+        polling. Notifications only add wakeups; the frozen claim/lease contract
+        is unaffected.
 
         Returns:
             True when an events channel should back worker wakeups.
@@ -1299,17 +1308,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             return False
         if self._event_channel is not None:
             return True
-        events_present = _EVENT_EXTENSION_NAME in (sqlspec_config.extension_config or {})
-        explicit_signal = (
-            self._notify_transport is not None
-            or "notify_transport" in queue_settings
-            or self._event_backend is not None
-            or "event_backend" in queue_settings
-            or bool(events_settings)
-            or events_present
-            or notifications_requested is True
-        )
-        return explicit_signal and transport != _NOTIFY_TRANSPORT_POLLING
+        return transport != _NOTIFY_TRANSPORT_POLLING
 
     def _resolve_event_poll_interval(
         self, queue_settings: "dict[str, Any]", events_settings: "dict[str, Any]"
@@ -2009,6 +2008,88 @@ async def _create_schema_statements(store: "SQLSpecQueueStore", driver: "SQLSpec
             return cast("list[str]", await result)
         return cast("list[str]", result)
     return store.create_statements()
+
+
+def _resolve_notify_transport(
+    *,
+    explicit_transport: "str | None",
+    event_backend: "str | None",
+    sqlspec_config: "SQLSpecConfig",
+    queue_settings: "dict[str, Any]",
+    events_settings: "dict[str, Any]",
+) -> "str":
+    """Resolve the effective wakeup transport from config precedence.
+
+    Explicit ``queue_backend_config`` selections win over ``extension_config``
+    defaults, which in turn win over the per-adapter capability gate.
+
+    Returns:
+        A canonical wakeup transport name.
+    """
+    if explicit_transport is not None:
+        return explicit_transport
+    configured_transport = _setting(queue_settings, "notify_transport")
+    if configured_transport is not None:
+        return _validate_queue_notify_transport(str(configured_transport))
+    configured_backend = event_backend or _setting(queue_settings, "event_backend") or events_settings.get("backend")
+    if configured_backend is not None:
+        return _validate_queue_notify_transport(str(configured_backend))
+    return _adapter_notify_transport(resolve_adapter_name(sqlspec_config))
+
+
+def resolve_events_migration_backend(
+    backend_config: "SQLSpecBackendConfig", sqlspec_config: "SQLSpecConfig"
+) -> "str | None":
+    """Return the durable events-table transport to register for migrations.
+
+    Mirrors the runtime notification decision so a capability-native adapter
+    provisions its events queue table through SQLSpec migrations with zero
+    configuration. Returns the transport name (``notify_queue`` / ``poll_queue``)
+    when the events queue table must exist, or ``None`` when notifications are
+    opted out, transient (``notify``), Oracle AQ (provisioned separately), or the
+    adapter polls.
+
+    Returns:
+        The durable events-table transport name, or ``None``.
+    """
+    if backend_config.notifications is False or backend_config.event_channel is not None:
+        return None
+    queue_settings = _queue_extension_settings(sqlspec_config)
+    if (
+        backend_config.notifications is None
+        and "notifications" in queue_settings
+        and not queue_settings["notifications"]
+    ):
+        return None
+    transport = _resolve_notify_transport(
+        explicit_transport=backend_config.notify_transport,
+        event_backend=backend_config.event_backend,
+        sqlspec_config=sqlspec_config,
+        queue_settings=queue_settings,
+        events_settings=_events_extension_settings(sqlspec_config),
+    )
+    return transport if transport in _EVENTS_TABLE_BACKENDS else None
+
+
+def _events_queue_create_statements(sqlspec_config: "SQLSpecConfig") -> "list[str]":
+    """Return the DDL provisioning the durable events queue table for this adapter.
+
+    Resolves the adapter's :class:`~sqlspec.extensions.events.BaseEventQueueStore`
+    the same way SQLSpec's events extension migration does and returns its
+    dialect-correct ``CREATE TABLE``/``CREATE INDEX`` statements. Emitting these
+    alongside the queue table makes the durable ``notify_queue`` / ``poll_queue``
+    wakeup transports work on a fresh database with no separate migration step.
+
+    Returns:
+        The ``CREATE`` statements for the events queue table and its index.
+    """
+    from sqlspec.utils.module_loader import import_string
+
+    config_class = type(sqlspec_config)
+    adapter_name = config_class.__module__.split(".")[2]
+    store_class_name = config_class.__name__.replace("Config", "EventQueueStore")
+    store_class = import_string(f"sqlspec.adapters.{adapter_name}.events.store.{store_class_name}")
+    return cast("list[str]", store_class(sqlspec_config).create_statements())
 
 
 def _events_extension_settings(sqlspec_config: "SQLSpecStoreConfig | None") -> "dict[str, Any]":

--- a/src/litestar_queues/backends/sqlspec/extension.py
+++ b/src/litestar_queues/backends/sqlspec/extension.py
@@ -14,9 +14,35 @@ if TYPE_CHECKING:
 
     from litestar_queues.backends.sqlspec._typing import SQLSpecConfig
 
-__all__ = ("QUEUE_EXTENSION_NAME", "configure_queue_migration_extension", "queue_migration_directory")
+__all__ = (
+    "QUEUE_EXTENSION_NAME",
+    "configure_events_migration_extension",
+    "configure_queue_migration_extension",
+    "queue_migration_directory",
+)
 
 QUEUE_EXTENSION_NAME = "litestar_queues"
+_EVENTS_EXTENSION_NAME = "events"
+
+
+def configure_events_migration_extension(
+    sqlspec_config: "SQLSpecConfig", *, backend: "str", queue_table: "str | None" = None
+) -> "None":
+    """Register SQLSpec's events queue migration for native wakeup provisioning.
+
+    Writing the events extension settings makes SQLSpec auto-include its bundled
+    events queue migration on migrate-up, so a capability-native backend gets its
+    durable events queue table with no manual step. Existing events settings are
+    preserved; only unset keys are filled in.
+    """
+    extension_config = dict(sqlspec_config.extension_config or {})
+    events_settings = dict(extension_config.get(_EVENTS_EXTENSION_NAME, {}) or {})
+    events_settings.setdefault("backend", backend)
+    if queue_table is not None:
+        events_settings.setdefault("queue_table", queue_table)
+    extension_config[_EVENTS_EXTENSION_NAME] = events_settings
+    sqlspec_config.extension_config = extension_config
+    sqlspec_config.set_migration_config(dict(sqlspec_config.migration_config or {}))
 
 
 def queue_migration_directory() -> "Path":

--- a/src/litestar_queues/plugin.py
+++ b/src/litestar_queues/plugin.py
@@ -92,8 +92,24 @@ class QueuePlugin(InitPlugin):
         if sqlspec_config is None:
             return
 
-        from litestar_queues.backends.sqlspec import configure_queue_migration_extension
+        from litestar_queues.backends.sqlspec.backend import resolve_events_migration_backend
+        from litestar_queues.backends.sqlspec.extension import (
+            configure_events_migration_extension,
+            configure_queue_migration_extension,
+        )
         from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME
+
+        # Register the durable events queue migration first: a capability-native
+        # adapter (asyncpg/psycopg/psqlpy notify_queue, DuckDB poll_queue) needs
+        # its events table provisioned on migrate-up so zero-config native wakeups
+        # work on a fresh database.
+        events_backend = resolve_events_migration_backend(backend_config, cast("SQLSpecConfig", sqlspec_config))
+        if events_backend is not None:
+            configure_events_migration_extension(
+                cast("SQLSpecConfig", sqlspec_config),
+                backend=events_backend,
+                queue_table=backend_config.event_queue_table,
+            )
 
         extension_config = sqlspec_config.extension_config or {}
         queue_settings = dict(extension_config.get("litestar_queues", {}) or {})

--- a/src/tests/integration/backends/sqlspec/test_notifications.py
+++ b/src/tests/integration/backends/sqlspec/test_notifications.py
@@ -30,7 +30,6 @@ from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueB
 from litestar_queues.backends.sqlspec.backend import _adapter_notify_transport
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.exceptions import QueueConfigurationError
-from tests.integration.backends.sqlspec._schema import run_queue_migrations
 from tests.integration.backends.sqlspec.conftest import StubAsyncEventChannel
 
 if TYPE_CHECKING:
@@ -463,7 +462,6 @@ async def test_sqlspec_backend_derives_sqlspec_event_channel_from_config(tmp_pat
 
     await backend.open()
     await backend.create_schema()
-    await run_queue_migrations(sqlspec_config)
     try:
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=1))
         await backend.enqueue("tasks.derived_notified")
@@ -532,12 +530,83 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
     assert QUEUE_EXTENSION_NAME in sqlspec_config.get_migration_commands().extension_configs
 
 
+def test_queue_plugin_registers_events_migration_for_capable_adapter() -> "None":
+    """A capability-native adapter auto-registers SQLSpec's events queue migration.
+
+    Registering the events extension makes SQLSpec provision the durable events
+    queue table on migrate-up, so a zero-config native-wakeup backend works on a
+    fresh database with no manual step. Incapable adapters register nothing.
+    """
+    from click import Group
+
+    pytest.importorskip("asyncpg")
+    from sqlspec.adapters.asyncpg import AsyncpgConfig
+
+    capable_config = AsyncpgConfig(
+        connection_config={"host": "localhost", "port": 5432, "user": "u", "password": "p", "database": "d"}
+    )
+    QueuePlugin(
+        QueueConfig(queue_backend=SQLSpecBackendConfig(config=capable_config), initialize_schedules=False)
+    ).on_cli_init(Group())
+    assert (capable_config.extension_config or {}).get("events") == {"backend": "notify_queue"}
+    assert "events" in capable_config.migration_config.get("include_extensions", [])
+
+    polling_config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    QueuePlugin(
+        QueueConfig(queue_backend=SQLSpecBackendConfig(config=polling_config), initialize_schedules=False)
+    ).on_cli_init(Group())
+    assert "events" not in (polling_config.extension_config or {})
+
+
+async def test_sqlspec_backend_migration_path_provisions_events_table(postgres_service: "PostgresService") -> "None":
+    """The plugin's migration registration provisions the events table for native wakeups.
+
+    Runs the SQLSpec migration path only (no ``create_schema``): the plugin
+    registers both the queue and the durable events queue migration, ``migrate_up``
+    creates both tables, and a bare asyncpg backend then wakes via NOTIFY on a
+    fresh database. Uses the default table names, which the queue migration
+    provisions.
+    """
+    from click import Group
+
+    from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME
+
+    pytest.importorskip("asyncpg")
+
+    # Start from a clean slate: another test or run may share this database.
+    cleanup_backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(config=_postgres_config("asyncpg", postgres_service))
+    )
+    await cleanup_backend.open()
+    await _drop_postgres_tables(cleanup_backend, DEFAULT_TABLE_NAME, "ddl_migrations")
+
+    sqlspec_config = _postgres_config("asyncpg", postgres_service)
+    backend_config = SQLSpecBackendConfig(config=sqlspec_config)
+    QueuePlugin(QueueConfig(queue_backend=backend_config, initialize_schedules=False)).on_cli_init(Group())
+    await sqlspec_config.migrate_up(echo=False)
+
+    backend = SQLSpecQueueBackend(backend_config=backend_config)
+    await backend.open()
+    # No create_schema: the migration path already provisioned both tables.
+    try:
+        assert backend.capabilities.notification_backend == "notify_queue"
+
+        waiter = asyncio.create_task(backend.wait_for_notifications(timeout=5))
+        await asyncio.sleep(0.3)
+        start = time.monotonic()
+        await backend.enqueue("tasks.migrate_wake")
+        assert await waiter is True
+        assert time.monotonic() - start < 0.9
+    finally:
+        await _drop_postgres_tables(backend, DEFAULT_TABLE_NAME, "ddl_migrations")
+
+
 @pytest.mark.parametrize(
     ("adapter_name", "expected_transport"),
     [
         ("asyncpg", "notify_queue"),
-        ("psycopg", "poll_queue"),
-        ("psqlpy", "poll_queue"),
+        ("psycopg", "notify_queue"),
+        ("psqlpy", "notify_queue"),
         ("cockroach_asyncpg", "polling"),
         ("cockroach_psycopg", "polling"),
         ("aiosqlite", "polling"),
@@ -554,10 +623,36 @@ async def test_sqlspec_backend_uses_user_registered_litestar_sqlspec_plugin(
 def test_adapter_notify_transport_capability_gate(adapter_name: "str | None", expected_transport: "str") -> "None":
     """The wakeup transport is gated by adapter knowledge.
 
-    Postgres-over-asyncpg gets ``notify_queue``; DuckDB, psycopg, and psqlpy
-    use ``poll_queue``; every other family reports ``polling``.
+    Every real Postgres driver (asyncpg, psycopg, psqlpy) gets the durable native
+    ``notify_queue`` LISTEN/NOTIFY hybrid; DuckDB uses the in-process durable
+    ``poll_queue``; every other family reports ``polling``.
     """
     assert _adapter_notify_transport(adapter_name) == expected_transport
+
+
+@pytest.mark.parametrize(
+    ("notifications_requested", "transport", "expected"),
+    [
+        # Default (None): on whenever the resolved transport is capability-native.
+        (None, "notify_queue", True),
+        (None, "poll_queue", True),
+        (None, "polling", False),
+        # Explicit opt-out is preserved even on a capable transport.
+        (False, "notify_queue", False),
+        (False, "polling", False),
+        # Explicit opt-in enables when capable and degrades to polling otherwise.
+        (True, "notify_queue", True),
+        (True, "polling", False),
+    ],
+)
+def test_notifications_should_enable_matrix(
+    tmp_path: "Path", notifications_requested: "bool | None", transport: "str", expected: "bool"
+) -> "None":
+    """Native wakeups are default-on when capable; ``False`` opts out; polling stays polling."""
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(config=AiosqliteConfig(connection_config={"database": ":memory:"}))
+    )
+    assert backend._notifications_should_enable(notifications_requested, transport) is expected
 
 
 def test_notify_transport_config_rejects_unknown_value() -> "None":
@@ -726,7 +821,6 @@ async def test_sqlspec_backend_notify_transport_override_enables_poll_queue(tmp_
 
     await backend.open()
     await backend.create_schema()
-    await run_queue_migrations(sqlspec_config)
     try:
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == "poll_queue"
@@ -740,23 +834,20 @@ async def test_sqlspec_backend_notify_transport_override_enables_poll_queue(tmp_
 
 
 async def test_sqlspec_backend_duckdb_defaults_to_poll_queue(tmp_path: "Path") -> "None":
-    """DuckDB uses SQLSpec's durable table-backed event transport when requested."""
+    """A bare DuckDB config gets the durable ``poll_queue`` transport with zero config.
+
+    DuckDB is embedded with no LISTEN/NOTIFY, so its capability-native default is
+    the in-process durable table queue. ``create_schema`` alone provisions the
+    events queue table, so no manual migration is needed.
+    """
     pytest.importorskip("duckdb")
     from sqlspec.adapters.duckdb import DuckDBConfig
 
     sqlspec_config = DuckDBConfig(connection_config={"database": str(tmp_path / "duckdb-poll-queue.db")})
-    backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(
-            config=sqlspec_config,
-            notifications=True,
-            notification_channel="duckdb_poll_queue",
-            event_poll_interval=0.01,
-        )
-    )
+    backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(config=sqlspec_config, event_poll_interval=0.01))
 
     await backend.open()
     await backend.create_schema()
-    await run_queue_migrations(sqlspec_config)
     try:
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == "poll_queue"
@@ -791,7 +882,12 @@ async def test_sqlspec_backend_notify_transport_polling_overrides_extension_conf
 async def test_sqlspec_backend_postgres_notify_queue_wakes(
     postgres_service: "PostgresService", tmp_path: "Path"
 ) -> "None":
-    """Postgres workers wake via NOTIFY with a durable fallback, no missed bursts."""
+    """A bare asyncpg config wakes via NOTIFY with a durable fallback, no missed bursts.
+
+    No notification settings and no manual migration step: ``create_schema`` alone
+    provisions the events queue table and native ``notify_queue`` wakeups are on by
+    default because asyncpg is capability-native.
+    """
     pytest.importorskip("asyncpg")
     from sqlspec.adapters.asyncpg import AsyncpgConfig
 
@@ -805,18 +901,11 @@ async def test_sqlspec_backend_postgres_notify_queue_wakes(
         }
     )
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(
-            config=sqlspec_config,
-            queue_table_name="lq_notify_asyncpg",
-            notifications=True,
-            notification_channel="lq_asyncpg_wake",
-            event_poll_interval=0.05,
-        )
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, queue_table_name="lq_notify_asyncpg")
     )
 
     await backend.open()
     await backend.create_schema()
-    await run_queue_migrations(sqlspec_config, queue_table_name="lq_notify_asyncpg")
     try:
         assert backend.capabilities.supports_notifications is True
         assert backend.capabilities.notification_backend == "notify_queue"
@@ -845,26 +934,31 @@ async def test_sqlspec_backend_postgres_notify_queue_wakes(
             async with _bridge_session(
                 cast("SQLSpecManager", backend._sqlspec), cast("SQLSpecSessionConfig", backend._sqlspec_config)
             ) as driver:
-                for ddl in (
-                    'DROP TABLE IF EXISTS "lq_notify_asyncpg"',
-                    'DROP TABLE IF EXISTS "sqlspec_async_events"',
-                    'DROP TABLE IF EXISTS "ddl_migrations"',
-                ):
+                for ddl in ('DROP TABLE IF EXISTS "lq_notify_asyncpg"', 'DROP TABLE IF EXISTS "sqlspec_event_queue"'):
                     await driver.execute_script(ddl)
             await backend.close()
 
 
-@pytest.mark.parametrize(("adapter_name", "expected_transport"), [("psycopg", "poll_queue"), ("psqlpy", "poll_queue")])
-async def test_sqlspec_backend_postgres_poll_queue_defaults_wake(
-    adapter_name: "str", expected_transport: "str", postgres_service: "PostgresService"
-) -> "None":
-    """PostgreSQL async adapters without native listeners use the canonical table queue."""
-    sqlspec_config: "Any"
+def _postgres_config(adapter_name: "str", postgres_service: "PostgresService") -> "Any":
+    """Return a bare SQLSpec config for a Postgres driver against the live service."""
+    if adapter_name == "asyncpg":
+        pytest.importorskip("asyncpg")
+        from sqlspec.adapters.asyncpg import AsyncpgConfig
+
+        return AsyncpgConfig(
+            connection_config={
+                "host": postgres_service.host,
+                "port": postgres_service.port,
+                "user": postgres_service.user,
+                "password": postgres_service.password,
+                "database": postgres_service.database,
+            }
+        )
     if adapter_name == "psycopg":
         pytest.importorskip("psycopg")
         from sqlspec.adapters.psycopg import PsycopgAsyncConfig
 
-        sqlspec_config = PsycopgAsyncConfig(
+        return PsycopgAsyncConfig(
             connection_config={
                 "host": postgres_service.host,
                 "port": postgres_service.port,
@@ -873,49 +967,87 @@ async def test_sqlspec_backend_postgres_poll_queue_defaults_wake(
                 "dbname": postgres_service.database,
             }
         )
-    else:
-        pytest.importorskip("psqlpy")
-        from sqlspec.adapters.psqlpy import PsqlpyConfig
+    pytest.importorskip("psqlpy")
+    from sqlspec.adapters.psqlpy import PsqlpyConfig
 
-        sqlspec_config = PsqlpyConfig(
-            connection_config={
-                "host": postgres_service.host,
-                "port": postgres_service.port,
-                "username": postgres_service.user,
-                "password": postgres_service.password,
-                "db_name": postgres_service.database,
-            }
-        )
+    return PsqlpyConfig(
+        connection_config={
+            "host": postgres_service.host,
+            "port": postgres_service.port,
+            "username": postgres_service.user,
+            "password": postgres_service.password,
+            "db_name": postgres_service.database,
+        }
+    )
 
-    table_name = f"lq_notify_{adapter_name}"
+
+async def _drop_postgres_tables(backend: "SQLSpecQueueBackend", *table_names: "str") -> "None":
+    from litestar_queues.backends.sqlspec.backend import _bridge_session
+
+    with suppress(Exception):
+        assert backend._sqlspec is not None
+        assert backend._sqlspec_config is not None
+        async with _bridge_session(
+            cast("SQLSpecManager", backend._sqlspec), cast("SQLSpecSessionConfig", backend._sqlspec_config)
+        ) as driver:
+            for table_name in (*table_names, "sqlspec_event_queue"):
+                await driver.execute_script(f'DROP TABLE IF EXISTS "{table_name}"')
+    await backend.close()
+
+
+@pytest.mark.parametrize("adapter_name", ["asyncpg", "psycopg", "psqlpy"])
+async def test_sqlspec_backend_postgres_native_wakeup_default_on(
+    adapter_name: "str", postgres_service: "PostgresService"
+) -> "None":
+    """Every Postgres driver gets native NOTIFY wakeups from a bare, zero-config backend.
+
+    No notification settings and no manual migration: ``create_schema`` provisions
+    the events queue table, and the enqueue wakes the waiter via LISTEN/NOTIFY far
+    faster than the default one-second poll interval.
+    """
+    sqlspec_config = _postgres_config(adapter_name, postgres_service)
+    table_name = f"lq_native_{adapter_name}"
     backend = SQLSpecQueueBackend(
-        backend_config=SQLSpecBackendConfig(
-            config=sqlspec_config,
-            queue_table_name=table_name,
-            notifications=True,
-            notification_channel=f"lq_{adapter_name}_wake",
-            event_poll_interval=0.01,
-        )
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, queue_table_name=table_name)
     )
 
     await backend.open()
     await backend.create_schema()
-    await run_queue_migrations(sqlspec_config, queue_table_name=table_name)
     try:
-        assert backend.capabilities.notification_backend == expected_transport
+        assert backend.capabilities.supports_notifications is True
+        assert backend.capabilities.notification_backend == "notify_queue"
         assert backend.capabilities.notifications_durable is True
 
         waiter = asyncio.create_task(backend.wait_for_notifications(timeout=5))
+        await asyncio.sleep(0.3)
+        start = time.monotonic()
         await backend.enqueue(f"tasks.{adapter_name}_wake")
         assert await waiter is True
+        # A real NOTIFY wake resolves well under the 1s default poll interval.
+        assert time.monotonic() - start < 0.9
     finally:
-        from litestar_queues.backends.sqlspec.backend import _bridge_session
+        await _drop_postgres_tables(backend, table_name)
 
-        with suppress(Exception):
-            assert backend._sqlspec is not None
-            assert backend._sqlspec_config is not None
-            async with _bridge_session(
-                cast("SQLSpecManager", backend._sqlspec), cast("SQLSpecSessionConfig", backend._sqlspec_config)
-            ) as driver:
-                await driver.execute_script(f'DROP TABLE IF EXISTS "{table_name}"')
-        await backend.close()
+
+@pytest.mark.parametrize("adapter_name", ["asyncpg", "psycopg", "psqlpy"])
+async def test_sqlspec_backend_postgres_notifications_false_forces_polling(
+    adapter_name: "str", postgres_service: "PostgresService"
+) -> "None":
+    """``notifications=False`` opts a capability-native Postgres driver out to polling."""
+    sqlspec_config = _postgres_config(adapter_name, postgres_service)
+    table_name = f"lq_optout_{adapter_name}"
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(config=sqlspec_config, queue_table_name=table_name, notifications=False)
+    )
+
+    await backend.open()
+    await backend.create_schema()
+    try:
+        assert backend.capabilities.supports_notifications is False
+        assert backend.capabilities.notification_backend is None
+
+        start = time.monotonic()
+        assert await backend.wait_for_notifications(timeout=0.05) is False
+        assert time.monotonic() - start >= 0.04
+    finally:
+        await _drop_postgres_tables(backend, table_name)


### PR DESCRIPTION
## Summary

SQLSpec workers now get their **native wakeup automatically**, with no configuration. On PostgreSQL (asyncpg, psycopg, and psqlpy) that means instant `LISTEN/NOTIFY` wakeups instead of interval polling; other databases use the best transport they support, and anything without one keeps polling.

## What changed

- **On by default when the driver supports it** — a bare `SQLSpecBackendConfig` enables native wakeups automatically. Set `notifications=False` to force fixed-interval polling.
- **All three Postgres drivers get native `LISTEN/NOTIFY`** — asyncpg, psycopg, and psqlpy now use the durable `notify_queue` transport. Previously only asyncpg did; psycopg and psqlpy fell back to table polling.
- **Zero setup** — the durable events table is provisioned automatically (both schema creation and the registered migration handle it), so a fresh database just works with no manual migration step.
- **Unchanged where it should be** — DuckDB keeps its table-queue wakeups; CockroachDB, MySQL, SQLite, SQL Server, and Spanner keep polling; Oracle's AQ/TxEventQ stays opt-in. The Advanced Alchemy backend is untouched.

## How you use it

Nothing to configure — capable databases get native wakeups out of the box. To go back to plain polling, set `notifications=False` on the backend config.