### PR TITLE
fix(sqlspec): declare protocol is_async as ClassVar

### DIFF
--- a/src/litestar_queues/backends/sqlspec/_typing.py
+++ b/src/litestar_queues/backends/sqlspec/_typing.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeAlias
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
 
+    from sqlspec.adapters.asyncpg import AsyncpgConfig
+    from sqlspec.adapters.sqlite import SqliteConfig
+
 
 DatetimeParam: TypeAlias = datetime | str
 
@@ -70,3 +73,10 @@ class SQLSpecDriver(Protocol):
     async def select_one_or_none(self, statement: Any, *parameters: Any, **kwargs: Any) -> Any | None: ...
 
     def select_stream(self, statement: Any, *, chunk_size: int | None = None) -> "AsyncIterator[Any] | Any": ...
+
+
+if TYPE_CHECKING:
+    _sync_config_contract: SQLSpecConfig = SqliteConfig()
+    _async_config_contract: SQLSpecConfig = AsyncpgConfig()
+    _sync_session_contract: SQLSpecSessionConfig = SqliteConfig()
+    _async_session_contract: SQLSpecSessionConfig = AsyncpgConfig()

--- a/src/litestar_queues/backends/sqlspec/_typing.py
+++ b/src/litestar_queues/backends/sqlspec/_typing.py
@@ -1,7 +1,7 @@
 """Internal typing helpers for the SQLSpec queue backend."""
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeAlias
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
@@ -16,9 +16,7 @@ class SQLSpecConfig(Protocol):
     statement_config: Any
     extension_config: Any
     migration_config: Any
-
-    @property
-    def is_async(self) -> bool: ...
+    is_async: ClassVar[bool]
 
     def close_pool(self) -> Any: ...
 
@@ -41,8 +39,7 @@ class SQLSpecStoreConfig(Protocol):
 class SQLSpecSessionConfig(Protocol):
     """Structural subset needed to obtain a SQLSpec session."""
 
-    @property
-    def is_async(self) -> bool: ...
+    is_async: ClassVar[bool]
 
 
 class SQLSpecManager(Protocol):

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from subprocess import run
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from uuid import uuid4
 
 import pytest
@@ -2114,7 +2114,7 @@ class _UniqueViolationDriver:
 
 
 class _FakeSyncConfig:
-    is_async = False
+    is_async: ClassVar[bool] = False
 
 
 class _FakeSyncSQLSpec:


### PR DESCRIPTION
## Summary

Fixes #57.

The `SQLSpecConfig` and `SQLSpecSessionConfig` protocols in `src/litestar_queues/backends/sqlspec/_typing.py` declared `is_async` as a `@property`, but sqlspec's `DatabaseConfigProtocol` defines it as `ClassVar[bool]`. Pyright rejected adapter configs such as `AsyncpgConfig` where these protocols were expected:

```
"is_async" is not defined as a ClassVar in protocol
```

## Change

Both `is_async` protocol members now use `is_async: ClassVar[bool]`.

Note: the plain attribute annotation (`is_async: bool`) suggested in the issue does **not** work — Pyright produces the same error, because a protocol declaring a plain instance attribute cannot be satisfied by a `ClassVar` implementation. The protocol must itself declare `ClassVar`.

## Verification

- End-to-end Pyright check passing a real `AsyncpgConfig` into `configure_queue_migration_extension` → **0 errors** (previously reproduced the reported error).
- `pyright` on the whole `backends/sqlspec/` package → **0 errors**.
- Runtime import of the module still works.