### PR TITLE
feat: add configurable queue runtime namespaces

### DIFF
--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -117,8 +117,10 @@ That one value produces names such as ``dma.wakeups`` for telemetry,
 ``dma.worker`` for loggers, ``dma:worker_wakeups`` for channels and Redis or
 Valkey keys, ``dma_service`` for Litestar state and dependency registration,
 ``DMA_SERVER_NONCE`` for private process coordination, and ``dma-worker`` for
-process, thread, and temporary-resource names. Multiple queue plugins can use
-different namespaces without mutating process-global naming state.
+process, thread, and temporary-resource names. Default event streams mount
+under ``/dma/events`` and Cloud Tasks delivery resources begin with ``dma-``.
+Multiple queue plugins can use different namespaces without mutating
+process-global naming state.
 
 Explicit component settings still win. User-authored task and queue names are
 never rewritten. SQL table names and Advanced Alchemy model classes also remain

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -27,6 +27,9 @@ Use this page as a map; each linked guide owns the detailed behavior.
    * - Persistence
      - ``queue_backend``
      - :doc:`backends`
+   * - Runtime identity
+     - ``namespace``
+     - This page
    * - Execution placement
      - ``execution_backend``
      - :doc:`backends`
@@ -99,3 +102,30 @@ more than idle load.
 Defaults favor zero-configuration background execution: ephemeral SQLite,
 local execution, and one server-owned worker started by ``litestar run``.
 Choose persistent storage and placement explicitly for durable deployments.
+
+Runtime namespace
+=================
+
+Set ``namespace`` once on :class:`~litestar_queues.QueueConfig` to rebrand
+package-owned runtime identity:
+
+.. code-block:: python
+
+   queue_config = QueueConfig(namespace="dma")
+
+That one value produces names such as ``dma.wakeups`` for telemetry,
+``dma.worker`` for loggers, ``dma:worker_wakeups`` for channels and Redis or
+Valkey keys, ``dma_service`` for Litestar state and dependency registration,
+``DMA_SERVER_NONCE`` for private process coordination, and ``dma-worker`` for
+process, thread, and temporary-resource names. Multiple queue plugins can use
+different namespaces without mutating process-global naming state.
+
+Explicit component settings still win. User-authored task and queue names are
+never rewritten. SQL table names and Advanced Alchemy model classes also remain
+under their existing backend settings; ``namespace`` does not derive them.
+
+External one-task executors use two stable bootstrap variables:
+``QUEUES_CONFIG_FACTORY`` and ``QUEUES_TASK_ID``. They are intentionally not
+namespace-derived because the consumer must locate the config factory before it
+can load ``QueueConfig.namespace``. After the factory is loaded, other derived
+runtime names use that config's namespace.

--- a/docs/usage/deployment/cloud-run.rst
+++ b/docs/usage/deployment/cloud-run.rst
@@ -211,7 +211,7 @@ Cloud Run Job worker
 
 The Cloud Run Job executes the queued task. Run it with ``litestar queues
 run-task``. The command reads the task id and
-``LITESTAR_QUEUES_CONFIG_FACTORY`` from the container environment, resolves the
+``QUEUES_CONFIG_FACTORY`` from the container environment, resolves the
 shared queue service, re-fetches the saved record, claims it, runs the task, and
 exits with a defined code.
 
@@ -231,7 +231,7 @@ prefix changes everywhere.
    * - Env var
      - Required
      - Meaning
-   * - ``LITESTAR_QUEUES_CONFIG_FACTORY``
+   * - ``QUEUES_CONFIG_FACTORY``
      - Yes
      - ``module:attr`` or dotted path returning the shared-DB ``QueueConfig``
        or ``QueueService``. Without it, the consumer cannot rebuild the queue
@@ -240,7 +240,7 @@ prefix changes everywhere.
      - Recommended
      - Comma-separated modules to import so ``@task`` registrations exist.
        The consumer merges these with ``config.task_modules``.
-   * - ``LITESTAR_QUEUES_TASK_ID``
+   * - ``QUEUES_TASK_ID``
      - Injected
      - The id (UUID) of the queued record to run. The dispatcher sets this
        automatically through container overrides. The consumer re-fetches the
@@ -287,7 +287,7 @@ Example job command:
      --command litestar \
      --args queues,run-task \
      --set-cloudsql-instances my-project:my-region:my-db \
-     --set-env-vars LITESTAR_QUEUES_CONFIG_FACTORY=myapp.queues:create_config,\
+     --set-env-vars QUEUES_CONFIG_FACTORY=myapp.queues:create_config,\
      LITESTAR_QUEUES_TASK_MODULES=myapp.tasks \
      --task-timeout 3600s
 

--- a/docs/usage/deployment/cloud-tasks.rst
+++ b/docs/usage/deployment/cloud-tasks.rst
@@ -144,6 +144,10 @@ from ``QueueConfig.namespace`` (for example ``/_dma/cloud-tasks``). Set
 ``route_path`` to move it. You do not
 write it, mount it, or wire it up.
 
+Cloud Tasks delivery resource names use ``lq-`` with the default namespace and
+the configured namespace otherwise (for example ``dma-``). Set
+``delivery_name_prefix`` when infrastructure needs an explicit prefix.
+
 It is never open by default. Either assert Cloud Run's own IAM with
 ``trust_platform_auth=True`` — which is a statement that the service is
 deployed ``--no-allow-unauthenticated``, so every request has already been

--- a/docs/usage/deployment/cloud-tasks.rst
+++ b/docs/usage/deployment/cloud-tasks.rst
@@ -139,7 +139,9 @@ The delivery route
 ==================
 
 A queue configured for Cloud Tasks registers one route on your application at
-``/_litestar-queues/cloud-tasks``. Set ``route_path`` to move it. You do not
+``/_litestar-queues/cloud-tasks`` by default, or the equivalent path derived
+from ``QueueConfig.namespace`` (for example ``/_dma/cloud-tasks``). Set
+``route_path`` to move it. You do not
 write it, mount it, or wire it up.
 
 It is never open by default. Either assert Cloud Run's own IAM with

--- a/docs/usage/event-streams.rst
+++ b/docs/usage/event-streams.rst
@@ -26,6 +26,12 @@ Use SSE for server-to-browser updates with automatic browser reconnection. Use
 WebSockets when the connection also needs bidirectional application messages.
 Both deliver the same JSON ``QueueEvent`` envelope.
 
+The default path follows :attr:`~litestar_queues.QueueConfig.namespace`: the
+legacy namespace uses ``/queues/events``, while
+``QueueConfig(namespace="dma")`` uses ``/dma/events``. Set
+``EventStreamConfig(path="/events")`` when the application owns an explicit
+path; explicit paths are never rewritten.
+
 When ``QueueEventsConfig.channels`` is set, generated stream routes use that
 same Channels source even if the application registers another
 ``ChannelsPlugin``. Without an explicit source, the routes use the registered

--- a/docs/usage/observability.rst
+++ b/docs/usage/observability.rst
@@ -110,7 +110,7 @@ CLI workers should load a config factory that returns the same settings:
 
 .. code-block:: bash
 
-   LITESTAR_QUEUES_CONFIG_FACTORY=app.queue:create_queue_config litestar queues run
+   QUEUES_CONFIG_FACTORY=app.queue:create_queue_config litestar queues run
 
 Trace Context
 =============

--- a/src/litestar_queues/__init__.py
+++ b/src/litestar_queues/__init__.py
@@ -94,6 +94,7 @@ if TYPE_CHECKING:
         TaskReservation,
         TaskStatus,
     )
+    from litestar_queues.namespace import QueueNamespace
     from litestar_queues.plugin import QueuePlugin
     from litestar_queues.service import QueueService
     from litestar_queues.task import (
@@ -153,6 +154,7 @@ __all__ = (
     "QueueMaintenancePhaseResult",
     "QueueMaintenanceService",
     "QueueMaintenanceSummary",
+    "QueueNamespace",
     "QueuePlugin",
     "QueueService",
     "QueueStatistics",
@@ -246,6 +248,7 @@ _EXPORTS = {
     "QueueMaintenancePhaseResult": "litestar_queues.maintenance",
     "QueueMaintenanceService": "litestar_queues.maintenance",
     "QueueMaintenanceSummary": "litestar_queues.maintenance",
+    "QueueNamespace": "litestar_queues.namespace",
     "QueuePlugin": "litestar_queues.plugin",
     "QueueService": "litestar_queues.service",
     "QueueStatistics": "litestar_queues.models",

--- a/src/litestar_queues/_cli.py
+++ b/src/litestar_queues/_cli.py
@@ -177,7 +177,7 @@ def scheduler_health_command(ctx: "click.Context", minutes: "int") -> "None":
 @queues_group.command(
     name="run-task",
     help="Run one queued record by id (external-executor consumer). By default reads the task id "
-    "(LITESTAR_QUEUES_TASK_ID) and LITESTAR_QUEUES_CONFIG_FACTORY from the environment; the options below "
+    "QUEUES_TASK_ID and QUEUES_CONFIG_FACTORY from the environment; the options below "
     "override those defaults so a job can be run by hand.",
 )
 @click.option("--task-id", default=None, help="Run the queued record with this id (local one-shot).")
@@ -374,7 +374,7 @@ async def _run_worker(
         # text: connection strings and credentials routinely appear in backend
         # errors. The full traceback still reaches the configured log handlers.
         click.echo(f"error: queue worker failed during {_failure_detail(exc)}", err=True)
-        logger.exception("Standalone queue worker failed")
+        logging.getLogger(config.names.logger("cli")).exception("Standalone queue worker failed")
         return int(WorkerRunResult.CRASHED)
     return int(result)
 

--- a/src/litestar_queues/_environment.py
+++ b/src/litestar_queues/_environment.py
@@ -1,0 +1,6 @@
+"""Stable environment keys required before queue configuration is loaded."""
+
+__all__ = ("CONFIG_FACTORY_ENV", "TASK_ID_ENV")
+
+CONFIG_FACTORY_ENV = "QUEUES_CONFIG_FACTORY"
+TASK_ID_ENV = "QUEUES_TASK_ID"

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -156,7 +156,10 @@ class SQLAlchemyBackend(BaseQueueBackend):
         """Return Advanced Alchemy-managed queue event history when enabled."""
         if self._event_log is None:
             self._event_log = AdvancedAlchemyQueueEventLog(
-                config=config, service_factory=self._event_log_service, transaction_factory=self._event_log_operation
+                config=config,
+                service_factory=self._event_log_service,
+                transaction_factory=self._event_log_operation,
+                runtime_logger=self._logger,
             )
         return self._event_log
 
@@ -577,11 +580,16 @@ class SQLAlchemyBackend(BaseQueueBackend):
         if amount == 0 or self.config is None or self.config.observability is None:
             return
         if self._observability_runtime is None:
-            self._observability_runtime = create_observability_runtime(self.config.observability)
+            self._observability_runtime = create_observability_runtime(
+                self.config.observability, namespace=self.config.names
+            )
         self._observability_runtime.record_counter(
             f"litestar_queues.queue.{name}",
             int(amount),
-            attributes={"messaging.system": "litestar_queues", "backend": "advanced-alchemy"},
+            attributes={
+                "messaging.system": self.config.names.root,
+                "backend": "advanced-alchemy",
+            },
         )
 
     def _resolve_model_classes(

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -586,10 +586,7 @@ class SQLAlchemyBackend(BaseQueueBackend):
         self._observability_runtime.record_counter(
             f"litestar_queues.queue.{name}",
             int(amount),
-            attributes={
-                "messaging.system": self.config.names.root,
-                "backend": "advanced-alchemy",
-            },
+            attributes={"messaging.system": self.config.names.root, "backend": "advanced-alchemy"},
         )
 
     def _resolve_model_classes(

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -107,7 +107,13 @@ class SQLAlchemyBackend(BaseQueueBackend):
             self._resolve_task_reservation_model_classes(backend_config.task_reservation_model_class)
         )
         self._notifications = backend_config.worker_wakeups
-        self._wakeup_channel = backend_config.wakeup_channel
+        self._wakeup_channel = (
+            backend_config.wakeup_channel
+            if backend_config.wakeup_channel is not None
+            else config.names.database_channel("tasks")
+            if config is not None
+            else "litestar_queues_tasks"
+        )
         self._event_poll_interval = backend_config.wakeup_poll_interval
         self._notification_listener: "NotificationListener | None" = None
         self._observability_runtime: "QueueObservabilityRuntimeProtocol | None" = None

--- a/src/litestar_queues/backends/advanced_alchemy/config.py
+++ b/src/litestar_queues/backends/advanced_alchemy/config.py
@@ -59,8 +59,8 @@ class SQLAlchemyBackendConfig:
     worker_wakeups: "bool" = False
     """Whether workers listen for database wakeup hints between polling passes."""
 
-    wakeup_channel: "str" = "litestar_queues_tasks"
-    """Database notification channel used for worker wakeup hints."""
+    wakeup_channel: "str | None" = None
+    """Database notification channel; ``None`` derives it from ``QueueConfig.namespace``."""
 
     wakeup_poll_interval: "float | None" = None
     """Wakeup-listener fallback poll interval in seconds; ``None`` uses the backend default."""

--- a/src/litestar_queues/backends/advanced_alchemy/event_log.py
+++ b/src/litestar_queues/backends/advanced_alchemy/event_log.py
@@ -23,7 +23,15 @@ logger = logging.getLogger(__name__)
 class AdvancedAlchemyQueueEventLog:
     """Buffered Advanced Alchemy event-history writer and query interface."""
 
-    __slots__ = ("_config", "_flush_lock", "_last_flush", "_pending", "_service_factory", "_transaction_factory")
+    __slots__ = (
+        "_config",
+        "_flush_lock",
+        "_last_flush",
+        "_logger",
+        "_pending",
+        "_service_factory",
+        "_transaction_factory",
+    )
 
     def __init__(
         self,
@@ -31,6 +39,7 @@ class AdvancedAlchemyQueueEventLog:
         config: "EventHistoryConfig",
         service_factory: 'Callable[[], AbstractAsyncContextManager["QueueEventLogService"]]',
         transaction_factory: 'Callable[[], AbstractAsyncContextManager["QueueEventLogService"]]',
+        runtime_logger: "logging.Logger | None" = None,
     ) -> "None":
         self._config = config
         self._service_factory = service_factory
@@ -38,6 +47,7 @@ class AdvancedAlchemyQueueEventLog:
         self._pending: "list[QueueEventLogRecord]" = []
         self._last_flush = time.monotonic()
         self._flush_lock = asyncio.Lock()
+        self._logger = runtime_logger or logger
 
     async def publish_event(self, event: "QueueEvent") -> "None":
         """Buffer a queue event and flush when configured thresholds are reached."""
@@ -60,7 +70,7 @@ class AdvancedAlchemyQueueEventLog:
             except Exception:
                 if self._config.strict:
                     raise
-                logger.warning("Advanced Alchemy queue event history flush failed", exc_info=True)
+                self._logger.warning("Advanced Alchemy queue event history flush failed", exc_info=True)
                 return
             del self._pending[: len(batch)]
             self._last_flush = time.monotonic()

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -10,6 +11,7 @@ from litestar_queues.models import (
     QueueStatistics,
     StaleTaskRecoveryResult,
 )
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -31,11 +33,13 @@ STALE_REQUEUE_PRIORITY = 4
 class BaseQueueBackend:
     """Base class for queue persistence backends."""
 
-    __slots__ = ("config",)
+    __slots__ = ("_logger", "config")
 
     def __init__(self, config: "QueueConfig | None" = None) -> "None":
         """Initialize the queue backend."""
         self.config = config
+        names = config.names if config is not None else QueueNamespace()
+        self._logger = logging.getLogger(names.logger("backends", type(self).__name__))
 
     @property
     def capabilities(self) -> "QueueBackendCapabilities":

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -194,7 +194,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
             QueueConfigurationError: If no server lifespan created the database,
                 or the location, schema, or nonce does not match this invocation.
         """
-        resolved = read_environment()
+        resolved = read_environment(self.config.names if self.config is not None else None)
         if resolved is None:
             raise QueueConfigurationError(_NOT_OPEN_ERROR)
         path, nonce = resolved

--- a/src/litestar_queues/backends/ephemeral/schema.py
+++ b/src/litestar_queues/backends/ephemeral/schema.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from litestar_queues.exceptions import QueueError
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -61,15 +62,16 @@ def _classify(error: "sqlite3.DatabaseError") -> "str | None":
     return UNREADABLE_ERROR
 
 
-def read_environment() -> "tuple[str, str] | None":
+def read_environment(namespace: "QueueNamespace | None" = None) -> "tuple[str, str] | None":
     """Return the active database path and invocation nonce.
 
     Returns:
         The ``(path, nonce)`` pair when both private variables are set and the
         path is absolute, otherwise ``None``.
     """
-    path = os.environ.get(PATH_ENV_VAR)
-    nonce = os.environ.get(NONCE_ENV_VAR)
+    names = namespace or QueueNamespace()
+    path = os.environ.get(names.environment("ephemeral", "path"))
+    nonce = os.environ.get(names.environment("ephemeral", "nonce"))
     if not path or not nonce or not Path(path).is_absolute():
         return None
     return path, nonce

--- a/src/litestar_queues/backends/ephemeral/server.py
+++ b/src/litestar_queues/backends/ephemeral/server.py
@@ -146,9 +146,7 @@ def _unlink_within_deadline(target: "Path") -> "bool":
         return True
 
 
-def _remove_directory_within_deadline(
-    directory: "Path", *, runtime_logger: "logging.Logger" = logger
-) -> "None":
+def _remove_directory_within_deadline(directory: "Path", *, runtime_logger: "logging.Logger" = logger) -> "None":
     """Remove the private directory once it is empty, or warn and leave it."""
     deadline = time.monotonic() + _CLEANUP_DEADLINE
     while True:

--- a/src/litestar_queues/backends/ephemeral/server.py
+++ b/src/litestar_queues/backends/ephemeral/server.py
@@ -12,8 +12,9 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from litestar_queues.backends.ephemeral.schema import NONCE_ENV_VAR, PATH_ENV_VAR, initialize_database
+from litestar_queues.backends.ephemeral.schema import initialize_database
 from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -25,7 +26,6 @@ __all__ = ("DATABASE_NAME", "EphemeralServerContext")
 logger = logging.getLogger(__name__)
 
 DATABASE_NAME = "queue.sqlite3"
-_DIRECTORY_PREFIX = "litestar-queues-"
 _DIRECTORY_MODE = 0o700
 _FILE_MODE = 0o600
 _CLEANUP_DEADLINE = 5.0
@@ -40,12 +40,17 @@ _CLEANUP_FILE_WARNING = "Could not remove the private ephemeral queue files (%s)
 class EphemeralServerContext:
     """Own one private temporary SQLite database for a server invocation."""
 
-    __slots__ = ("_directory", "_nonce", "_path")
+    __slots__ = ("_directory", "_logger", "_nonce", "_nonce_env_var", "_path", "_path_env_var", "_resource_prefix")
 
-    def __init__(self, *, nonce: "str") -> "None":
+    def __init__(self, *, nonce: "str", namespace: "QueueNamespace | None" = None) -> "None":
+        names = namespace or QueueNamespace()
         self._nonce = nonce
         self._directory: "Path | None" = None
         self._path: "Path | None" = None
+        self._path_env_var = names.environment("ephemeral", "path")
+        self._nonce_env_var = names.environment("ephemeral", "nonce")
+        self._resource_prefix = f"{names.resource()}-"
+        self._logger = logging.getLogger(names.logger("backends", "ephemeral"))
 
     @property
     def path(self) -> "Path":
@@ -71,13 +76,13 @@ class EphemeralServerContext:
         Raises:
             QueueConfigurationError: If the private environment already exists.
         """
-        if os.environ.get(PATH_ENV_VAR) or os.environ.get(NONCE_ENV_VAR):
+        if os.environ.get(self._path_env_var) or os.environ.get(self._nonce_env_var):
             raise QueueConfigurationError(_PREEXISTING_ERROR)
-        directory = Path(tempfile.mkdtemp(prefix=_DIRECTORY_PREFIX))
+        directory = Path(tempfile.mkdtemp(prefix=self._resource_prefix))
         try:
             directory.chmod(_DIRECTORY_MODE)
         except OSError:
-            logger.debug("Could not restrict ephemeral queue directory permissions.")
+            self._logger.debug("Could not restrict ephemeral queue directory permissions.")
         path = directory / DATABASE_NAME
         descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, _FILE_MODE)
         os.close(descriptor)
@@ -88,8 +93,8 @@ class EphemeralServerContext:
             raise
         self._directory = directory
         self._path = path
-        os.environ[PATH_ENV_VAR] = str(path)
-        os.environ[NONCE_ENV_VAR] = self._nonce
+        os.environ[self._path_env_var] = str(path)
+        os.environ[self._nonce_env_var] = self._nonce
         return self
 
     def __exit__(
@@ -100,8 +105,8 @@ class EphemeralServerContext:
     ) -> "None":
         """Remove the environment, database files, and private directory."""
         del exc_type, exc_value, traceback
-        os.environ.pop(PATH_ENV_VAR, None)
-        os.environ.pop(NONCE_ENV_VAR, None)
+        os.environ.pop(self._path_env_var, None)
+        os.environ.pop(self._nonce_env_var, None)
         directory, path = self._directory, self._path
         self._directory = self._path = None
         if directory is None or path is None:
@@ -112,8 +117,8 @@ class EphemeralServerContext:
         targets = (path, path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-shm"))
         survivors = [target.name for target in targets if not _unlink_within_deadline(target)]
         if survivors:
-            logger.warning(_CLEANUP_FILE_WARNING, ", ".join(survivors))
-        _remove_directory_within_deadline(directory)
+            self._logger.warning(_CLEANUP_FILE_WARNING, ", ".join(survivors))
+        _remove_directory_within_deadline(directory, runtime_logger=self._logger)
 
 
 def _unlink_within_deadline(target: "Path") -> "bool":
@@ -141,7 +146,9 @@ def _unlink_within_deadline(target: "Path") -> "bool":
         return True
 
 
-def _remove_directory_within_deadline(directory: "Path") -> "None":
+def _remove_directory_within_deadline(
+    directory: "Path", *, runtime_logger: "logging.Logger" = logger
+) -> "None":
     """Remove the private directory once it is empty, or warn and leave it."""
     deadline = time.monotonic() + _CLEANUP_DEADLINE
     while True:
@@ -151,7 +158,7 @@ def _remove_directory_within_deadline(directory: "Path") -> "None":
             return
         except OSError:
             if time.monotonic() >= deadline:
-                logger.warning(_CLEANUP_WARNING)
+                runtime_logger.warning(_CLEANUP_WARNING)
                 return
             time.sleep(_CLEANUP_RETRY)
             continue

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -705,9 +705,22 @@ class RedisQueueBackend(BaseQueueBackend):
         self._client: "ClientLike | None" = cast("ClientLike | None", backend_config.client)
         self._owns_client = self._client is None
         self._url = backend_config.url
-        self._key_prefix = backend_config.key_prefix.rstrip(":")
+        key_prefix = (
+            backend_config.key_prefix
+            if backend_config.key_prefix is not None
+            else config.names.root
+            if config is not None
+            else "litestar_queues"
+        )
+        self._key_prefix = key_prefix.rstrip(":")
         self._notifications = backend_config.worker_wakeups
-        self._wakeup_channel = backend_config.wakeup_channel
+        self._wakeup_channel = (
+            backend_config.wakeup_channel
+            if backend_config.wakeup_channel is not None
+            else config.names.channel("worker_wakeups")
+            if config is not None
+            else "litestar_queues:worker_wakeups"
+        )
         self._pubsub: "PubSubLike | None" = None
         self._pending_read = PendingNativeRead()
         self._event_log: "RedisQueueEventLog | None" = None

--- a/src/litestar_queues/backends/redis/config.py
+++ b/src/litestar_queues/backends/redis/config.py
@@ -19,14 +19,14 @@ class RedisBackendConfig:
     url: "str" = "redis://localhost:6379/0"
     """Redis connection URL used when no client is injected."""
 
-    key_prefix: "str" = "litestar_queues"
-    """Prefix applied to every queue key stored in Redis."""
+    key_prefix: "str | None" = None
+    """Prefix applied to every queue key; ``None`` derives it from ``QueueConfig.namespace``."""
 
     worker_wakeups: "bool" = True
     """Whether workers subscribe for Redis wakeup hints between polling passes."""
 
-    wakeup_channel: "str" = DEFAULT_WAKEUP_CHANNEL
-    """Redis pub/sub channel used for worker wakeup hints."""
+    wakeup_channel: "str | None" = None
+    """Worker-wakeup pub/sub channel; ``None`` derives it from ``QueueConfig.namespace``."""
 
     client: "Redis | None" = None
     """Injected async Redis client; ``None`` creates one from ``url``."""

--- a/src/litestar_queues/backends/redis/event_log.py
+++ b/src/litestar_queues/backends/redis/event_log.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 class RedisQueueEventLog:
     """Buffered Redis-protocol event-history writer and query interface."""
 
-    __slots__ = ("_backend", "_config", "_flush_lock", "_last_flush", "_pending")
+    __slots__ = ("_backend", "_config", "_flush_lock", "_last_flush", "_logger", "_pending")
 
     def __init__(self, *, backend: "RedisQueueBackend", config: "EventHistoryConfig") -> "None":
         self._backend = backend
@@ -42,6 +42,7 @@ class RedisQueueEventLog:
         self._pending: "list[dict[str, str]]" = []
         self._last_flush = time.monotonic()
         self._flush_lock = asyncio.Lock()
+        self._logger = backend._logger
 
     async def publish_event(self, event: "QueueEvent") -> "None":
         """Buffer a queue event and flush when configured thresholds are reached."""
@@ -64,7 +65,7 @@ class RedisQueueEventLog:
             except Exception:
                 if self._config.strict:
                     raise
-                logger.warning("Redis queue event history flush failed", exc_info=True)
+                self._logger.warning("Redis queue event history flush failed", exc_info=True)
                 return
             del self._pending[: len(batch)]
             self._last_flush = time.monotonic()

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1846,7 +1846,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             skip_explicit_begin=store.skip_explicit_begin,
             skip_cleanup_rollback=store.skip_cleanup_rollback,
             thread_name_prefix=(
-                self.config.names.resource("sqlspec", "sync") if self.config is not None else "litestar-queues-sqlspec-sync"
+                self.config.names.resource("sqlspec", "sync")
+                if self.config is not None
+                else "litestar-queues-sqlspec-sync"
             ),
         ) as driver:
             yield driver

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -5,7 +5,6 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable, iscoroutinefunction
-from logging import getLogger
 from typing import TYPE_CHECKING, Any, cast, overload
 from uuid import UUID, uuid4
 
@@ -254,6 +253,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 datetime_serializer=self._serialize_datetime,
                 config=config,
                 store=self._get_event_log_store(),
+                runtime_logger=self._logger,
             )
         return self._event_log
 
@@ -291,7 +291,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         if replace is None or getattr(statement_config, "enable_sqlcommenter", False):
             return
         attributes = dict(getattr(statement_config, "sqlcommenter_attributes", None) or {})
-        attributes.setdefault("framework", "litestar-queues")
+        attributes.setdefault(
+            "framework", self.config.names.resource() if self.config is not None else "litestar-queues"
+        )
         config.statement_config = replace(
             enable_sqlcommenter=True,
             sqlcommenter_attributes=attributes,
@@ -1843,6 +1845,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             sqlspec_config,
             skip_explicit_begin=store.skip_explicit_begin,
             skip_cleanup_rollback=store.skip_cleanup_rollback,
+            thread_name_prefix=(
+                self.config.names.resource("sqlspec", "sync") if self.config is not None else "litestar-queues-sqlspec-sync"
+            ),
         ) as driver:
             yield driver
 
@@ -1867,6 +1872,11 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 cast("SQLSpecManager", self._sqlspec),
                 cast("SQLSpecSessionConfig", self._heartbeat_pool_config),
                 skip_cleanup_rollback=self._get_store().skip_cleanup_rollback,
+                thread_name_prefix=(
+                    self.config.names.resource("sqlspec", "sync")
+                    if self.config is not None
+                    else "litestar-queues-sqlspec-sync"
+                ),
             ) as driver:
                 yield driver
         else:
@@ -1887,7 +1897,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             try:
                 cast("Any", self._get_or_create_sqlspec()).add_config(self._heartbeat_pool_config)
             except Exception:
-                getLogger("litestar_queues").warning(
+                self._logger.warning(
                     "SQLSpecQueueBackend heartbeat pool registration failed; "
                     "falling back to main pool for heartbeat writes.",
                     exc_info=True,
@@ -1905,7 +1915,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 if isawaitable(close_result):
                     await close_result
             except Exception:
-                getLogger("litestar_queues").debug("SQLSpecQueueBackend heartbeat pool close failed.", exc_info=True)
+                self._logger.debug("SQLSpecQueueBackend heartbeat pool close failed.", exc_info=True)
             self._heartbeat_pool_registered = False
 
     async def _select_pending_rows(
@@ -2254,6 +2264,7 @@ async def _bridge_session(
     *,
     skip_explicit_begin: "bool" = False,
     skip_cleanup_rollback: "bool" = False,
+    thread_name_prefix: "str" = "litestar-queues-sqlspec-sync",
 ) -> "AsyncIterator[SQLSpecDriver]":
     """Yield a SQLSpec driver regardless of sync/async config.
 
@@ -2271,7 +2282,7 @@ async def _bridge_session(
         async with session_cm as driver:
             yield cast("SQLSpecDriver", driver)
     else:
-        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="litestar-queues-sqlspec-sync")
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=thread_name_prefix)
         driver = await async_(session_cm.__enter__, executor=executor)()
         managed_driver = _ManagedAsyncDriver(driver, executor, skip_explicit_begin=skip_explicit_begin)
         try:

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -181,6 +181,8 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         self._event_channel = worker_wakeups.channel if worker_wakeups is not None else None
         self._owns_event_channel = self._event_channel is None
         self._wakeup_channel = worker_wakeups.channel_name if worker_wakeups is not None else None
+        if self._wakeup_channel is None and config is not None:
+            self._wakeup_channel = config.names.database_channel("tasks")
         self._wakeup_transport = worker_wakeups.transport if worker_wakeups is not None else None
         self._event_history_table_name = (
             validate_table_name(backend_config.event_history_table_name)

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -312,6 +312,7 @@ class SQLSpecQueueEventLog:
         "_datetime_serializer",
         "_flush_lock",
         "_last_flush",
+        "_logger",
         "_pending",
         "_session_factory",
         "_store",
@@ -324,6 +325,7 @@ class SQLSpecQueueEventLog:
         datetime_serializer: "Callable[[datetime], datetime | str]",
         config: "EventHistoryConfig",
         store: "SQLSpecQueueEventLogStore",
+        runtime_logger: "logging.Logger | None" = None,
     ) -> "None":
         self._session_factory = session_factory
         self._datetime_serializer = datetime_serializer
@@ -332,6 +334,7 @@ class SQLSpecQueueEventLog:
         self._pending: "list[dict[str, Any]]" = []
         self._last_flush = time.monotonic()
         self._flush_lock = asyncio.Lock()
+        self._logger = runtime_logger or logger
 
     async def publish_event(self, event: "QueueEvent") -> "None":
         """Buffer a queue event and flush when configured thresholds are reached."""
@@ -361,7 +364,7 @@ class SQLSpecQueueEventLog:
             except Exception:
                 if self._config.strict:
                     raise
-                logger.warning("SQLSpec queue event history flush failed", exc_info=True)
+                self._logger.warning("SQLSpec queue event history flush failed", exc_info=True)
                 return
             del self._pending[: len(batch)]
             self._last_flush = time.monotonic()

--- a/src/litestar_queues/backends/valkey/config.py
+++ b/src/litestar_queues/backends/valkey/config.py
@@ -19,14 +19,14 @@ class ValkeyBackendConfig:
     url: "str" = "redis://localhost:6379/0"
     """Valkey connection URL used when no client is injected."""
 
-    key_prefix: "str" = "litestar_queues"
-    """Prefix applied to every queue key stored in Valkey."""
+    key_prefix: "str | None" = None
+    """Prefix applied to every queue key; ``None`` derives it from ``QueueConfig.namespace``."""
 
     worker_wakeups: "bool" = True
     """Whether workers subscribe for Valkey wakeup hints between polling passes."""
 
-    wakeup_channel: "str" = DEFAULT_WAKEUP_CHANNEL
-    """Valkey pub/sub channel used for worker wakeup hints."""
+    wakeup_channel: "str | None" = None
+    """Worker-wakeup pub/sub channel; ``None`` derives it from ``QueueConfig.namespace``."""
 
     client: "Valkey | None" = None
     """Injected async Valkey client; ``None`` creates one from ``url``."""

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -492,10 +492,7 @@ class QueueConfig:
         if isinstance(cached, QueueService):
             return cached
 
-        msg = (
-            f"QueueService has not been opened in app state under {state_key!r}; "
-            f"found {type(cached).__name__}."
-        )
+        msg = f"QueueService has not been opened in app state under {state_key!r}; found {type(cached).__name__}."
         raise RuntimeError(msg)
 
     def get_queue_backend(self) -> "BaseQueueBackend":

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, cast, get_args, runtime_checkable
 
 from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.namespace import DEFAULT_NAMESPACE, QueueNamespace
 
 if TYPE_CHECKING:
     from litestar.datastructures import State
@@ -28,6 +29,7 @@ __all__ = (
     "QueueBackendConfig",
     "QueueBackendConfigProtocol",
     "QueueConfig",
+    "QueueNamespace",
     "TaskDependencyResolver",
     "TaskErrorSanitizer",
     "WorkerConfig",
@@ -266,6 +268,9 @@ class WorkerConfig:
 class QueueConfig:
     """Configuration for QueuePlugin."""
 
+    namespace: "str" = DEFAULT_NAMESPACE
+    """Root used to derive package-owned runtime identifiers."""
+
     queue_backend: "QueueBackendConfig" = "ephemeral"
     """Queue-record persistence backend selector or typed backend configuration."""
 
@@ -281,11 +286,11 @@ class QueueConfig:
     worker: "WorkerConfig" = field(default_factory=WorkerConfig)
     """Shared configuration for in-app and standalone workers."""
 
-    service_dependency_key: "str" = "queue_service"
-    """Litestar dependency key for the injected queue service."""
+    service_dependency_key: "str | None" = None
+    """Litestar dependency key for the injected queue service; ``None`` derives it from the namespace."""
 
-    events_dependency_key: "str" = "queue_events"
-    """Litestar dependency key for the injected queue event producer."""
+    events_dependency_key: "str | None" = None
+    """Litestar dependency key for the event producer; ``None`` derives it from the namespace."""
 
     events: "QueueEventsConfig | None" = None
     """Task-event capabilities; ``None`` disables delivery, streams, and history."""
@@ -309,11 +314,11 @@ class QueueConfig:
     Threads are created on demand, so this is a ceiling rather than a startup cost.
     """
 
-    sync_thread_name_prefix: "str" = "litestar-queues"
-    """Thread-name prefix for the synchronous task thread pool."""
+    sync_thread_name_prefix: "str | None" = None
+    """Thread-name prefix for synchronous tasks; ``None`` derives it from the namespace."""
 
-    scheduler_canary_task: "str" = "scheduler.heartbeat"
-    """Registered task name used by the scheduler-health command."""
+    scheduler_canary_task: "str | None" = None
+    """Scheduler-health task name; ``None`` derives the package-owned default."""
 
     maintenance: "QueueMaintenanceConfig | None" = None
     """Automatic maintenance policy; ``None`` disables the maintenance loop."""
@@ -321,8 +326,20 @@ class QueueConfig:
     max_argument_identity_bytes: "int | None" = None
     """Maximum canonical argument-identity size in bytes; ``None`` disables the bound."""
 
+    names: "QueueNamespace" = field(init=False)
+    """Validated format-specific runtime-name renderer."""
+
     def __post_init__(self) -> "None":
         """Validate the synchronous task thread pool and the placement matrix."""
+        self.names = QueueNamespace(self.namespace)
+        if self.service_dependency_key is None:
+            self.service_dependency_key = self.names.registration("service")
+        if self.events_dependency_key is None:
+            self.events_dependency_key = self.names.registration("events")
+        if self.sync_thread_name_prefix is None:
+            self.sync_thread_name_prefix = self.names.resource()
+        if self.scheduler_canary_task is None:
+            self.scheduler_canary_task = self.names.package_task("scheduler", "heartbeat")
         if self.sync_thread_pool_size <= 0:
             msg = "QueueConfig.sync_thread_pool_size must be greater than 0."
             raise QueueConfigurationError(msg)
@@ -422,9 +439,39 @@ class QueueConfig:
         from litestar.di import Provide
 
         return {
-            self.service_dependency_key: Provide(self.provide_service_dependency),
-            self.events_dependency_key: Provide(self.provide_event_producer_dependency),
+            cast("str", self.service_dependency_key): Provide(self.provide_service_dependency),
+            cast("str", self.events_dependency_key): Provide(self.provide_event_producer_dependency),
         }
+
+    @property
+    def service_state_key(self) -> "str":
+        """Litestar state key holding the queue service."""
+        return self.names.registration("service")
+
+    @property
+    def worker_state_key(self) -> "str":
+        """Litestar state key holding the in-process worker."""
+        return self.names.registration("worker")
+
+    @property
+    def event_publisher_state_key(self) -> "str":
+        """Litestar state key holding the event publisher."""
+        return self.names.registration("event", "publisher")
+
+    @property
+    def event_channels_state_key(self) -> "str":
+        """Litestar state key holding the resolved channels backend."""
+        return self.names.registration("event", "channels")
+
+    @property
+    def observability_runtime_state_key(self) -> "str":
+        """Litestar state key holding the observability runtime."""
+        return self.names.registration("observability", "runtime")
+
+    @property
+    def maintenance_name(self) -> "str":
+        """Distributed maintenance coordination name."""
+        return self.names.coordination("maintenance")
 
     def get_service(self, state: "State | None" = None) -> "QueueService":
         """Return a QueueService for this configuration."""
@@ -433,19 +480,20 @@ class QueueConfig:
         if state is None:
             return QueueService(self)
 
-        if _SERVICE_STATE_KEY not in state:
+        state_key = self.service_state_key
+        if state_key not in state:
             msg = (
-                f"QueueService is not available in app state under {_SERVICE_STATE_KEY!r}; "
+                f"QueueService is not available in app state under {state_key!r}; "
                 "ensure QueuePlugin startup has completed before resolving the queue service."
             )
             raise RuntimeError(msg)
 
-        cached = state[_SERVICE_STATE_KEY]
+        cached = state[state_key]
         if isinstance(cached, QueueService):
             return cached
 
         msg = (
-            f"QueueService has not been opened in app state under {_SERVICE_STATE_KEY!r}; "
+            f"QueueService has not been opened in app state under {state_key!r}; "
             f"found {type(cached).__name__}."
         )
         raise RuntimeError(msg)
@@ -486,7 +534,7 @@ class QueueConfig:
         events_config = self.events
         if events_config is None or events_config.delivery is None:
             sink: "QueueEventSink" = NoopQueueEventSink()
-            return QueueEventPublisher(sink)
+            return QueueEventPublisher(sink, namespace=self.names)
         delivery = events_config.delivery
         sinks: "list[QueueEventSink]" = []
         live_backend = events_config.channels if events_config.channels is not None else channels_backend
@@ -511,6 +559,7 @@ class QueueConfig:
             publish_task_channel=delivery.publish_task_channel,
             publish_queue_channel=delivery.publish_queue_channel,
             publish_global_lifecycle=delivery.publish_global_lifecycle,
+            namespace=self.names,
         )
 
     async def provide_service_dependency(self, state: "State") -> 'AsyncIterator["QueueService"]':
@@ -521,11 +570,12 @@ class QueueConfig:
         """Yield the application-scoped QueueEventProducer for Litestar dependency injection."""
         from litestar_queues.events import QueueEventProducer
 
-        if _EVENT_PUBLISHER_STATE_KEY not in state:
+        state_key = self.event_publisher_state_key
+        if state_key not in state:
             msg = (
                 "Queue event publisher is not available in app state under "
-                f"{_EVENT_PUBLISHER_STATE_KEY!r}; ensure QueuePlugin startup has completed before "
+                f"{state_key!r}; ensure QueuePlugin startup has completed before "
                 "resolving queue events."
             )
             raise RuntimeError(msg)
-        yield QueueEventProducer(state[_EVENT_PUBLISHER_STATE_KEY])
+        yield QueueEventProducer(state[state_key])

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -551,7 +551,11 @@ class QueueConfig:
         if not sinks:
             msg = "EventDeliveryConfig requires events.channels, an app ChannelsPlugin, or at least one custom sink."
             raise QueueConfigurationError(msg)
-        sink = sinks[0] if len(sinks) == 1 else CompositeQueueEventSink(sinks, strict=delivery.strict)
+        sink = (
+            sinks[0]
+            if len(sinks) == 1
+            else CompositeQueueEventSink(sinks, strict=delivery.strict, namespace=self.names)
+        )
         return QueueEventPublisher(
             sink,
             buffer_config=delivery.buffer,

--- a/src/litestar_queues/consumer.py
+++ b/src/litestar_queues/consumer.py
@@ -330,9 +330,7 @@ def _env_name(config: "QueueConfig | None", suffix: "str") -> "str":
     return f"QUEUES_{suffix}"
 
 
-def _runtime_logger(
-    *, config: "QueueConfig | None" = None, service: "QueueService | None" = None
-) -> "logging.Logger":
+def _runtime_logger(*, config: "QueueConfig | None" = None, service: "QueueService | None" = None) -> "logging.Logger":
     resolved_config = service.config if service is not None else config
     if resolved_config is None:
         return logger

--- a/src/litestar_queues/consumer.py
+++ b/src/litestar_queues/consumer.py
@@ -17,6 +17,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
+from litestar_queues._environment import CONFIG_FACTORY_ENV, TASK_ID_ENV
 from litestar_queues.config import QueueConfig
 from litestar_queues.events.context import _bind_beat_sink, _reset_beat_sink
 from litestar_queues.exceptions import QueueConfigurationError
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
     ServiceFactory = Callable[[], QueueConfig | QueueService | AbstractAsyncContextManager[QueueService]]
 
 __all__ = ("TaskExitCode", "consume_one", "run_task")
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("queues.consumer")
 
 _TASK_ID_ENV_SUFFIX = "TASK_ID"
 
@@ -140,7 +141,7 @@ async def run_task(
     ) and not _has_config_factory(config, environ):
         if not has_task_id_override and not environ.get(_env_name(config, _TASK_ID_ENV_SUFFIX)):
             return TaskExitCode.MISSING_TASK_ID
-        logger.error("External consumer process missing CONFIG_FACTORY")
+        _runtime_logger(config=config, service=service).error("External consumer process missing CONFIG_FACTORY")
         return TaskExitCode.MISSING_CONFIG_FACTORY
 
     async with contextlib.AsyncExitStack() as stack:
@@ -151,11 +152,15 @@ async def run_task(
         except QueueConfigurationError:
             # Process-local storage cannot be reached from a separate consumer
             # process. That is a configuration fault, not a missing factory.
-            logger.exception("External consumer process cannot attach to the configured queue backend")
+            _runtime_logger(config=config, service=service).exception(
+                "External consumer process cannot attach to the configured queue backend"
+            )
             return TaskExitCode.MISSING_CONFIG_FACTORY
         except Exception:
             if _requires_config_factory(config=config, service=service, service_factory=service_factory):
-                logger.exception("External consumer process could not load CONFIG_FACTORY")
+                _runtime_logger(config=config, service=service).exception(
+                    "External consumer process could not load CONFIG_FACTORY"
+                )
                 return TaskExitCode.MISSING_CONFIG_FACTORY
             raise
 
@@ -278,11 +283,13 @@ def _requires_config_factory(
 
 
 def _has_config_factory(config: "QueueConfig | None", env: "Mapping[str, str]") -> "bool":
-    return bool(env.get(_env_name(config, "CONFIG_FACTORY")))
+    del config
+    return bool(env.get(CONFIG_FACTORY_ENV))
 
 
 def _load_config_factory(config: "QueueConfig | None", env: "Mapping[str, str]") -> "ServiceFactory | None":
-    import_path = env.get(_env_name(config, "CONFIG_FACTORY"))
+    del config
+    import_path = env.get(CONFIG_FACTORY_ENV)
     if not import_path:
         return None
     return _import_factory(import_path)
@@ -312,8 +319,21 @@ def _load_configured_task_modules(
 
 
 def _env_name(config: "QueueConfig | None", suffix: "str") -> "str":
+    if suffix == _TASK_ID_ENV_SUFFIX:
+        return TASK_ID_ENV
     raw_config = config.execution_backend if config is not None else None
     env_name = getattr(raw_config, "env_name", None)
     if callable(env_name):
-        return str(env_name(suffix))
-    return f"LITESTAR_QUEUES_{suffix}"
+        return str(env_name(suffix, namespace=cast("QueueConfig", config).names))
+    if config is not None:
+        return config.names.environment(suffix.lower())
+    return f"QUEUES_{suffix}"
+
+
+def _runtime_logger(
+    *, config: "QueueConfig | None" = None, service: "QueueService | None" = None
+) -> "logging.Logger":
+    resolved_config = service.config if service is not None else config
+    if resolved_config is None:
+        return logger
+    return logging.getLogger(resolved_config.names.logger("consumer"))

--- a/src/litestar_queues/events/buffer.py
+++ b/src/litestar_queues/events/buffer.py
@@ -36,6 +36,7 @@ class LiveEventBuffer:
     __slots__ = (
         "_condition",
         "_config",
+        "_logger",
         "_order",
         "_pending",
         "_record_drop",
@@ -46,9 +47,15 @@ class LiveEventBuffer:
     )
 
     def __init__(
-        self, config: "EventBufferConfig", *, sink_publish: "SinkPublish", record_drop: "RecordDrop"
+        self,
+        config: "EventBufferConfig",
+        *,
+        sink_publish: "SinkPublish",
+        record_drop: "RecordDrop",
+        runtime_logger: "logging.Logger | None" = None,
     ) -> "None":
         self._config = config
+        self._logger = runtime_logger or logger
         self._sink_publish = sink_publish
         self._record_drop = record_drop
         self._condition = asyncio.Condition()
@@ -166,7 +173,7 @@ class LiveEventBuffer:
         if self._warned_drop:
             return
         self._warned_drop = True
-        logger.warning(
+        self._logger.warning(
             "Queue event buffer full; dropping event",
             extra={"queue_event_scope": event.scope, "queue_event_type": event.type},
         )

--- a/src/litestar_queues/events/channels.py
+++ b/src/litestar_queues/events/channels.py
@@ -4,6 +4,8 @@ import re
 import unicodedata
 from typing import ClassVar
 
+from litestar_queues.namespace import QueueNamespace
+
 __all__ = ("QueueChannels",)
 
 _INVALID_CHARS = re.compile(r"[^a-z0-9_.:-]+")
@@ -17,29 +19,43 @@ class QueueChannels:
     prefix: "ClassVar[str]" = "litestar_queues"
 
     @classmethod
-    def task(cls, task_id: "str", *, topic: "str" = "events") -> "str":
+    def task(
+        cls, task_id: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None
+    ) -> "str":
         """Return the channel for task-scoped events."""
-        return f"{cls.prefix}:task:{_normalize_part(task_id)}:{_normalize_part(topic)}"
+        return f"{_prefix(namespace)}:task:{_normalize_part(task_id)}:{_normalize_part(topic)}"
 
     @classmethod
-    def queue(cls, queue: "str", *, topic: "str" = "events") -> "str":
+    def queue(
+        cls, queue: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None
+    ) -> "str":
         """Return the channel for queue-scoped events."""
-        return f"{cls.prefix}:queue:{_normalize_part(queue)}:{_normalize_part(topic)}"
+        return f"{_prefix(namespace)}:queue:{_normalize_part(queue)}:{_normalize_part(topic)}"
 
     @classmethod
-    def worker(cls, worker_id: "str", *, topic: "str" = "events") -> "str":
+    def worker(
+        cls, worker_id: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None
+    ) -> "str":
         """Return the channel for worker-scoped events."""
-        return f"{cls.prefix}:worker:{_normalize_part(worker_id)}:{_normalize_part(topic)}"
+        return f"{_prefix(namespace)}:worker:{_normalize_part(worker_id)}:{_normalize_part(topic)}"
 
     @classmethod
-    def global_channel(cls, *, topic: "str" = "events") -> "str":
+    def global_channel(cls, *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None) -> "str":
         """Return the global queue event channel."""
-        return f"{cls.prefix}:global:{_normalize_part(topic)}"
+        return f"{_prefix(namespace)}:global:{_normalize_part(topic)}"
 
     @classmethod
-    def custom(cls, scope_key: "str", *, topic: "str" = "events") -> "str":
+    def custom(
+        cls, scope_key: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None
+    ) -> "str":
         """Return a custom queue event channel."""
-        return f"{cls.prefix}:custom:{_normalize_part(scope_key, allow_colon=True)}:{_normalize_part(topic)}"
+        return f"{_prefix(namespace)}:custom:{_normalize_part(scope_key, allow_colon=True)}:{_normalize_part(topic)}"
+
+
+def _prefix(namespace: "QueueNamespace | str | None") -> str:
+    if namespace is None:
+        return QueueChannels.prefix
+    return namespace.root if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace).root
 
 
 def _normalize_part(value: "str", *, allow_colon: "bool" = False) -> "str":

--- a/src/litestar_queues/events/channels.py
+++ b/src/litestar_queues/events/channels.py
@@ -19,16 +19,12 @@ class QueueChannels:
     prefix: "ClassVar[str]" = "litestar_queues"
 
     @classmethod
-    def task(
-        cls, task_id: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None
-    ) -> "str":
+    def task(cls, task_id: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None) -> "str":
         """Return the channel for task-scoped events."""
         return f"{_prefix(namespace)}:task:{_normalize_part(task_id)}:{_normalize_part(topic)}"
 
     @classmethod
-    def queue(
-        cls, queue: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None
-    ) -> "str":
+    def queue(cls, queue: "str", *, topic: "str" = "events", namespace: "QueueNamespace | str | None" = None) -> "str":
         """Return the channel for queue-scoped events."""
         return f"{_prefix(namespace)}:queue:{_normalize_part(queue)}:{_normalize_part(topic)}"
 

--- a/src/litestar_queues/events/publisher.py
+++ b/src/litestar_queues/events/publisher.py
@@ -8,6 +8,7 @@ from litestar_queues.events.buffer import LiveEventBuffer, event_buffer_key
 from litestar_queues.events.channels import QueueChannels
 from litestar_queues.events.sinks import NoopQueueEventSink, QueueEventSink, default_publish_many
 from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -84,6 +85,7 @@ class QueueEventPublisher:
         "_event_log",
         "_event_log_strict",
         "_live_failure_signature",
+        "_namespace",
         "_sink",
         "publish_global_lifecycle",
         "publish_queue_channel",
@@ -102,6 +104,7 @@ class QueueEventPublisher:
         publish_task_channel: "bool" = True,
         publish_queue_channel: "bool" = True,
         publish_global_lifecycle: "bool" = False,
+        namespace: "QueueNamespace | str | None" = None,
     ) -> "None":
         self._sink = sink or NoopQueueEventSink()
         self._event_log = event_log
@@ -116,6 +119,7 @@ class QueueEventPublisher:
         self.publish_queue_channel = publish_queue_channel
         self.publish_global_lifecycle = publish_global_lifecycle
         self._live_failure_signature: "tuple[str, str] | None" = None
+        self._namespace = namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
 
     @property
     def sink(self) -> "QueueEventSink":
@@ -228,22 +232,22 @@ class QueueEventPublisher:
         """Return canonical publish channels for an event plus explicit extras."""
         resolved: "list[str]" = []
         if self.publish_task_channel and event.task_id is not None:
-            resolved.append(QueueChannels.task(event.task_id))
+            resolved.append(QueueChannels.task(event.task_id, namespace=self._namespace))
         if event.scope == "queue" and event.scope_key is not None:
-            resolved.append(QueueChannels.queue(event.scope_key))
+            resolved.append(QueueChannels.queue(event.scope_key, namespace=self._namespace))
         if self.publish_queue_channel and event.queue is not None:
-            resolved.append(QueueChannels.queue(event.queue))
+            resolved.append(QueueChannels.queue(event.queue, namespace=self._namespace))
         if event.scope == "worker" and event.worker_id is not None:
-            resolved.append(QueueChannels.worker(event.worker_id))
+            resolved.append(QueueChannels.worker(event.worker_id, namespace=self._namespace))
         if event.scope == "global":
-            resolved.append(QueueChannels.global_channel())
+            resolved.append(QueueChannels.global_channel(namespace=self._namespace))
         if event.scope == "custom" and event.scope_key is not None:
-            resolved.append(QueueChannels.custom(event.scope_key))
+            resolved.append(QueueChannels.custom(event.scope_key, namespace=self._namespace))
         if self.publish_global_lifecycle and event.type in _LIFECYCLE_EVENT_TYPES:
-            resolved.append(QueueChannels.global_channel())
+            resolved.append(QueueChannels.global_channel(namespace=self._namespace))
         if channels:
             resolved.extend(channels)
-        return _dedupe(resolved or [QueueChannels.global_channel()])
+        return _dedupe(resolved or [QueueChannels.global_channel(namespace=self._namespace)])
 
 
 def _dedupe(channels: "Sequence[str]") -> "tuple[str, ...]":

--- a/src/litestar_queues/events/publisher.py
+++ b/src/litestar_queues/events/publisher.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
 __all__ = ("EventBufferConfig", "QueueEventPublisher")
 
-logger = logging.getLogger(__name__)
-
 
 class _QueueEventHistoryWriter(Protocol):
     async def publish_event(self, event: "QueueEvent") -> "None":
@@ -85,6 +83,7 @@ class QueueEventPublisher:
         "_event_log",
         "_event_log_strict",
         "_live_failure_signature",
+        "_logger",
         "_namespace",
         "_sink",
         "publish_global_lifecycle",
@@ -106,11 +105,18 @@ class QueueEventPublisher:
         publish_global_lifecycle: "bool" = False,
         namespace: "QueueNamespace | str | None" = None,
     ) -> "None":
+        self._namespace = namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
+        self._logger = logging.getLogger(self._namespace.logger("events", "publisher"))
         self._sink = sink or NoopQueueEventSink()
         self._event_log = event_log
         self._event_log_strict = event_log_strict
         self._buffer = (
-            LiveEventBuffer(buffer_config, sink_publish=self._deliver_live_many, record_drop=_ignore_buffer_drop)
+            LiveEventBuffer(
+                buffer_config,
+                sink_publish=self._deliver_live_many,
+                record_drop=_ignore_buffer_drop,
+                runtime_logger=self._logger,
+            )
             if buffer_config is not None
             else None
         )
@@ -119,7 +125,6 @@ class QueueEventPublisher:
         self.publish_queue_channel = publish_queue_channel
         self.publish_global_lifecycle = publish_global_lifecycle
         self._live_failure_signature: "tuple[str, str] | None" = None
-        self._namespace = namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
 
     @property
     def sink(self) -> "QueueEventSink":
@@ -143,7 +148,7 @@ class QueueEventPublisher:
             except Exception:
                 if self.strict:
                     raise
-                logger.warning(
+                self._logger.warning(
                     "Queue event buffer publish failed",
                     exc_info=True,
                     extra={"queue_event_type": event.type, "queue_event_id": event.id},
@@ -155,7 +160,7 @@ class QueueEventPublisher:
             except Exception:
                 if self.strict:
                     raise
-                logger.warning(
+                self._logger.warning(
                     "Queue event buffer flush failed",
                     exc_info=True,
                     extra={"queue_event_type": event.type, "queue_event_id": event.id},
@@ -183,7 +188,7 @@ class QueueEventPublisher:
         except Exception:
             if self.strict:
                 raise
-            logger.warning(
+            self._logger.warning(
                 "Queue event publish failed",
                 exc_info=True,
                 extra={"queue_event_type": event.type, "queue_event_id": event.id},
@@ -209,10 +214,10 @@ class QueueEventPublisher:
         # spamming a WARNING per batch. Reset happens on the next successful delivery.
         signature = (type(exc).__name__, str(exc))
         if signature == self._live_failure_signature:
-            logger.debug("Queue event batch publish failed", extra={"queue_event_count": count})
+            self._logger.debug("Queue event batch publish failed", extra={"queue_event_count": count})
             return
         self._live_failure_signature = signature
-        logger.warning("Queue event batch publish failed", exc_info=exc, extra={"queue_event_count": count})
+        self._logger.warning("Queue event batch publish failed", exc_info=exc, extra={"queue_event_count": count})
 
     async def _record_event(self, event: "QueueEvent") -> "None":
         if self._event_log is None:
@@ -222,7 +227,7 @@ class QueueEventPublisher:
         except Exception:
             if self._event_log_strict:
                 raise
-            logger.warning(
+            self._logger.warning(
                 "Queue event history publish failed",
                 exc_info=True,
                 extra={"queue_event_type": event.type, "queue_event_id": event.id},

--- a/src/litestar_queues/events/publisher.py
+++ b/src/litestar_queues/events/publisher.py
@@ -105,7 +105,9 @@ class QueueEventPublisher:
         publish_global_lifecycle: "bool" = False,
         namespace: "QueueNamespace | str | None" = None,
     ) -> "None":
-        self._namespace = namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
+        self._namespace = (
+            namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
+        )
         self._logger = logging.getLogger(self._namespace.logger("events", "publisher"))
         self._sink = sink or NoopQueueEventSink()
         self._event_log = event_log

--- a/src/litestar_queues/events/sinks.py
+++ b/src/litestar_queues/events/sinks.py
@@ -6,6 +6,8 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Protocol
 
+from litestar_queues.namespace import QueueNamespace
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -80,12 +82,20 @@ class NoopQueueEventSink:
 class CompositeQueueEventSink:
     """Deliver events to multiple sinks in deterministic order."""
 
-    __slots__ = ("_opened_sinks", "_sinks", "_strict")
+    __slots__ = ("_logger", "_opened_sinks", "_sinks", "_strict")
 
-    def __init__(self, sinks: "Sequence[QueueEventSink]", *, strict: "bool" = False) -> "None":
+    def __init__(
+        self,
+        sinks: "Sequence[QueueEventSink]",
+        *,
+        strict: "bool" = False,
+        namespace: "QueueNamespace | str | None" = None,
+    ) -> "None":
+        names = namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
         self._sinks = tuple(sinks)
         self._strict = strict
         self._opened_sinks: "tuple[QueueEventSink, ...]" = ()
+        self._logger = logging.getLogger(names.logger("events", "sinks"))
 
     @property
     def sinks(self) -> "tuple[QueueEventSink, ...]":
@@ -106,7 +116,7 @@ class CompositeQueueEventSink:
                 try:
                     await _call_optional_lifecycle(sink, "close")
                 except BaseException:  # noqa: PERF203
-                    logger.warning("Queue event sink rollback failed", exc_info=True)
+                    self._logger.warning("Queue event sink rollback failed", exc_info=True)
             raise
         self._opened_sinks = tuple(opened)
 
@@ -121,7 +131,7 @@ class CompositeQueueEventSink:
             except BaseException as exc:  # noqa: PERF203
                 errors.append(exc)
                 if not self._strict and isinstance(exc, Exception):
-                    logger.warning("Queue event sink close failed", exc_info=True)
+                    self._logger.warning("Queue event sink close failed", exc_info=True)
         error = _select_lifecycle_error(errors)
         if error is not None and (self._strict or not isinstance(error, Exception)):
             raise error
@@ -142,7 +152,7 @@ class CompositeQueueEventSink:
         except Exception:
             if self._strict:
                 raise
-            logger.warning("Queue event sink publish failed", exc_info=True)
+            self._logger.warning("Queue event sink publish failed", exc_info=True)
 
     async def _publish_batch_to_sink(
         self, sink: "QueueEventSink", batch: "Sequence[tuple[QueueEvent, Sequence[str]]]"
@@ -156,7 +166,7 @@ class CompositeQueueEventSink:
         except Exception:
             if self._strict:
                 raise
-            logger.warning("Queue event sink batch publish failed", exc_info=True)
+            self._logger.warning("Queue event sink batch publish failed", exc_info=True)
 
 
 class InMemoryQueueEventSink:

--- a/src/litestar_queues/events/stream_config.py
+++ b/src/litestar_queues/events/stream_config.py
@@ -1,11 +1,12 @@
 """Configuration for plugin-owned queue event streaming endpoints."""
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from litestar_queues.events.models import QueueEventScope
 from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from litestar.connection import ASGIConnection
@@ -24,6 +25,7 @@ EventStreamTransport = Literal["sse", "websocket"]
 UnauthenticatedAccess = Literal["warn", "allow", "error"]
 
 _DEFAULT_STREAM_SCOPES: "tuple[QueueEventScope, ...]" = ("task", "queue", "worker", "global", "custom")
+_DEFAULT_STREAM_PATH = cast("str", object())
 
 
 def _default_stream_scopes() -> "set[QueueEventScope]":
@@ -37,8 +39,10 @@ class EventStreamConfig:
     transports: "set[EventStreamTransport]" = field(default_factory=lambda: {"sse", "websocket"})
     """Enabled browser stream transports."""
 
-    path: "str" = "/queues/events"
+    path: "str" = _DEFAULT_STREAM_PATH
     """Leading-slash route path shared by configured stream transports."""
+
+    _path_derived: "bool" = field(init=False, repr=False)
 
     guards: list[Guard] | None = None
     """Litestar route guards applied to stream endpoints; ``None`` adds none."""
@@ -66,6 +70,9 @@ class EventStreamConfig:
 
     def __post_init__(self) -> "None":
         """Validate stream routing, authorization, and replay bounds."""
+        self._path_derived = self.path is _DEFAULT_STREAM_PATH
+        if self._path_derived:
+            self.path = "/queues/events"
         if not self.transports or not self.transports <= {"sse", "websocket"}:
             msg = "EventStreamConfig.transports must contain sse and/or websocket."
             raise QueueConfigurationError(msg)
@@ -81,3 +88,12 @@ class EventStreamConfig:
         if self.replay_limit < 0:
             msg = "EventStreamConfig.replay_limit must be greater than or equal to 0."
             raise QueueConfigurationError(msg)
+
+    def resolve(self, namespace: "QueueNamespace | None" = None) -> "EventStreamConfig":
+        """Resolve the namespace-owned default path without mutating this reusable config."""
+        if not self._path_derived:
+            return self
+        names = namespace or QueueNamespace()
+        if names.is_default:
+            return self
+        return replace(self, path=f"/{names.resource()}/events")

--- a/src/litestar_queues/events/streaming.py
+++ b/src/litestar_queues/events/streaming.py
@@ -327,6 +327,7 @@ def _build_stream_router(
         A router containing one handler per recognized configured scope for each
         enabled transport (WebSocket and/or SSE).
     """
+    stream_config = stream_config.resolve(config.names)
     authorizer = stream_config.channel_authorizer
     history = stream_config.replay_limit
     configured_channels_backend = _configured_stream_channels_backend(config, channels_backend)
@@ -514,9 +515,7 @@ def _sse_frame(
     return {"event": event.type, "data": event.to_json().decode("utf-8")}
 
 
-def _append_task_handler(
-    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
-) -> None:
+def _append_task_handler(handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace") -> None:
     if "task" not in scopes:
         return
 
@@ -534,9 +533,7 @@ def _append_sse_task_handler(
         return
 
     @get(
-        "/sse/tasks/{task_id:str}",
-        name=namespace.registration("event", "sse", "task"),
-        media_type="text/event-stream",
+        "/sse/tasks/{task_id:str}", name=namespace.registration("event", "sse", "task"), media_type="text/event-stream"
     )
     async def task_sse(request: Request, task_id: FromPath[str]) -> Any:
         return await relay(request, "task", task_id, QueueChannels.task(task_id, namespace=namespace))
@@ -544,9 +541,7 @@ def _append_sse_task_handler(
     handlers.append(task_sse)
 
 
-def _append_queue_handler(
-    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
-) -> None:
+def _append_queue_handler(handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace") -> None:
     if "queue" not in scopes:
         return
 
@@ -564,9 +559,7 @@ def _append_sse_queue_handler(
         return
 
     @get(
-        "/sse/queues/{queue:str}",
-        name=namespace.registration("event", "sse", "queue"),
-        media_type="text/event-stream",
+        "/sse/queues/{queue:str}", name=namespace.registration("event", "sse", "queue"), media_type="text/event-stream"
     )
     async def queue_sse(request: Request, queue: FromPath[str]) -> Any:
         return await relay(request, "queue", queue, QueueChannels.queue(queue, namespace=namespace))

--- a/src/litestar_queues/events/streaming.py
+++ b/src/litestar_queues/events/streaming.py
@@ -23,7 +23,6 @@ from litestar.exceptions import PermissionDeniedException, WebSocketException
 from litestar.params import FromPath
 from litestar.response import ServerSentEvent
 
-from litestar_queues.config import _OBSERVABILITY_RUNTIME_STATE_KEY
 from litestar_queues.events.channels import QueueChannels
 from litestar_queues.events.models import QueueEvent, QueueEventScope
 
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
     from litestar_queues.config import QueueConfig
     from litestar_queues.events.stream_config import EventStreamConfig
     from litestar_queues.events.typing import ChannelsLike, ChannelsStreamBackend, ChannelsSubscriptionBackend
+    from litestar_queues.namespace import QueueNamespace
     from litestar_queues.observability import QueueObservabilityRuntimeProtocol
 
 __all__ = ("StreamMetrics",)
@@ -290,7 +290,7 @@ def _resolve_observability_runtime(
     state = getattr(app, "state", None)
     if state is None:
         return None
-    key = _OBSERVABILITY_RUNTIME_STATE_KEY
+    key = config.observability_runtime_state_key
     with contextlib.suppress(KeyError, TypeError):
         runtime = state[key]
         if runtime is not None:
@@ -385,17 +385,17 @@ def _build_stream_router(
 
     handlers: list[Any] = []
     if "websocket" in stream_config.transports:
-        _append_task_handler(handlers, stream_config.scopes, _relay)
-        _append_queue_handler(handlers, stream_config.scopes, _relay)
-        _append_worker_handler(handlers, stream_config.scopes, _relay)
-        _append_global_handler(handlers, stream_config.scopes, _relay)
-        _append_custom_handler(handlers, stream_config.scopes, _relay)
+        _append_task_handler(handlers, stream_config.scopes, _relay, config.names)
+        _append_queue_handler(handlers, stream_config.scopes, _relay, config.names)
+        _append_worker_handler(handlers, stream_config.scopes, _relay, config.names)
+        _append_global_handler(handlers, stream_config.scopes, _relay, config.names)
+        _append_custom_handler(handlers, stream_config.scopes, _relay, config.names)
     if "sse" in stream_config.transports:
-        _append_sse_task_handler(handlers, stream_config.scopes, _sse)
-        _append_sse_queue_handler(handlers, stream_config.scopes, _sse)
-        _append_sse_worker_handler(handlers, stream_config.scopes, _sse)
-        _append_sse_global_handler(handlers, stream_config.scopes, _sse)
-        _append_sse_custom_handler(handlers, stream_config.scopes, _sse)
+        _append_sse_task_handler(handlers, stream_config.scopes, _sse, config.names)
+        _append_sse_queue_handler(handlers, stream_config.scopes, _sse, config.names)
+        _append_sse_worker_handler(handlers, stream_config.scopes, _sse, config.names)
+        _append_sse_global_handler(handlers, stream_config.scopes, _sse, config.names)
+        _append_sse_custom_handler(handlers, stream_config.scopes, _sse, config.names)
 
     return Router(
         path=stream_config.path,
@@ -514,111 +514,147 @@ def _sse_frame(
     return {"event": event.type, "data": event.to_json().decode("utf-8")}
 
 
-def _append_task_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_task_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "task" not in scopes:
         return
 
-    @websocket("/tasks/{task_id:str}", name="queue_event_stream_task")
+    @websocket("/tasks/{task_id:str}", name=namespace.registration("event", "stream", "task"))
     async def task_stream(socket: "WebSocket", task_id: FromPath[str]) -> None:
-        await relay(socket, "task", task_id, QueueChannels.task(task_id))
+        await relay(socket, "task", task_id, QueueChannels.task(task_id, namespace=namespace))
 
     handlers.append(task_stream)
 
 
-def _append_sse_task_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_sse_task_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "task" not in scopes:
         return
 
-    @get("/sse/tasks/{task_id:str}", name="queue_event_sse_task", media_type="text/event-stream")
+    @get(
+        "/sse/tasks/{task_id:str}",
+        name=namespace.registration("event", "sse", "task"),
+        media_type="text/event-stream",
+    )
     async def task_sse(request: Request, task_id: FromPath[str]) -> Any:
-        return await relay(request, "task", task_id, QueueChannels.task(task_id))
+        return await relay(request, "task", task_id, QueueChannels.task(task_id, namespace=namespace))
 
     handlers.append(task_sse)
 
 
-def _append_queue_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_queue_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "queue" not in scopes:
         return
 
-    @websocket("/queues/{queue:str}", name="queue_event_stream_queue")
+    @websocket("/queues/{queue:str}", name=namespace.registration("event", "stream", "queue"))
     async def queue_stream(socket: "WebSocket", queue: FromPath[str]) -> None:
-        await relay(socket, "queue", queue, QueueChannels.queue(queue))
+        await relay(socket, "queue", queue, QueueChannels.queue(queue, namespace=namespace))
 
     handlers.append(queue_stream)
 
 
-def _append_sse_queue_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_sse_queue_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "queue" not in scopes:
         return
 
-    @get("/sse/queues/{queue:str}", name="queue_event_sse_queue", media_type="text/event-stream")
+    @get(
+        "/sse/queues/{queue:str}",
+        name=namespace.registration("event", "sse", "queue"),
+        media_type="text/event-stream",
+    )
     async def queue_sse(request: Request, queue: FromPath[str]) -> Any:
-        return await relay(request, "queue", queue, QueueChannels.queue(queue))
+        return await relay(request, "queue", queue, QueueChannels.queue(queue, namespace=namespace))
 
     handlers.append(queue_sse)
 
 
-def _append_worker_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_worker_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "worker" not in scopes:
         return
 
-    @websocket("/workers/{worker_id:str}", name="queue_event_stream_worker")
+    @websocket("/workers/{worker_id:str}", name=namespace.registration("event", "stream", "worker"))
     async def worker_stream(socket: "WebSocket", worker_id: FromPath[str]) -> None:
-        await relay(socket, "worker", worker_id, QueueChannels.worker(worker_id))
+        await relay(socket, "worker", worker_id, QueueChannels.worker(worker_id, namespace=namespace))
 
     handlers.append(worker_stream)
 
 
-def _append_sse_worker_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_sse_worker_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "worker" not in scopes:
         return
 
-    @get("/sse/workers/{worker_id:str}", name="queue_event_sse_worker", media_type="text/event-stream")
+    @get(
+        "/sse/workers/{worker_id:str}",
+        name=namespace.registration("event", "sse", "worker"),
+        media_type="text/event-stream",
+    )
     async def worker_sse(request: Request, worker_id: FromPath[str]) -> Any:
-        return await relay(request, "worker", worker_id, QueueChannels.worker(worker_id))
+        return await relay(request, "worker", worker_id, QueueChannels.worker(worker_id, namespace=namespace))
 
     handlers.append(worker_sse)
 
 
-def _append_global_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_global_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "global" not in scopes:
         return
 
-    @websocket("/global", name="queue_event_stream_global")
+    @websocket("/global", name=namespace.registration("event", "stream", "global"))
     async def global_stream(socket: "WebSocket") -> None:
-        await relay(socket, "global", None, QueueChannels.global_channel())
+        await relay(socket, "global", None, QueueChannels.global_channel(namespace=namespace))
 
     handlers.append(global_stream)
 
 
-def _append_sse_global_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_sse_global_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "global" not in scopes:
         return
 
-    @get("/sse/global", name="queue_event_sse_global", media_type="text/event-stream")
+    @get("/sse/global", name=namespace.registration("event", "sse", "global"), media_type="text/event-stream")
     async def global_sse(request: Request) -> Any:
-        return await relay(request, "global", None, QueueChannels.global_channel())
+        return await relay(request, "global", None, QueueChannels.global_channel(namespace=namespace))
 
     handlers.append(global_sse)
 
 
-def _append_custom_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_custom_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "custom" not in scopes:
         return
 
-    @websocket("/custom/{scope_key:str}", name="queue_event_stream_custom")
+    @websocket("/custom/{scope_key:str}", name=namespace.registration("event", "stream", "custom"))
     async def custom_stream(socket: "WebSocket", scope_key: FromPath[str]) -> None:
-        await relay(socket, "custom", scope_key, QueueChannels.custom(scope_key))
+        await relay(socket, "custom", scope_key, QueueChannels.custom(scope_key, namespace=namespace))
 
     handlers.append(custom_stream)
 
 
-def _append_sse_custom_handler(handlers: list[Any], scopes: Container[str], relay: Any) -> None:
+def _append_sse_custom_handler(
+    handlers: list[Any], scopes: Container[str], relay: Any, namespace: "QueueNamespace"
+) -> None:
     if "custom" not in scopes:
         return
 
-    @get("/sse/custom/{scope_key:str}", name="queue_event_sse_custom", media_type="text/event-stream")
+    @get(
+        "/sse/custom/{scope_key:str}",
+        name=namespace.registration("event", "sse", "custom"),
+        media_type="text/event-stream",
+    )
     async def custom_sse(request: Request, scope_key: FromPath[str]) -> Any:
-        return await relay(request, "custom", scope_key, QueueChannels.custom(scope_key))
+        return await relay(request, "custom", scope_key, QueueChannels.custom(scope_key, namespace=namespace))
 
     handlers.append(custom_sse)

--- a/src/litestar_queues/execution/base.py
+++ b/src/litestar_queues/execution/base.py
@@ -1,7 +1,10 @@
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from typing_extensions import Self
+
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -71,11 +74,13 @@ class DispatchRepairResult:
 class BaseExecutionBackend:
     """Base class for queue execution backends."""
 
-    __slots__ = ("config",)
+    __slots__ = ("_logger", "config")
 
     def __init__(self, config: "QueueConfig | None" = None) -> "None":
         """Initialize the execution backend."""
         self.config = config
+        names = config.names if config is not None else QueueNamespace()
+        self._logger = logging.getLogger(names.logger("execution", type(self).__name__))
 
     @property
     def is_external(self) -> "bool":

--- a/src/litestar_queues/execution/cloudrun/backend.py
+++ b/src/litestar_queues/execution/cloudrun/backend.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
+from litestar_queues._environment import TASK_ID_ENV
 from litestar_queues.backends.base import EXTERNAL_DISPATCH_RESERVATION_PREFIX
 from litestar_queues.events import QueueEvent
 from litestar_queues.exceptions import MissingDependencyError
@@ -32,7 +33,6 @@ __all__ = ("CloudRunExecutionBackend", "CloudRunExecutionStatus")
 
 _GOOGLE_CLOUD_RUN_PACKAGE = "google-cloud-run"
 _CLOUDRUN_EXTRA = "cloudrun"
-_TASK_ID_ENV_SUFFIX = "TASK_ID"
 _DISPATCH_RESERVATION_LEASE_SECONDS = 15 * 60
 _DISPATCH_OWNERSHIP_LOST_ERROR = "Cloud Run dispatch reservation ownership was lost before finalization"
 _HTTP_NOT_FOUND = 404
@@ -279,7 +279,7 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         except Exception as exc:
             if _is_not_found_error(exc):
                 return CloudRunExecutionStatus(running=False, failed=True, error="Cloud Run execution not found")
-            logger.warning(
+            self._logger.warning(
                 "Cloud Run status probe failed", exc_info=True, extra={"cloudrun_execution_ref": execution_ref}
             )
             return CloudRunExecutionStatus(running=True, error=str(exc))
@@ -319,14 +319,14 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         """Build the single-value task environment for a Cloud Run task process.
 
         The record travels as its id in one prefix-aware environment variable
-        (``LITESTAR_QUEUES_TASK_ID`` by default); the consumer re-fetches the
+        (``QUEUES_TASK_ID``); the consumer re-fetches the
         live record by that id. Adopter ``extra_env`` values are merged in.
 
         Returns:
             Environment variables for the Cloud Run task process.
         """
         config = self.execution_config
-        env = {config.env_name(_TASK_ID_ENV_SUFFIX): str(record.id)}
+        env = {TASK_ID_ENV: str(record.id)}
         env.update(config.extra_env)
         return env
 
@@ -352,7 +352,7 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         self, service: "QueueService", record: "QueuedTaskRecord", exc: "BaseException"
     ) -> "None":
         fallback = self.execution_config.fallback_execution_backend
-        logger.warning(
+        self._logger.warning(
             "Cloud Run dispatch failed",
             exc_info=(type(exc), exc, exc.__traceback__),
             extra={
@@ -385,7 +385,7 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
                 )
             )
         except Exception:
-            logger.warning(
+            self._logger.warning(
                 "Cloud Run dispatch failure event publish failed",
                 exc_info=True,
                 extra={"queue_task_id": str(record.id)},

--- a/src/litestar_queues/execution/cloudrun/config.py
+++ b/src/litestar_queues/execution/cloudrun/config.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
 
+from litestar_queues._environment import TASK_ID_ENV
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
     from litestar_queues.config import QueueConfig
+    from litestar_queues.namespace import QueueNamespace
 
 __all__ = ("CloudRunExecutionConfig",)
 
@@ -29,8 +31,8 @@ class CloudRunExecutionConfig:
     timeout: "int" = 300
     """Cloud Run API operation timeout in seconds."""
 
-    env_prefix: "str" = "LITESTAR_QUEUES"
-    """Prefix used for environment variables passed to Cloud Run jobs."""
+    env_prefix: "str | None" = None
+    """Explicit environment prefix; ``None`` derives it from ``QueueConfig.namespace``."""
 
     extra_env: "dict[str, str]" = field(default_factory=dict)
     """Additional environment variables passed to every Cloud Run execution."""
@@ -56,10 +58,13 @@ class CloudRunExecutionConfig:
         msg = "CloudRunExecutionConfig requires job_name or profiles['default']."
         raise QueueConfigurationError(msg)
 
-    def env_name(self, suffix: "str") -> "str":
+    def env_name(self, suffix: "str", *, namespace: "QueueNamespace | None" = None) -> "str":
         """Return an environment variable name using the configured prefix."""
-        normalized = suffix.upper().removeprefix(f"{self.env_prefix}_")
-        return f"{self.env_prefix}_{normalized}"
+        if suffix.upper() == "TASK_ID":
+            return TASK_ID_ENV
+        prefix = self.env_prefix or (namespace.root.upper() if namespace is not None else "LITESTAR_QUEUES")
+        normalized = suffix.upper().removeprefix(f"{prefix}_")
+        return f"{prefix}_{normalized}"
 
 
 def _execution_config_from_queue_config(config: "QueueConfig | None") -> "CloudRunExecutionConfig":

--- a/src/litestar_queues/execution/cloudtasks/backend.py
+++ b/src/litestar_queues/execution/cloudtasks/backend.py
@@ -45,7 +45,6 @@ __all__ = ("CloudTasksExecutionBackend",)
 _GOOGLE_CLOUD_TASKS_PACKAGE = "google-cloud-tasks"
 _CLOUD_TASKS_EXTRA = "cloud-tasks"
 _BACKEND_NAME = CLOUD_TASKS_BACKEND_NAME
-_DELIVERY_PREFIX = "lq-"
 _HTTP_CONFLICT = 409
 _HTTP_NOT_FOUND = 404
 # A record a consumer already holds is excluded: Cloud Tasks keeps that delivery
@@ -500,7 +499,8 @@ def _delivery_name(config: "CloudTasksExecutionConfig", record: "QueuedTaskRecor
 
 
 def _delivery_name_prefix(config: "CloudTasksExecutionConfig", record: "QueuedTaskRecord") -> "str":
-    return f"{config.queue_path}/tasks/{_DELIVERY_PREFIX}{record.id.hex}-r{record.retry_count}-"
+    delivery_name_prefix = config.delivery_name_prefix or "lq-"
+    return f"{config.queue_path}/tasks/{delivery_name_prefix}{record.id.hex}-r{record.retry_count}-"
 
 
 def _is_current_delivery_name(name: "str", config: "CloudTasksExecutionConfig", record: "QueuedTaskRecord") -> "bool":

--- a/src/litestar_queues/execution/cloudtasks/backend.py
+++ b/src/litestar_queues/execution/cloudtasks/backend.py
@@ -155,7 +155,7 @@ class CloudTasksExecutionBackend(BaseExecutionBackend):
     def execution_config(self) -> "CloudTasksExecutionConfig":
         """Resolved Cloud Tasks execution config."""
         if self._execution_config is not None:
-            return self._execution_config
+            return self._execution_config.resolve(self.config.names if self.config is not None else None)
         return _execution_config_from_queue_config(self.config)
 
     async def schedule(self, service: "QueueService", record: "QueuedTaskRecord") -> "str | None":
@@ -409,7 +409,7 @@ class CloudTasksExecutionBackend(BaseExecutionBackend):
         both.
         """
         message = operation.failure_message
-        logger.warning(
+        self._logger.warning(
             message,
             exc_info=(type(exc), exc, exc.__traceback__),
             extra={
@@ -437,7 +437,7 @@ class CloudTasksExecutionBackend(BaseExecutionBackend):
                 )
             )
         except Exception:
-            logger.warning(
+            self._logger.warning(
                 "Cloud Tasks delivery failure event publish failed",
                 exc_info=True,
                 extra={"queue_task_id": str(record.id)},

--- a/src/litestar_queues/execution/cloudtasks/config.py
+++ b/src/litestar_queues/execution/cloudtasks/config.py
@@ -1,10 +1,11 @@
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from urllib.parse import urlsplit
 
 from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from litestar.types import Guard
@@ -33,6 +34,7 @@ route cannot drift apart while both still look correct on their own.
 
 _MIN_DISPATCH_DEADLINE = 15
 _MAX_DISPATCH_DEADLINE = 1800
+_DEFAULT_ROUTE_PATH = cast("str", object())
 
 
 def _require_finite_positive(name: "str", value: "Any") -> "None":
@@ -74,8 +76,10 @@ class CloudTasksExecutionConfig:
     audience: "str | None" = None
     """OIDC audience; ``None`` resolves to the :attr:`service_url` origin."""
 
-    route_path: "str" = "/_litestar-queues/cloud-tasks"
+    route_path: "str" = _DEFAULT_ROUTE_PATH
     """Path the consumer route is mounted on."""
+
+    _route_path_derived: "bool" = field(init=False, repr=False)
 
     dispatch_deadline: "int" = 1800
     """Seconds Cloud Tasks waits for a delivery response before abandoning it."""
@@ -102,6 +106,9 @@ class CloudTasksExecutionConfig:
         accepted it and will keep retrying a request that can never succeed. So
         every rule runs before the first record is persisted.
         """
+        self._route_path_derived = self.route_path is _DEFAULT_ROUTE_PATH
+        if self._route_path_derived:
+            self.route_path = "/_litestar-queues/cloud-tasks"
         self._validate_identifiers()
         self._validate_delivery_target()
         self._validate_budgets()
@@ -214,6 +221,13 @@ class CloudTasksExecutionConfig:
         """Absolute URL Cloud Tasks posts each record to."""
         return f"{self.service_url.rstrip('/')}{self.route_path}"
 
+    def resolve(self, namespace: "QueueNamespace | None" = None) -> "CloudTasksExecutionConfig":
+        """Resolve namespace-owned defaults without mutating this reusable config."""
+        if not self._route_path_derived:
+            return self
+        names = namespace or QueueNamespace()
+        return replace(self, route_path=f"/_{names.resource()}/cloud-tasks")
+
     @property
     def queue_path(self) -> "str":
         """Fully qualified Cloud Tasks queue resource name."""
@@ -230,7 +244,7 @@ def _execution_config_from_queue_config(config: "QueueConfig | None") -> "CloudT
         QueueConfigurationError: If no typed Cloud Tasks config is available.
     """
     if config is not None and isinstance(config.execution_backend, CloudTasksExecutionConfig):
-        return config.execution_backend
+        return config.execution_backend.resolve(config.names)
 
     msg = (
         "Cloud Tasks execution requires QueueConfig.execution_backend with a "

--- a/src/litestar_queues/execution/cloudtasks/config.py
+++ b/src/litestar_queues/execution/cloudtasks/config.py
@@ -81,6 +81,9 @@ class CloudTasksExecutionConfig:
 
     _route_path_derived: "bool" = field(init=False, repr=False)
 
+    delivery_name_prefix: "str | None" = None
+    """Cloud Tasks task-name prefix; ``None`` derives it from ``QueueConfig.namespace``."""
+
     dispatch_deadline: "int" = 1800
     """Seconds Cloud Tasks waits for a delivery response before abandoning it."""
 
@@ -135,6 +138,12 @@ class CloudTasksExecutionConfig:
             if not isinstance(value, str) or not value.strip():
                 msg = f"CloudTasksExecutionConfig.{name} must be a non-empty value."
                 raise QueueConfigurationError(msg)
+        if self.delivery_name_prefix is not None and (
+            not self.delivery_name_prefix
+            or not all(character.isalnum() or character in {"-", "_"} for character in self.delivery_name_prefix)
+        ):
+            msg = "CloudTasksExecutionConfig.delivery_name_prefix must contain only letters, digits, '-' and '_'."
+            raise QueueConfigurationError(msg)
 
     def _validate_delivery_target(self) -> "None":
         """Reject a service origin or route path Cloud Tasks cannot deliver to.
@@ -223,10 +232,14 @@ class CloudTasksExecutionConfig:
 
     def resolve(self, namespace: "QueueNamespace | None" = None) -> "CloudTasksExecutionConfig":
         """Resolve namespace-owned defaults without mutating this reusable config."""
-        if not self._route_path_derived:
+        if not self._route_path_derived and self.delivery_name_prefix is not None:
             return self
         names = namespace or QueueNamespace()
-        return replace(self, route_path=f"/_{names.resource()}/cloud-tasks")
+        route_path = self.route_path if not self._route_path_derived else f"/_{names.resource()}/cloud-tasks"
+        delivery_name_prefix = self.delivery_name_prefix
+        if delivery_name_prefix is None:
+            delivery_name_prefix = "lq-" if names.is_default else f"{names.resource()}-"
+        return replace(self, route_path=route_path, delivery_name_prefix=delivery_name_prefix)
 
     @property
     def queue_path(self) -> "str":

--- a/src/litestar_queues/execution/cloudtasks/routes.py
+++ b/src/litestar_queues/execution/cloudtasks/routes.py
@@ -114,13 +114,14 @@ async def _run_delivered_record(service: "QueueService", task_id: "UUID") -> "Re
         An empty acknowledgement, or an empty retryable response.
     """
     runtime = service.observability_runtime
+    runtime_logger = logging.getLogger(service.config.names.logger("execution", "cloudtasks", "delivery"))
     try:
         exit_code = await consume_one(service, task_id)
     except QueueDispatchError:
         # Already reported with a sanitized payload where it was raised. The
         # record is durable and active; this same delivery arriving again is
         # what gives it a new Cloud Task.
-        logger.warning(
+        runtime_logger.warning(
             "Cloud Tasks delivery could not schedule the next attempt", extra={"queue_task_id": str(task_id)}
         )
         _record_delivery(runtime, _OUTCOME_TRANSIENT_ERROR)
@@ -129,7 +130,7 @@ async def _run_delivered_record(service: "QueueService", task_id: "UUID") -> "Re
         # Task failures never reach here -- the service records those durably.
         # What is left is the queue itself being unreachable or broken, which
         # says nothing about the task, so the delivery has to survive it.
-        logger.exception("Cloud Tasks delivery failed", extra={"queue_task_id": str(task_id)})
+        runtime_logger.exception("Cloud Tasks delivery failed", extra={"queue_task_id": str(task_id)})
         _record_delivery(runtime, _OUTCOME_TRANSIENT_ERROR)
         return Response(content=None, status_code=_REDELIVER)
 

--- a/src/litestar_queues/maintenance.py
+++ b/src/litestar_queues/maintenance.py
@@ -233,8 +233,9 @@ class QueueMaintenanceService:
             raise QueueConfigurationError(msg)
 
         token = uuid4().hex
+        maintenance_name = getattr(getattr(self._service, "config", None), "maintenance_name", MAINTENANCE_NAME)
         acquired = await backend.acquire_maintenance(
-            MAINTENANCE_NAME, token, ttl=timedelta(seconds=self._config.coordination_timeout)
+            maintenance_name, token, ttl=timedelta(seconds=self._config.coordination_timeout)
         )
         if not acquired:
             results = [QueueMaintenancePhaseResult(phase=phase, status="skipped") for phase in selected]
@@ -259,7 +260,7 @@ class QueueMaintenanceService:
                     continue
                 results.append(await self._run_phase(phase, cutoffs))
         finally:
-            await backend.release_maintenance(MAINTENANCE_NAME, token)
+            await backend.release_maintenance(maintenance_name, token)
 
         return QueueMaintenanceSummary(
             outcome=self._final_outcome(results),

--- a/src/litestar_queues/namespace.py
+++ b/src/litestar_queues/namespace.py
@@ -1,0 +1,84 @@
+"""Runtime namespace rendering for package-owned identifiers."""
+
+import re
+from dataclasses import dataclass
+
+from litestar_queues.exceptions import QueueConfigurationError
+
+__all__ = ("DEFAULT_NAMESPACE", "QueueNamespace")
+
+DEFAULT_NAMESPACE = "litestar_queues"
+_NAMESPACE_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+
+
+@dataclass(frozen=True, slots=True)
+class QueueNamespace:
+    """Validated root for package-owned runtime identifiers."""
+
+    root: str = DEFAULT_NAMESPACE
+
+    def __post_init__(self) -> None:
+        """Reject roots that cannot render consistently across target formats."""
+        if not _NAMESPACE_PATTERN.fullmatch(self.root):
+            msg = (
+                "QueueConfig.namespace must start with a lowercase letter and contain only "
+                "lowercase letters, digits, and single underscores between non-empty segments."
+            )
+            raise QueueConfigurationError(msg)
+
+    def metric(self, *parts: str) -> str:
+        """Render an OpenTelemetry or Prometheus identifier."""
+        return self._join(".", self.root, *parts)
+
+    def logger(self, *parts: str) -> str:
+        """Render a runtime logger name."""
+        return self._join(".", self.root, *parts)
+
+    def channel(self, *parts: str) -> str:
+        """Render a pub/sub or event channel."""
+        return self._join(":", self.root, *parts)
+
+    def key(self, *parts: str) -> str:
+        """Render a storage key."""
+        return self._join(":", self.root, *parts)
+
+    def database_channel(self, *parts: str) -> str:
+        """Render a database notification channel."""
+        return self._join("_", self.root, *parts)
+
+    def registration(self, *parts: str) -> str:
+        """Render a Litestar state, dependency, or route registration."""
+        root = "queue" if self.is_default else self.root
+        return self._join("_", root, *parts)
+
+    def environment(self, *parts: str) -> str:
+        """Render an environment-variable name."""
+        return self._join("_", self.root.upper(), *(part.upper() for part in parts))
+
+    def resource(self, *parts: str) -> str:
+        """Render a process, thread, or filesystem resource name."""
+        root = self.root.replace("_", "-")
+        return self._join("-", root, *(part.replace("_", "-") for part in parts))
+
+    def coordination(self, *parts: str) -> str:
+        """Render a distributed coordination name with legacy compatibility."""
+        root = "queue" if self.is_default else self.root.replace("_", "-")
+        return self._join("-", root, *(part.replace("_", "-") for part in parts))
+
+    def package_task(self, *parts: str) -> str:
+        """Render a package-owned built-in task name with legacy compatibility."""
+        if self.is_default:
+            return self._join(".", *parts)
+        return self.metric(*parts)
+
+    @property
+    def is_default(self) -> bool:
+        """Return whether this root is the compatibility namespace."""
+        return self.root == DEFAULT_NAMESPACE
+
+    @staticmethod
+    def _join(separator: str, *parts: str) -> str:
+        if not parts or any(not part for part in parts):
+            msg = "Namespace identifier parts must be non-empty strings."
+            raise QueueConfigurationError(msg)
+        return separator.join(parts)

--- a/src/litestar_queues/observability.py
+++ b/src/litestar_queues/observability.py
@@ -9,6 +9,7 @@ from litestar_queues._correlation import (
     reset_correlation_id,
 )
 from litestar_queues.exceptions import MissingDependencyError
+from litestar_queues.namespace import DEFAULT_NAMESPACE, QueueNamespace
 from litestar_queues.typing import (
     OPENTELEMETRY_INSTALLED,
     PROMETHEUS_INSTALLED,
@@ -135,11 +136,11 @@ class ObservabilityConfig:
     enable_sqlcommenter: "bool | None" = None
     """SQLCommenter policy; ``None`` follows resolved queue telemetry."""
 
-    tracer_name: "str" = "litestar_queues"
-    """Instrumentation name used to obtain the OpenTelemetry tracer."""
+    tracer_name: "str | None" = None
+    """Instrumentation name; ``None`` uses ``QueueConfig.namespace``."""
 
-    meter_name: "str" = "litestar_queues"
-    """Instrumentation name used to obtain the OpenTelemetry meter."""
+    meter_name: "str | None" = None
+    """Instrumentation name; ``None`` uses ``QueueConfig.namespace``."""
 
     tracer_provider: "Any | None" = None
     """Explicit OpenTelemetry tracer provider; ``None`` uses the global provider."""
@@ -150,8 +151,8 @@ class ObservabilityConfig:
     prometheus_registry: "Any | None" = None
     """Explicit Prometheus registry; ``None`` uses the client default registry."""
 
-    metric_prefix: "str" = "litestar_queues"
-    """Prefix applied to package queue metric names."""
+    metric_prefix: "str | None" = None
+    """Prometheus prefix; ``None`` uses ``QueueConfig.namespace``."""
 
     duration_buckets: "tuple[float, ...]" = field(default=DEFAULT_DURATION_BUCKETS)
     """Prometheus histogram buckets, in seconds, for queue duration metrics."""
@@ -296,6 +297,7 @@ class QueueObservabilityRuntime:
         "_gauges",
         "_histograms",
         "_meter",
+        "_namespace",
         "_otel_enabled",
         "_prometheus_enabled",
         "_registry",
@@ -304,8 +306,17 @@ class QueueObservabilityRuntime:
         "enabled",
     )
 
-    def __init__(self, config: "ObservabilityConfig | None", *, app: "Litestar | None" = None) -> "None":
+    def __init__(
+        self,
+        config: "ObservabilityConfig | None",
+        *,
+        app: "Litestar | None" = None,
+        namespace: "QueueNamespace | str | None" = None,
+    ) -> "None":
         self._config = config
+        self._namespace = (
+            namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or DEFAULT_NAMESPACE)
+        )
         self._otel_enabled = config.should_enable_otel(app) if config is not None else False
         self._prometheus_enabled = config.should_enable_prometheus(app) if config is not None else False
         self._sqlcommenter_enabled = config.should_enable_sqlcommenter(app) if config is not None else False
@@ -333,7 +344,9 @@ class QueueObservabilityRuntime:
         """
         if self._tracer is None:
             config = self._require_config()
-            self._tracer = otel_trace.get_tracer(config.tracer_name, tracer_provider=config.tracer_provider)
+            self._tracer = otel_trace.get_tracer(
+                config.tracer_name or self._namespace.root, tracer_provider=config.tracer_provider
+            )
         return self._tracer
 
     def get_meter(self) -> "Any":
@@ -344,7 +357,9 @@ class QueueObservabilityRuntime:
         """
         if self._meter is None:
             config = self._require_config()
-            self._meter = otel_metrics.get_meter(config.meter_name, meter_provider=config.meter_provider)
+            self._meter = otel_metrics.get_meter(
+                config.meter_name or self._namespace.root, meter_provider=config.meter_provider
+            )
         return self._meter
 
     def start_span(
@@ -369,8 +384,14 @@ class QueueObservabilityRuntime:
             if kind == "consumer"
             else OtelSpanKind.INTERNAL
         )
+        runtime_attributes = dict(attributes)
+        if runtime_attributes.get("messaging.system") == DEFAULT_NAMESPACE:
+            runtime_attributes["messaging.system"] = self._namespace.root
         span = self.get_tracer().start_span(
-            name, context=cast("Any", parent), kind=span_kind, attributes=cast("Any", dict(attributes))
+            self._runtime_name(name),
+            context=cast("Any", parent),
+            kind=span_kind,
+            attributes=cast("Any", runtime_attributes),
         )
         token = otel_context.attach(otel_trace.set_span_in_context(span))
         return _SpanHandle(span, token)
@@ -422,6 +443,7 @@ class QueueObservabilityRuntime:
 
     def record_counter(self, name: "str", value: "int" = 1, *, attributes: "Mapping[str, str]") -> "None":
         """Record a counter value for enabled metrics sinks."""
+        name = self._runtime_name(name)
         if self._otel_enabled:
             counter = self._counters.get(name)
             if counter is None:
@@ -430,12 +452,13 @@ class QueueObservabilityRuntime:
             counter.add(value, attributes=dict(attributes))
         if self._prometheus_enabled:
             collector = self._prometheus_collector(
-                PrometheusCounter, name, _counter_name(name, self._config), attributes
+                PrometheusCounter, name, _counter_name(name, self._metric_prefix()), attributes
             )
             collector.labels(**dict(attributes)).inc(value)
 
     def record_gauge_delta(self, name: "str", delta: "int" = 1, *, attributes: "Mapping[str, str]") -> "None":
         """Record a gauge delta for enabled metrics sinks."""
+        name = self._runtime_name(name)
         if self._otel_enabled:
             key = f"updown:{name}"
             gauge = self._gauges.get(key)
@@ -444,11 +467,14 @@ class QueueObservabilityRuntime:
                 self._gauges[key] = gauge
             gauge.add(delta, attributes=dict(attributes))
         if self._prometheus_enabled:
-            collector = self._prometheus_collector(PrometheusGauge, name, _gauge_name(name, self._config), attributes)
+            collector = self._prometheus_collector(
+                PrometheusGauge, name, _gauge_name(name, self._metric_prefix()), attributes
+            )
             collector.labels(**dict(attributes)).inc(delta)
 
     def record_duration(self, name: "str", seconds: "float", *, attributes: "Mapping[str, str]") -> "None":
         """Record a duration for enabled metrics sinks."""
+        name = self._runtime_name(name)
         if self._otel_enabled:
             histogram = self._durations.get(name)
             if histogram is None:
@@ -457,7 +483,11 @@ class QueueObservabilityRuntime:
             histogram.record(seconds, attributes=dict(attributes))
         if self._prometheus_enabled:
             collector = self._prometheus_collector(
-                PrometheusHistogram, name, _duration_name(name, self._config), attributes, buckets=self._buckets()
+                PrometheusHistogram,
+                name,
+                _duration_name(name, self._metric_prefix()),
+                attributes,
+                buckets=self._buckets(),
             )
             collector.labels(**dict(attributes)).observe(seconds)
 
@@ -467,7 +497,10 @@ class QueueObservabilityRuntime:
         """Record a non-duration histogram sample for enabled metric sinks."""
         if not self.enabled:
             return
-        _validate_transport_metric(name, kind="histogram", unit=unit, attributes=attributes)
+        _validate_transport_metric(
+            self._canonical_name(name), kind="histogram", unit=unit, attributes=attributes
+        )
+        name = self._runtime_name(name)
         if self._otel_enabled:
             key = (name, unit)
             histogram = self._histograms.get(key)
@@ -479,7 +512,7 @@ class QueueObservabilityRuntime:
             collector = self._prometheus_collector(
                 PrometheusHistogram,
                 name,
-                _histogram_name(name, unit, self._config),
+                _histogram_name(name, unit, self._metric_prefix()),
                 attributes,
                 buckets=_VALUE_HISTOGRAM_BUCKETS,
             )
@@ -522,16 +555,32 @@ class QueueObservabilityRuntime:
             raise RuntimeError(msg)
         return self._config
 
+    def _runtime_name(self, name: "str") -> "str":
+        suffix = name.removeprefix(f"{DEFAULT_NAMESPACE}.")
+        return self._namespace.metric(suffix) if suffix != name else name
+
+    def _canonical_name(self, name: "str") -> "str":
+        suffix = name.removeprefix(f"{self._namespace.root}.")
+        return f"{DEFAULT_NAMESPACE}.{suffix}" if suffix != name else name
+
+    def _metric_prefix(self) -> "str":
+        if self._config is not None and self._config.metric_prefix is not None:
+            return self._config.metric_prefix
+        return self._namespace.root
+
 
 def create_observability_runtime(
-    config: "ObservabilityConfig | None", *, app: "Litestar | None" = None
+    config: "ObservabilityConfig | None",
+    *,
+    app: "Litestar | None" = None,
+    namespace: "QueueNamespace | str | None" = None,
 ) -> "QueueObservabilityRuntime":
     """Create the queue observability runtime for a service.
 
     Returns:
         Queue observability runtime instance.
     """
-    return QueueObservabilityRuntime(config, app=app)
+    return QueueObservabilityRuntime(config, app=app, namespace=namespace)
 
 
 def _has_otel_plugin(app: "Litestar") -> "bool":
@@ -559,12 +608,12 @@ def _has_prometheus_middleware(app: "Litestar") -> "bool":
     return False
 
 
-def _base_name(name: "str", config: "ObservabilityConfig | None") -> "tuple[str, str]":
-    prefix = config.metric_prefix if config is not None else "litestar_queues"
-    return prefix, name.removeprefix("litestar_queues.").replace(".", "_")
+def _base_name(name: "str", prefix: "str | None") -> "tuple[str, str]":
+    prefix = prefix or DEFAULT_NAMESPACE
+    return prefix, name.removeprefix(f"{prefix}.").replace(".", "_")
 
 
-def _counter_name(name: "str", config: "ObservabilityConfig | None") -> "str":
+def _counter_name(name: "str", prefix: "str | None") -> "str":
     """Build the Prometheus counter name.
 
     Counter instruments carry no ``.count`` suffix -- the instrument type already
@@ -573,32 +622,32 @@ def _counter_name(name: "str", config: "ObservabilityConfig | None") -> "str":
     Returns:
         The Prometheus collector name for this counter.
     """
-    prefix, base = _base_name(name, config)
+    prefix, base = _base_name(name, prefix)
     return f"{prefix}_{base}"
 
 
-def _gauge_name(name: "str", config: "ObservabilityConfig | None") -> "str":
+def _gauge_name(name: "str", prefix: "str") -> "str":
     """Build the Prometheus gauge name.
 
     Returns:
         The Prometheus collector name for this gauge.
     """
-    prefix, base = _base_name(name, config)
+    prefix, base = _base_name(name, prefix)
     return f"{prefix}_{base}"
 
 
-def _duration_name(name: "str", config: "ObservabilityConfig | None") -> "str":
+def _duration_name(name: "str", prefix: "str") -> "str":
     """Build the Prometheus histogram name, carrying the conventional unit suffix.
 
     Returns:
         The Prometheus collector name for this duration histogram.
     """
-    prefix, base = _base_name(name, config)
+    prefix, base = _base_name(name, prefix)
     if not base.endswith("_seconds"):
         base = f"{base}_seconds"
     return f"{prefix}_{base}"
 
 
-def _histogram_name(name: "str", unit: "str", config: "ObservabilityConfig | None") -> "str":
-    prefix, base = _base_name(name, config)
+def _histogram_name(name: "str", unit: "str", prefix: "str") -> "str":
+    prefix, base = _base_name(name, prefix)
     return f"{prefix}_{base}_{unit}"

--- a/src/litestar_queues/observability.py
+++ b/src/litestar_queues/observability.py
@@ -87,19 +87,43 @@ class _TransportMetricSpec:
 
 
 _TRANSPORT_METRIC_SPECS = {
-    "litestar_queues.enqueue.batch.size": _TransportMetricSpec("histogram", "records", frozenset({"queue.backend", "queue.operation"})),
-    "litestar_queues.wakeup.emitted": _TransportMetricSpec("counter", "hints", frozenset({"queue.backend", "queue.transport"})),
-    "litestar_queues.wakeup.coalesced": _TransportMetricSpec("counter", "hints", frozenset({"queue.backend", "queue.transport"})),
+    "litestar_queues.enqueue.batch.size": _TransportMetricSpec(
+        "histogram", "records", frozenset({"queue.backend", "queue.operation"})
+    ),
+    "litestar_queues.wakeup.emitted": _TransportMetricSpec(
+        "counter", "hints", frozenset({"queue.backend", "queue.transport"})
+    ),
+    "litestar_queues.wakeup.coalesced": _TransportMetricSpec(
+        "counter", "hints", frozenset({"queue.backend", "queue.transport"})
+    ),
     "litestar_queues.worker.poll.empty": _TransportMetricSpec("counter", "polls", frozenset({"queue.backend"})),
-    "litestar_queues.worker.poll.delay": _TransportMetricSpec("histogram", "s", frozenset({"queue.backend", "worker.wait.kind"})),
-    "litestar_queues.worker.wait.duration": _TransportMetricSpec("duration", "s", frozenset({"queue.backend", "worker.wait.kind"})),
-    "litestar_queues.worker.wakeup_to_claim.duration": _TransportMetricSpec("duration", "s", frozenset({"queue.backend", "queue.transport"})),
-    "litestar_queues.listener.reconnect": _TransportMetricSpec("counter", "reconnects", frozenset({"queue.backend", "queue.transport"})),
-    "litestar_queues.listener.error": _TransportMetricSpec("counter", "errors", frozenset({"queue.backend", "queue.transport", "queue.outcome"})),
-    "litestar_queues.claim.batch.size": _TransportMetricSpec("histogram", "records", frozenset({"queue.backend", "queue.operation"})),
-    "litestar_queues.event.flush.size": _TransportMetricSpec("histogram", "events", frozenset({"queue.transport", "queue.outcome"})),
-    "litestar_queues.event.flush.duration": _TransportMetricSpec("duration", "s", frozenset({"queue.transport", "queue.outcome"})),
-    "litestar_queues.event.dropped": _TransportMetricSpec("counter", "events", frozenset({"queue.transport", "queue.outcome"})),
+    "litestar_queues.worker.poll.delay": _TransportMetricSpec(
+        "histogram", "s", frozenset({"queue.backend", "worker.wait.kind"})
+    ),
+    "litestar_queues.worker.wait.duration": _TransportMetricSpec(
+        "duration", "s", frozenset({"queue.backend", "worker.wait.kind"})
+    ),
+    "litestar_queues.worker.wakeup_to_claim.duration": _TransportMetricSpec(
+        "duration", "s", frozenset({"queue.backend", "queue.transport"})
+    ),
+    "litestar_queues.listener.reconnect": _TransportMetricSpec(
+        "counter", "reconnects", frozenset({"queue.backend", "queue.transport"})
+    ),
+    "litestar_queues.listener.error": _TransportMetricSpec(
+        "counter", "errors", frozenset({"queue.backend", "queue.transport", "queue.outcome"})
+    ),
+    "litestar_queues.claim.batch.size": _TransportMetricSpec(
+        "histogram", "records", frozenset({"queue.backend", "queue.operation"})
+    ),
+    "litestar_queues.event.flush.size": _TransportMetricSpec(
+        "histogram", "events", frozenset({"queue.transport", "queue.outcome"})
+    ),
+    "litestar_queues.event.flush.duration": _TransportMetricSpec(
+        "duration", "s", frozenset({"queue.transport", "queue.outcome"})
+    ),
+    "litestar_queues.event.dropped": _TransportMetricSpec(
+        "counter", "events", frozenset({"queue.transport", "queue.outcome"})
+    ),
 }
 _VALUE_HISTOGRAM_BUCKETS = (1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0)
 
@@ -116,10 +140,7 @@ def _validate_transport_metric(name: str, *, kind: str, unit: str, attributes: "
         raise ValueError(msg)
     actual = frozenset(attributes)
     if actual != spec.attributes:
-        msg = (
-            f"Transport metric {name!r} requires attributes {sorted(spec.attributes)!r}, "
-            f"not {sorted(actual)!r}."
-        )
+        msg = f"Transport metric {name!r} requires attributes {sorted(spec.attributes)!r}, not {sorted(actual)!r}."
         raise ValueError(msg)
 
 
@@ -270,9 +291,7 @@ class QueueObservabilityRuntimeProtocol(Protocol):
         """Record a duration sample."""
         ...
 
-    def record_histogram(
-        self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]"
-    ) -> "None":
+    def record_histogram(self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]") -> "None":
         """Record a value histogram sample."""
         ...
 
@@ -491,15 +510,11 @@ class QueueObservabilityRuntime:
             )
             collector.labels(**dict(attributes)).observe(seconds)
 
-    def record_histogram(
-        self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]"
-    ) -> "None":
+    def record_histogram(self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]") -> "None":
         """Record a non-duration histogram sample for enabled metric sinks."""
         if not self.enabled:
             return
-        _validate_transport_metric(
-            self._canonical_name(name), kind="histogram", unit=unit, attributes=attributes
-        )
+        _validate_transport_metric(self._canonical_name(name), kind="histogram", unit=unit, attributes=attributes)
         name = self._runtime_name(name)
         if self._otel_enabled:
             key = (name, unit)

--- a/src/litestar_queues/observability.py
+++ b/src/litestar_queues/observability.py
@@ -78,6 +78,50 @@ backends in one process legitimately record the same metrics.
 """
 
 
+@dataclass(frozen=True, slots=True)
+class _TransportMetricSpec:
+    kind: str
+    unit: str
+    attributes: frozenset[str]
+
+
+_TRANSPORT_METRIC_SPECS = {
+    "litestar_queues.enqueue.batch.size": _TransportMetricSpec("histogram", "records", frozenset({"queue.backend", "queue.operation"})),
+    "litestar_queues.wakeup.emitted": _TransportMetricSpec("counter", "hints", frozenset({"queue.backend", "queue.transport"})),
+    "litestar_queues.wakeup.coalesced": _TransportMetricSpec("counter", "hints", frozenset({"queue.backend", "queue.transport"})),
+    "litestar_queues.worker.poll.empty": _TransportMetricSpec("counter", "polls", frozenset({"queue.backend"})),
+    "litestar_queues.worker.poll.delay": _TransportMetricSpec("histogram", "s", frozenset({"queue.backend", "worker.wait.kind"})),
+    "litestar_queues.worker.wait.duration": _TransportMetricSpec("duration", "s", frozenset({"queue.backend", "worker.wait.kind"})),
+    "litestar_queues.worker.wakeup_to_claim.duration": _TransportMetricSpec("duration", "s", frozenset({"queue.backend", "queue.transport"})),
+    "litestar_queues.listener.reconnect": _TransportMetricSpec("counter", "reconnects", frozenset({"queue.backend", "queue.transport"})),
+    "litestar_queues.listener.error": _TransportMetricSpec("counter", "errors", frozenset({"queue.backend", "queue.transport", "queue.outcome"})),
+    "litestar_queues.claim.batch.size": _TransportMetricSpec("histogram", "records", frozenset({"queue.backend", "queue.operation"})),
+    "litestar_queues.event.flush.size": _TransportMetricSpec("histogram", "events", frozenset({"queue.transport", "queue.outcome"})),
+    "litestar_queues.event.flush.duration": _TransportMetricSpec("duration", "s", frozenset({"queue.transport", "queue.outcome"})),
+    "litestar_queues.event.dropped": _TransportMetricSpec("counter", "events", frozenset({"queue.transport", "queue.outcome"})),
+}
+_VALUE_HISTOGRAM_BUCKETS = (1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0)
+
+
+def _validate_transport_metric(name: str, *, kind: str, unit: str, attributes: "Mapping[str, str]") -> None:
+    spec = _TRANSPORT_METRIC_SPECS.get(name)
+    if spec is None:
+        return
+    if spec.kind != kind:
+        msg = f"Transport metric {name!r} requires kind {spec.kind!r}, not {kind!r}."
+        raise ValueError(msg)
+    if spec.unit != unit:
+        msg = f"Transport metric {name!r} requires unit {spec.unit!r}, not {unit!r}."
+        raise ValueError(msg)
+    actual = frozenset(attributes)
+    if actual != spec.attributes:
+        msg = (
+            f"Transport metric {name!r} requires attributes {sorted(spec.attributes)!r}, "
+            f"not {sorted(actual)!r}."
+        )
+        raise ValueError(msg)
+
+
 @dataclass(slots=True)
 class ObservabilityConfig:
     """Configuration for optional queue-domain observability."""
@@ -225,6 +269,12 @@ class QueueObservabilityRuntimeProtocol(Protocol):
         """Record a duration sample."""
         ...
 
+    def record_histogram(
+        self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]"
+    ) -> "None":
+        """Record a value histogram sample."""
+        ...
+
 
 class _SpanHandle:
     """A started span plus the context token that made it current."""
@@ -244,6 +294,7 @@ class QueueObservabilityRuntime:
         "_counters",
         "_durations",
         "_gauges",
+        "_histograms",
         "_meter",
         "_otel_enabled",
         "_prometheus_enabled",
@@ -267,6 +318,7 @@ class QueueObservabilityRuntime:
         self._counters: "dict[str, Any]" = {}
         self._durations: "dict[str, Any]" = {}
         self._gauges: "dict[str, Any]" = {}
+        self._histograms: "dict[tuple[str, str], Any]" = {}
 
     @property
     def sqlcommenter_enabled(self) -> "bool":
@@ -409,6 +461,30 @@ class QueueObservabilityRuntime:
             )
             collector.labels(**dict(attributes)).observe(seconds)
 
+    def record_histogram(
+        self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]"
+    ) -> "None":
+        """Record a non-duration histogram sample for enabled metric sinks."""
+        if not self.enabled:
+            return
+        _validate_transport_metric(name, kind="histogram", unit=unit, attributes=attributes)
+        if self._otel_enabled:
+            key = (name, unit)
+            histogram = self._histograms.get(key)
+            if histogram is None:
+                histogram = self.get_meter().create_histogram(name, unit=unit)
+                self._histograms[key] = histogram
+            histogram.record(value, attributes=dict(attributes))
+        if self._prometheus_enabled:
+            collector = self._prometheus_collector(
+                PrometheusHistogram,
+                name,
+                _histogram_name(name, unit, self._config),
+                attributes,
+                buckets=_VALUE_HISTOGRAM_BUCKETS,
+            )
+            collector.labels(**dict(attributes)).observe(value)
+
     def _prometheus_collector(
         self,
         collector_type: "Any",
@@ -521,3 +597,8 @@ def _duration_name(name: "str", config: "ObservabilityConfig | None") -> "str":
     if not base.endswith("_seconds"):
         base = f"{base}_seconds"
     return f"{prefix}_{base}"
+
+
+def _histogram_name(name: "str", unit: "str", config: "ObservabilityConfig | None") -> "str":
+    prefix, base = _base_name(name, config)
+    return f"{prefix}_{base}_{unit}"

--- a/src/litestar_queues/plugin.py
+++ b/src/litestar_queues/plugin.py
@@ -8,17 +8,7 @@ from typing import TYPE_CHECKING
 from litestar.channels import ChannelsPlugin
 from litestar.plugins import CLIPlugin, InitPlugin
 
-from litestar_queues.config import (
-    _EVENT_CHANNELS_STATE_KEY,
-    _EVENT_PUBLISHER_STATE_KEY,
-    _OBSERVABILITY_RUNTIME_STATE_KEY,
-    _SERVICE_STATE_KEY,
-    _WORKER_STATE_KEY,
-    MigrationConfiguringBackend,
-    QueueConfig,
-    execution_backend_name,
-    queue_backend_name,
-)
+from litestar_queues.config import MigrationConfiguringBackend, QueueConfig, execution_backend_name, queue_backend_name
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.service import QueueService
 from litestar_queues.task import load_task_modules, set_default_service
@@ -161,9 +151,12 @@ class QueuePlugin(InitPlugin, CLIPlugin):
         self._event_publisher = self._config.get_event_publisher(channels_backend=self._auto_channels_backend)
         app_config.dependencies.update(self._config.dependencies)
         app_config.signature_namespace.update(self._config.signature_namespace)
-        state = {_SERVICE_STATE_KEY: self._config, _EVENT_PUBLISHER_STATE_KEY: self._event_publisher}
+        state = {
+            self._config.service_state_key: self._config,
+            self._config.event_publisher_state_key: self._event_publisher,
+        }
         if self._config.events is not None and self._effective_channels_backend() is not None:
-            state[_EVENT_CHANNELS_STATE_KEY] = self._effective_channels_backend()
+            state[self._config.event_channels_state_key] = self._effective_channels_backend()
         stream_config = self._config.events.stream if self._config.events is not None else None
         if stream_config is not None:
             from litestar_queues.events.streaming import _build_stream_router
@@ -373,7 +366,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
 
             observability_runtime = create_observability_runtime(observability_config, app=app)
         if observability_runtime is not None:
-            app.state[_OBSERVABILITY_RUNTIME_STATE_KEY] = observability_runtime
+            app.state[self._config.observability_runtime_state_key] = observability_runtime
 
         self._service = QueueService(
             self._config,
@@ -383,11 +376,11 @@ class QueuePlugin(InitPlugin, CLIPlugin):
         )
         await self._service.open()
         set_default_service(self._service)
-        app.state[_SERVICE_STATE_KEY] = self._service
-        app.state[_EVENT_PUBLISHER_STATE_KEY] = self._service.get_event_publisher()
+        app.state[self._config.service_state_key] = self._service
+        app.state[self._config.event_publisher_state_key] = self._service.get_event_publisher()
         effective_channels = self._effective_channels_backend()
         if self._config.events is not None and effective_channels is not None:
-            app.state[_EVENT_CHANNELS_STATE_KEY] = effective_channels
+            app.state[self._config.event_channels_state_key] = effective_channels
 
         # Schedules belong to whichever process owns a worker, so an enqueue-only
         # ASGI process never writes schedule records: server and external
@@ -404,7 +397,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
             self._worker_task = asyncio.create_task(self._worker.start())
             self._worker_task.add_done_callback(self._log_worker_task_result)
             await asyncio.sleep(0)
-            app.state[_WORKER_STATE_KEY] = self._worker
+            app.state[self._config.worker_state_key] = self._worker
 
         try:
             yield

--- a/src/litestar_queues/plugin.py
+++ b/src/litestar_queues/plugin.py
@@ -29,8 +29,6 @@ if TYPE_CHECKING:
 
 __all__ = ("QueuePlugin",)
 
-logger = logging.getLogger(__name__)
-
 _UNKNOWN = object()
 _APP_PATH_ENV_VAR = "LITESTAR_APP"
 _CLOUD_TASKS_BACKEND = "cloudtasks"
@@ -86,6 +84,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
         "_auto_channels_backend",
         "_config",
         "_event_publisher",
+        "_logger",
         "_queue_backend",
         "_service",
         "_worker",
@@ -95,6 +94,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
     def __init__(self, config: "QueueConfig | None" = None) -> "None":
         """Initialize the queue plugin."""
         self._config = config or QueueConfig()
+        self._logger = logging.getLogger(self._config.names.logger("plugin"))
         self._service: "QueueService | None" = None
         self._queue_backend: "BaseQueueBackend | None" = None
         self._event_publisher: "QueueEventPublisher | None" = None
@@ -174,7 +174,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
                 )
                 if stream_config.unauthenticated_access == "error":
                     raise QueueConfigurationError(message)
-                logger.warning(message)
+                self._logger.warning(message)
             app_config.route_handlers.append(
                 _build_stream_router(self._config, stream_config, channels_backend=self._effective_channels_backend())
             )
@@ -315,7 +315,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
             return contextlib.nullcontext()
         from litestar_queues.backends.ephemeral.server import EphemeralServerContext
 
-        return EphemeralServerContext(nonce=nonce)
+        return EphemeralServerContext(nonce=nonce, namespace=self._config.names)
 
     @contextmanager
     def server_lifespan(self, app: "Litestar") -> "Generator[None]":
@@ -337,7 +337,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
         from litestar_queues.worker import supervisor
         from litestar_queues.worker.invocation import console_break_unwinds, server_context
 
-        with console_break_unwinds(), server_context() as nonce, self._storage_context(nonce):
+        with console_break_unwinds(), server_context(self._config.names) as nonce, self._storage_context(nonce):
             server_worker = supervisor.ServerWorkerSupervisor.from_plugin(self)
             server_worker.start()
             try:
@@ -353,7 +353,7 @@ class QueuePlugin(InitPlugin, CLIPlugin):
             # traffic against a queue whose worker was never started.
             from litestar_queues.worker.invocation import server_context_active
 
-            if not server_context_active():
+            if not server_context_active(self._config.names):
                 raise QueueConfigurationError(_MISSING_SERVER_CONTEXT_ERROR)
         self._validate_channels_shutdown_order(app)
         if self._config.task_modules:
@@ -364,7 +364,9 @@ class QueuePlugin(InitPlugin, CLIPlugin):
         if observability_config is not None:
             from litestar_queues.observability import create_observability_runtime
 
-            observability_runtime = create_observability_runtime(observability_config, app=app)
+            observability_runtime = create_observability_runtime(
+                observability_config, app=app, namespace=self._config.names
+            )
         if observability_runtime is not None:
             app.state[self._config.observability_runtime_state_key] = observability_runtime
 
@@ -419,6 +421,6 @@ class QueuePlugin(InitPlugin, CLIPlugin):
         exception = task.exception()
         if exception is None:
             return
-        logger.error(
+        self._logger.error(
             "In-app queue worker stopped unexpectedly", exc_info=(type(exception), exception, exception.__traceback__)
         )

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -45,8 +45,6 @@ if TYPE_CHECKING:
 
 __all__ = ("QueueService",)
 
-logger = logging.getLogger(__name__)
-
 _CLOUD_TASKS_BACKEND = "cloudtasks"
 
 
@@ -126,6 +124,7 @@ class QueueService:
         "_event_publisher",
         "_execution_backend",
         "_is_open",
+        "_logger",
         "_observability_runtime",
         "_opened_resources",
         "_queue_backend",
@@ -143,6 +142,7 @@ class QueueService:
     ) -> "None":
         """Initialize the queue service."""
         self._config = config
+        self._logger = logging.getLogger(config.names.logger("service"))
         self._queue_backend = queue_backend
         self._execution_backend = execution_backend
         self._event_log: "QueueEventLog | None" = None
@@ -152,7 +152,7 @@ class QueueService:
         if observability_runtime is None and config.observability is not None:
             from litestar_queues.observability import create_observability_runtime
 
-            observability_runtime = create_observability_runtime(config.observability)
+            observability_runtime = create_observability_runtime(config.observability, namespace=config.names)
         self._observability_runtime = observability_runtime
         self._sync_executor: "ThreadPoolExecutor | None" = None
         if queue_backend is not None:
@@ -210,7 +210,9 @@ class QueueService:
         if self._observability_runtime is None:
             from litestar_queues.observability import create_observability_runtime
 
-            self._observability_runtime = create_observability_runtime(self._config.observability)
+            self._observability_runtime = create_observability_runtime(
+                self._config.observability, namespace=self._config.names
+            )
         return self._observability_runtime
 
     async def open(self) -> "Self":
@@ -818,7 +820,7 @@ class QueueService:
                     else get_execution_backend(record.execution_backend, config=self._config)
                 )
             except ValueError:
-                logger.warning(
+                self._logger.warning(
                     "Skipping external queue record with unknown execution backend",
                     extra={"task_id": str(record.id), "execution_backend": record.execution_backend},
                 )
@@ -1204,7 +1206,7 @@ class QueueService:
     def _log_task_event(
         self, message: "str", record: "QueuedTaskRecord", *, level: "int", payload: "Mapping[str, object] | None" = None
     ) -> "None":
-        logger.log(
+        self._logger.log(
             level,
             message,
             extra={
@@ -1231,7 +1233,7 @@ class QueueService:
         try:
             task_obj = self.resolve_task(record.task_name)
         except KeyError:
-            logger.warning(
+            self._logger.warning(
                 "Queue task stale failure hook skipped for unknown task",
                 extra={"queue_task_id": str(record.id), "queue_task_name": record.task_name},
             )

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable, iscoroutinefunction
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from typing_extensions import Self
@@ -240,7 +240,7 @@ class QueueService:
             if self._sync_executor is None:
                 self._sync_executor = ThreadPoolExecutor(
                     max_workers=self._config.sync_thread_pool_size,
-                    thread_name_prefix=self._config.sync_thread_name_prefix,
+                    thread_name_prefix=cast("str", self._config.sync_thread_name_prefix),
                 )
                 opened.append(_RESOURCE_SYNC_EXECUTOR)
         except BaseException:

--- a/src/litestar_queues/worker/heartbeat.py
+++ b/src/litestar_queues/worker/heartbeat.py
@@ -264,7 +264,9 @@ class WorkerHeartbeatManager:
                 1,
                 attributes={**self._metric_attributes(), "worker.error.type": type(exc).__name__},
             )
-        self._logger.warning(message, exc_info=(type(exc), exc, exc.__traceback__), extra={"worker_id": self._worker_id})
+        self._logger.warning(
+            message, exc_info=(type(exc), exc, exc.__traceback__), extra={"worker_id": self._worker_id}
+        )
 
     def _record_gauge_delta(self, name: "str", delta: "int") -> "None":
         self._service.observability_runtime.record_gauge_delta(name, delta, attributes=self._metric_attributes())

--- a/src/litestar_queues/worker/heartbeat.py
+++ b/src/litestar_queues/worker/heartbeat.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from litestar_queues.models import HeartbeatTouch
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -87,6 +88,7 @@ class WorkerHeartbeatManager:
         "_beats",
         "_interval",
         "_jitter_fraction",
+        "_logger",
         "_miss_threshold",
         "_registrations",
         "_service",
@@ -105,6 +107,9 @@ class WorkerHeartbeatManager:
         jitter_fraction: "float" = 0.1,
     ) -> "None":
         self._service = service
+        config = getattr(service, "config", None)
+        names = getattr(config, "names", QueueNamespace())
+        self._logger = logging.getLogger(names.logger("worker", "heartbeat"))
         self._interval = interval
         self._miss_threshold = max(1, miss_threshold)
         self._worker_id = worker_id
@@ -259,7 +264,7 @@ class WorkerHeartbeatManager:
                 1,
                 attributes={**self._metric_attributes(), "worker.error.type": type(exc).__name__},
             )
-        logger.warning(message, exc_info=(type(exc), exc, exc.__traceback__), extra={"worker_id": self._worker_id})
+        self._logger.warning(message, exc_info=(type(exc), exc, exc.__traceback__), extra={"worker_id": self._worker_id})
 
     def _record_gauge_delta(self, name: "str", delta: "int") -> "None":
         self._service.observability_runtime.record_gauge_delta(name, delta, attributes=self._metric_attributes())

--- a/src/litestar_queues/worker/invocation.py
+++ b/src/litestar_queues/worker/invocation.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -52,7 +53,6 @@ MARKER_VERSION = 1
 
 _MARKER_NAME = "server.json"
 _MARKER_FIELDS = frozenset({"version", "owner_pid", "nonce"})
-_DIRECTORY_PREFIX = "litestar-queues-server-"
 _DIRECTORY_MODE = 0o700
 _FILE_MODE = 0o600
 _NONCE_BYTES = 16
@@ -68,7 +68,7 @@ _CLEANUP_WARNING = "Could not remove the private queue server marker directory; 
 _ACTIVE_SERVER_CONTEXTS: "set[str]" = set()
 
 
-def _remove(directory: "Path", marker: "Path") -> "None":
+def _remove(directory: "Path", marker: "Path", *, runtime_logger: "logging.Logger" = logger) -> "None":
     """Unlink the marker and its private directory, retrying a bounded number of times."""
     deadline = time.monotonic() + _CLEANUP_DEADLINE
     while True:
@@ -87,7 +87,7 @@ def _remove(directory: "Path", marker: "Path") -> "None":
             return
         except OSError:
             if time.monotonic() >= deadline:
-                logger.warning(_CLEANUP_WARNING)
+                runtime_logger.warning(_CLEANUP_WARNING)
                 return
             time.sleep(_CLEANUP_RETRY)
             continue
@@ -138,7 +138,7 @@ def console_break_unwinds() -> "Generator[None]":
 
 
 @contextmanager
-def server_context() -> "Generator[str]":
+def server_context(namespace: "QueueNamespace | None" = None) -> "Generator[str]":
     """Mark this process tree as owned for the lifetime of a server invocation.
 
     Yields:
@@ -147,14 +147,18 @@ def server_context() -> "Generator[str]":
     Raises:
         QueueConfigurationError: If a marker is already present in the environment.
     """
-    if os.environ.get(NONCE_ENV_VAR) or os.environ.get(MARKER_ENV_VAR):
+    names = namespace or QueueNamespace()
+    nonce_env_var = names.environment("server", "nonce")
+    marker_env_var = names.environment("server", "marker")
+    runtime_logger = logging.getLogger(names.logger("worker", "invocation"))
+    if os.environ.get(nonce_env_var) or os.environ.get(marker_env_var):
         raise QueueConfigurationError(_PREEXISTING_ERROR)
     nonce = secrets.token_hex(_NONCE_BYTES)
-    directory = Path(tempfile.mkdtemp(prefix=_DIRECTORY_PREFIX))
+    directory = Path(tempfile.mkdtemp(prefix=f"{names.resource('server')}-"))
     try:
         directory.chmod(_DIRECTORY_MODE)
     except OSError:
-        logger.debug("Could not restrict the private queue server marker directory permissions.")
+        runtime_logger.debug("Could not restrict the private queue server marker directory permissions.")
     marker = directory / _MARKER_NAME
     document = json.dumps({"version": MARKER_VERSION, "owner_pid": os.getpid(), "nonce": nonce})
     try:
@@ -162,18 +166,18 @@ def server_context() -> "Generator[str]":
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             handle.write(document)
     except BaseException:
-        _remove(directory, marker)
+        _remove(directory, marker, runtime_logger=runtime_logger)
         raise
-    os.environ[NONCE_ENV_VAR] = nonce
-    os.environ[MARKER_ENV_VAR] = str(marker)
+    os.environ[nonce_env_var] = nonce
+    os.environ[marker_env_var] = str(marker)
     _ACTIVE_SERVER_CONTEXTS.add(nonce)
     try:
         yield nonce
     finally:
         _ACTIVE_SERVER_CONTEXTS.discard(nonce)
-        os.environ.pop(NONCE_ENV_VAR, None)
-        os.environ.pop(MARKER_ENV_VAR, None)
-        _remove(directory, marker)
+        os.environ.pop(nonce_env_var, None)
+        os.environ.pop(marker_env_var, None)
+        _remove(directory, marker, runtime_logger=runtime_logger)
 
 
 def _read_marker(marker: "Path") -> "dict[str, object] | None":
@@ -194,15 +198,16 @@ def _read_marker(marker: "Path") -> "dict[str, object] | None":
     return document
 
 
-def server_context_active() -> "bool":
+def server_context_active(namespace: "QueueNamespace | None" = None) -> "bool":
     """Return whether this process belongs to an invocation that owns a queue worker.
 
     Returns:
         True when both private variables are present and the marker file they
         name matches this invocation exactly.
     """
-    nonce = os.environ.get(NONCE_ENV_VAR)
-    path = os.environ.get(MARKER_ENV_VAR)
+    names = namespace or QueueNamespace()
+    nonce = os.environ.get(names.environment("server", "nonce"))
+    path = os.environ.get(names.environment("server", "marker"))
     if not nonce or not path:
         return False
     marker = Path(path)

--- a/src/litestar_queues/worker/supervisor.py
+++ b/src/litestar_queues/worker/supervisor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, Protocol, cast
 
 from litestar_queues.exceptions import QueueConfigurationError, QueueError
+from litestar_queues.namespace import DEFAULT_NAMESPACE, QueueNamespace
 from litestar_queues.worker.runtime import WorkerRunResult, _WorkerStageError
 from litestar_queues.worker.runtime import run_worker as _run_worker
 
@@ -40,7 +41,6 @@ _ERROR_MESSAGE_LENGTH = 3
 _RUNNER_STAGES = frozenset(("load_tasks", "open_service", "initialize_schedules", "start_worker"))
 _BOOTSTRAP_STAGES = frozenset(("bootstrap", "load_app", "resolve_plugin", "validate"))
 _SAFE_STAGES = _RUNNER_STAGES | _BOOTSTRAP_STAGES
-_PROCESS_ROLE_ENV_VAR = "LITESTAR_QUEUES_PROCESS_ROLE"
 _WINDOWS_CLEANUP_ERROR = "Windows process-tree cleanup failed."
 _POSIX_SIGKILL = cast("int", getattr(signal, "SIGKILL", 9))
 # STATUS_CONTROL_C_EXIT: Windows terminates a console process with this status
@@ -99,6 +99,7 @@ class _WorkerLaunchSpec:
     sys_path: "tuple[str, ...]"
     environment: "tuple[tuple[str, str], ...]" = field(repr=False)
     log_level: "int"
+    namespace: "str" = DEFAULT_NAMESPACE
 
 
 def _select_process_context(
@@ -110,7 +111,7 @@ def _select_process_context(
     return _get_context("forkserver" if "forkserver" in methods else "spawn")
 
 
-def _build_launch_spec(*, log_level: "int" = logging.INFO) -> "_WorkerLaunchSpec":
+def _build_launch_spec(*, log_level: "int" = logging.INFO, namespace: "str" = DEFAULT_NAMESPACE) -> "_WorkerLaunchSpec":
     try:
         app_path = os.environ["LITESTAR_APP"]
     except KeyError as exc:
@@ -125,6 +126,7 @@ def _build_launch_spec(*, log_level: "int" = logging.INFO) -> "_WorkerLaunchSpec
         sys_path=tuple(sys.path),
         environment=tuple(os.environ.items()),
         log_level=log_level,
+        namespace=namespace,
     )
 
 
@@ -204,7 +206,7 @@ def _validate_child_plugin(plugin: "QueuePlugin") -> "None":
         raise QueueConfigurationError(msg)
     if backend != "ephemeral":
         return
-    resolved = read_environment()
+    resolved = read_environment(config.names)
     if resolved is None:
         msg = "The server-owned ephemeral queue database is not available to this worker process."
         raise QueueConfigurationError(msg)
@@ -268,11 +270,12 @@ async def _run_child(
         nonlocal parent_bridge
         _safe_send(connection, ("ready", child_pid))
         loop = asyncio.get_running_loop()
+        names = getattr(plugin.config, "names", QueueNamespace())
         parent_bridge = _thread_factory(
             target=_parent_loss_bridge,
             args=(parent, loop, graceful_stop, bridge_completed),
             kwargs={"_wait": _parent_wait},
-            name="litestar-queues-parent-watch",
+            name=names.resource("parent", "watch"),
             daemon=True,
         )
         parent_bridge.start()
@@ -328,7 +331,9 @@ def _worker_process_main(spec: "_WorkerLaunchSpec", stop_event: "_EventLike", co
     stage = "bootstrap"
     try:
         _apply_launch_spec(spec)
-        os.environ[_PROCESS_ROLE_ENV_VAR] = "server-worker"
+        names = QueueNamespace(spec.namespace)
+        process_role_env_var = names.environment("process", "role")
+        os.environ[process_role_env_var] = "server-worker"
         if _os_name() == "posix":
             os.setsid()
         parent = _get_parent_process()
@@ -348,7 +353,7 @@ def _worker_process_main(spec: "_WorkerLaunchSpec", stop_event: "_EventLike", co
         else:
             _safe_send(connection, ("error", stage, type(exc).__name__))
     finally:
-        os.environ.pop(_PROCESS_ROLE_ENV_VAR, None)
+        os.environ.pop(QueueNamespace(spec.namespace).environment("process", "role"), None)
         with contextlib.suppress(BaseException):
             stop_event.set()
         with contextlib.suppress(BaseException):
@@ -472,6 +477,7 @@ class ServerWorkerSupervisor:
         "_expected_stop",
         "_launch_spec",
         "_lock",
+        "_logger",
         "_process",
         "_request_parent_shutdown",
         "_send_connection",
@@ -502,6 +508,7 @@ class ServerWorkerSupervisor:
         self._expected_stop = threading.Event()
         self._shutdown_requested = threading.Event()
         self._lock = threading.Lock()
+        self._logger = logging.getLogger(config.names.logger("worker", "supervisor"))
         self._start_attempted = False
         self._process: "_ProcessLike | None" = None
         self._connection: "Connection | None" = None
@@ -568,9 +575,9 @@ class ServerWorkerSupervisor:
                 # console shutdown, not a crash: the server is already on its way
                 # down and escalating would kill it before it unwinds its
                 # lifespan, leaking the private database it removes on exit.
-                logger.debug("Server queue worker stopped with the console; leaving shutdown to the server.")
+                self._logger.debug("Server queue worker stopped with the console; leaving shutdown to the server.")
                 return
-            logger.error("Server queue worker exited unexpectedly with exit code %s.", exit_code)
+            self._logger.error("Server queue worker exited unexpectedly with exit code %s.", exit_code)
             with contextlib.suppress(BaseException):
                 self._request_parent_shutdown()
         finally:
@@ -584,7 +591,7 @@ class ServerWorkerSupervisor:
                 raise QueueConfigurationError(msg)
             self._start_attempted = True
             context = self._context or _select_process_context()
-            spec = self._launch_spec or _build_launch_spec()
+            spec = self._launch_spec or _build_launch_spec(namespace=self._config.namespace)
             receive_connection, send_connection = context.Pipe(duplex=False)
             self._connection = receive_connection
             self._send_connection = send_connection
@@ -593,7 +600,7 @@ class ServerWorkerSupervisor:
                 process = cast("Any", context).Process(
                     target=_worker_process_main,
                     args=(spec, stop_event, send_connection),
-                    name="litestar-queues-server-worker",
+                    name=self._config.names.resource("server", "worker"),
                 )
             except BaseException:
                 self._close_handles()
@@ -616,7 +623,7 @@ class ServerWorkerSupervisor:
                 raise
             try:
                 watchdog = self._thread_factory(
-                    target=self._watch_child, name="litestar-queues-child-watch", daemon=True
+                    target=self._watch_child, name=self._config.names.resource("child", "watch"), daemon=True
                 )
                 self._watchdog = watchdog
                 watchdog.start()

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
 
 __all__ = ("Worker",)
 
-logger = logging.getLogger(__name__)
-
 
 def _clamp(value: "float", *, low: "float", high: "float") -> "float":
     """Clamp a value between inclusive bounds.
@@ -78,6 +76,7 @@ class Worker:
         "_last_expiry_check_at",
         "_last_reconcile_at",
         "_last_stale_check_at",
+        "_logger",
         "_max_concurrency",
         "_poll_backoff_max",
         "_poll_backoff_multiplier",
@@ -105,6 +104,7 @@ class Worker:
         """
         worker_config = config or WorkerConfig()
         self._service = service
+        self._logger = logging.getLogger(service.config.names.logger("worker"))
         self._batch_size = worker_config.batch_size
         self._poll_interval = worker_config.poll_interval
         self._poll_backoff_max = worker_config.poll_backoff_max
@@ -260,7 +260,7 @@ class Worker:
                     raise
                 except Exception as exc:
                     self._record_counter("litestar_queues.worker.loop.error", {"worker.error.type": type(exc).__name__})
-                    logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
+                    self._logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
                     self._reset_poll_backoff()
                     await self._backoff_after_loop_error()
                     continue
@@ -541,7 +541,7 @@ class Worker:
             # the listener from a clean state. The backoff resets so a stale
             # listener does not compound into a longer discovery delay.
             self._record_counter("litestar_queues.worker.loop.error", {"worker.error.type": type(exc).__name__})
-            logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
+            self._logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
             self._reset_poll_backoff()
             await self._backoff_after_loop_error()
             return None

--- a/src/tests/integration/execution/cloudrun/helpers.py
+++ b/src/tests/integration/execution/cloudrun/helpers.py
@@ -112,4 +112,4 @@ def task_id_from_request(request: "RunJobRequest") -> "str":
     Returns:
         The queued record id the request dispatches.
     """
-    return env_map(request)["LITESTAR_QUEUES_TASK_ID"]
+    return env_map(request)["QUEUES_TASK_ID"]

--- a/src/tests/integration/execution/cloudrun/test_emulator.py
+++ b/src/tests/integration/execution/cloudrun/test_emulator.py
@@ -197,7 +197,7 @@ async def test_cloudrun_dispatch_env_has_no_legacy_task_fields() -> "None":
 
     # The whole per-field env-map is gone: the record travels as its id alone
     # (no extra_env on this config), so no legacy per-field vars remain.
-    assert set(env) == {"LITESTAR_QUEUES_TASK_ID"}
+    assert set(env) == {"QUEUES_TASK_ID"}
     legacy_names = {
         f"LITESTAR_QUEUES_{suffix}" for suffix in ("TASK_DISPATCH", "TASK_NAME", "TASK_ARGS", "TASK_KWARGS")
     }
@@ -236,7 +236,7 @@ async def test_cloudrun_dispatch_env_excludes_large_and_sensitive_task_args() ->
     # Only the record id travels; the live record (fetched by id) stays the
     # source of truth for args, so neither the task name nor its arguments --
     # however large or sensitive -- ever reach the Cloud Run Jobs API request.
-    assert set(env) == {"LITESTAR_QUEUES_TASK_ID"}
+    assert set(env) == {"QUEUES_TASK_ID"}
     assert task_id_from_request(request) == str(record.id)
     serialized_request = repr(request)
     assert secret not in serialized_request
@@ -270,7 +270,7 @@ async def test_cloudrun_dispatch_env_respects_custom_prefix() -> "None":
     env = env_map(jobs_client.requests[0])
 
     assert "PREFIX_TASK_ID" in env
-    assert "LITESTAR_QUEUES_TASK_ID" not in env
+    assert "QUEUES_TASK_ID" not in env
 
 
 async def test_cloudrun_dispatch_returns_without_waiting_for_operation_result() -> "None":

--- a/src/tests/integration/execution/cloudrun/test_emulator.py
+++ b/src/tests/integration/execution/cloudrun/test_emulator.py
@@ -244,7 +244,7 @@ async def test_cloudrun_dispatch_env_excludes_large_and_sensitive_task_args() ->
     assert remote_sensitive_args.name not in serialized_request
 
 
-async def test_cloudrun_dispatch_env_respects_custom_prefix() -> "None":
+async def test_cloudrun_dispatch_env_uses_stable_bootstrap_name_with_custom_prefix() -> "None":
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
 
     @task("tasks.remote")
@@ -269,8 +269,8 @@ async def test_cloudrun_dispatch_env_respects_custom_prefix() -> "None":
 
     env = env_map(jobs_client.requests[0])
 
-    assert "PREFIX_TASK_ID" in env
-    assert "QUEUES_TASK_ID" not in env
+    assert set(env) == {"QUEUES_TASK_ID"}
+    assert task_id_from_request(jobs_client.requests[0]) == str(record.id)
 
 
 async def test_cloudrun_dispatch_returns_without_waiting_for_operation_result() -> "None":

--- a/src/tests/integration/execution/cloudtasks/README.md
+++ b/src/tests/integration/execution/cloudtasks/README.md
@@ -44,7 +44,7 @@ here is the part that needs Google, because there is no local Cloud Tasks API.
 
 ```bash
 export LITESTAR_QUEUES_GCP_LIVE=1
-export LITESTAR_QUEUES_CONFIG_FACTORY="your_app.queue:config"
+export QUEUES_CONFIG_FACTORY="your_app.queue:config"
 export LITESTAR_QUEUES_GCP_EVIDENCE_PATH="$PWD/cloud-tasks-evidence.json"   # optional
 export LITESTAR_QUEUES_GCP_TIMEOUT=180                                      # optional
 

--- a/src/tests/integration/execution/cloudtasks/live.py
+++ b/src/tests/integration/execution/cloudtasks/live.py
@@ -45,7 +45,7 @@ __all__ = (
 LIVE_FLAG_ENV = "LITESTAR_QUEUES_GCP_LIVE"
 """Set to exactly ``1`` to opt in. Anything else is an operator saying no."""
 
-CONFIG_FACTORY_ENV = "LITESTAR_QUEUES_CONFIG_FACTORY"
+CONFIG_FACTORY_ENV = "QUEUES_CONFIG_FACTORY"
 """Import path to the queue configuration both processes share.
 
 Deliberately the package's own consumer seam rather than a set of topology

--- a/src/tests/unit/backends/test_ephemeral_runtime.py
+++ b/src/tests/unit/backends/test_ephemeral_runtime.py
@@ -63,6 +63,23 @@ def test_entering_creates_a_private_database_and_environment() -> "None":
     assert NONCE_ENV_VAR not in os.environ
 
 
+def test_entering_with_namespace_derives_private_environment_and_directory() -> "None":
+    from litestar_queues import QueueNamespace
+
+    names = QueueNamespace("dma")
+    path_env = names.environment("ephemeral", "path")
+    nonce_env = names.environment("ephemeral", "nonce")
+
+    with EphemeralServerContext(nonce="nonce-dma", namespace=names) as context:
+        path = context.path
+        assert os.environ[path_env] == str(path)
+        assert os.environ[nonce_env] == "nonce-dma"
+        assert path.parent.name.startswith("dma-")
+
+    assert path_env not in os.environ
+    assert nonce_env not in os.environ
+
+
 @posix_only
 def test_the_private_directory_and_file_are_owner_only() -> "None":
     with EphemeralServerContext(nonce="nonce-modes") as context:

--- a/src/tests/unit/events/test_publisher.py
+++ b/src/tests/unit/events/test_publisher.py
@@ -53,6 +53,13 @@ def test_queue_channels_normalize_parts_deterministically() -> "None":
     assert QueueChannels.custom("tenant:acme") == "litestar_queues:custom:tenant:acme:events"
 
 
+def test_queue_event_publisher_uses_custom_namespace() -> "None":
+    publisher = QueueEventPublisher(namespace="dma")
+    event = QueueEvent(type="task.started", scope="task", task_id="task-1")
+
+    assert publisher.resolve_channels(event) == ("dma:task:task-1:events",)
+
+
 async def test_queue_event_publisher_targets_configured_channels() -> "None":
     sink = InMemoryQueueEventSink()
     publisher = QueueEventPublisher(sink, publish_queue_channel=True, publish_global_lifecycle=True)

--- a/src/tests/unit/events/test_stream_metrics.py
+++ b/src/tests/unit/events/test_stream_metrics.py
@@ -25,10 +25,11 @@ async def test_plugin_startup_publishes_observability_runtime_on_state(monkeypat
     runtime = _FakeObservabilityRuntime()
 
     def create_runtime(
-        config: "ObservabilityConfig | None", *, app: Litestar | None = None
+        config: "ObservabilityConfig | None", *, app: Litestar | None = None, namespace: object | None = None
     ) -> "_FakeObservabilityRuntime":
         assert config is not None
         assert app is not None
+        assert namespace is not None
         return runtime
 
     monkeypatch.setattr("litestar_queues.observability.create_observability_runtime", create_runtime)

--- a/src/tests/unit/events/test_stream_routes.py
+++ b/src/tests/unit/events/test_stream_routes.py
@@ -66,6 +66,18 @@ def test_build_stream_router_sse_only_registers_no_websocket_routes() -> None:
     assert _stream_paths(router) == {"/queues/events/sse/tasks/{task_id:str}"}
 
 
+def test_build_stream_router_names_handlers_from_namespace() -> None:
+    router = _build_stream_router(
+        QueueConfig(namespace="dma", worker=WorkerConfig(placement="external"), queue_backend="memory"),
+        EventStreamConfig(scopes={"task"}),
+    )
+
+    assert _stream_handler(router, "/tasks/{task_id:str}").name == "dma_event_stream_task"
+    sse_route = next(route for route in router.routes if "/sse/tasks/{task_id:str}" in route.path)
+    sse_handler = sse_route.route_handlers[0]
+    assert sse_handler.name == "dma_event_sse_task"
+
+
 def test_stream_config_with_both_transports_disabled_raises_at_app_init() -> None:
     from litestar_queues.exceptions import QueueConfigurationError
 

--- a/src/tests/unit/events/test_stream_routes.py
+++ b/src/tests/unit/events/test_stream_routes.py
@@ -72,10 +72,18 @@ def test_build_stream_router_names_handlers_from_namespace() -> None:
         EventStreamConfig(scopes={"task"}),
     )
 
-    assert _stream_handler(router, "/tasks/{task_id:str}").name == "dma_event_stream_task"
-    sse_route = next(route for route in router.routes if "/sse/tasks/{task_id:str}" in route.path)
-    sse_handler = sse_route.route_handlers[0]
-    assert sse_handler.name == "dma_event_sse_task"
+    assert _stream_handler_name(router, "/tasks/{task_id:str}") == "dma_event_stream_task"
+    assert _stream_handler_name(router, "/sse/tasks/{task_id:str}") == "dma_event_sse_task"
+    assert _stream_paths(router) == {"/dma/events/tasks/{task_id:str}", "/dma/events/sse/tasks/{task_id:str}"}
+
+
+def test_build_stream_router_preserves_explicit_path_with_custom_namespace() -> None:
+    router = _build_stream_router(
+        QueueConfig(namespace="dma", worker=WorkerConfig(placement="external"), queue_backend="memory"),
+        EventStreamConfig(path="/events", scopes={"task"}),
+    )
+
+    assert _stream_paths(router) == {"/events/tasks/{task_id:str}", "/events/sse/tasks/{task_id:str}"}
 
 
 def test_stream_config_with_both_transports_disabled_raises_at_app_init() -> None:
@@ -173,7 +181,7 @@ async def test_task_stream_prefers_configured_channels_backend_to_connection_plu
 
 def _stream_paths(router: Any) -> "set[str]":
     app = Litestar(route_handlers=[router], openapi_config=None)
-    return {route.path for route in app.routes if route.path.startswith("/queues/events")}
+    return {route.path for route in app.routes}
 
 
 def _stream_handler(router: Any, path: str) -> "WebsocketRouteHandler":
@@ -181,6 +189,19 @@ def _stream_handler(router: Any, path: str) -> "WebsocketRouteHandler":
         handler = route.route_handler
         if path in handler.paths:
             return cast("WebsocketRouteHandler", handler)
+    msg = f"No stream handler registered for {path!r}."
+    raise AssertionError(msg)
+
+
+def _stream_handler_name(router: Any, path: str) -> "str | None":
+    for route in router.routes:
+        handlers = getattr(route, "route_handlers", None)
+        if handlers is None:
+            handler = getattr(route, "route_handler", None)
+            handlers = () if handler is None else (handler,)
+        for handler in handlers:
+            if path in handler.paths:
+                return cast("str | None", handler.name)
     msg = f"No stream handler registered for {path!r}."
     raise AssertionError(msg)
 

--- a/src/tests/unit/execution/cloudtasks/test_backend.py
+++ b/src/tests/unit/execution/cloudtasks/test_backend.py
@@ -92,21 +92,21 @@ async def harness(
     opened: "list[QueueService]" = []
 
     async def build(**config_overrides: "Any") -> "Harness":
+        queue_namespace = config_overrides.pop("queue_namespace", "litestar_queues")
         execution_config = cloud_tasks_config(**config_overrides)
         client = FakeCloudTasksClient()
-        backend = CloudTasksExecutionBackend(execution_config=execution_config, client=client)
         events = InMemoryQueueEventSink()
-        service = QueueService(
-            QueueConfig(
-                queue_backend=shared_storage,
-                execution_backend=execution_config,
-                worker=WorkerConfig(placement="external"),
-                # Unbuffered: these tests assert on what one call published, and
-                # the default producer buffer only flushes at close.
-                events=QueueEventsConfig(delivery=EventDeliveryConfig(sinks=(events,), buffer=None)),
-            ),
-            execution_backend=backend,
+        queue_config = QueueConfig(
+            namespace=queue_namespace,
+            queue_backend=shared_storage,
+            execution_backend=execution_config,
+            worker=WorkerConfig(placement="external"),
+            # Unbuffered: these tests assert on what one call published, and
+            # the default producer buffer only flushes at close.
+            events=QueueEventsConfig(delivery=EventDeliveryConfig(sinks=(events,), buffer=None)),
         )
+        backend = CloudTasksExecutionBackend(config=queue_config, execution_config=execution_config, client=client)
+        service = QueueService(queue_config, execution_backend=backend)
         await service.open()
         opened.append(service)
         return Harness(service, backend, client, execution_config, events)
@@ -284,6 +284,16 @@ async def test_the_delivery_name_is_random_and_encodes_the_record_and_attempt(ha
     suffix = name[len(prefix) :]
     assert len(suffix) == 32
     assert suffix != record.id.hex
+
+
+async def test_the_delivery_name_prefix_derives_from_queue_namespace(harness: "Callable[..., Any]") -> "None":
+    live = await harness(queue_namespace="dma")
+    record = await live.enqueue()
+
+    name = await live.schedule(record)
+
+    assert name is not None
+    assert name.startswith(f"{live.execution_config.queue_path}/tasks/dma-{record.id.hex}-r0-")
 
 
 async def test_two_records_never_share_a_delivery_name(harness: "Callable[..., Any]") -> "None":

--- a/src/tests/unit/execution/cloudtasks/test_config.py
+++ b/src/tests/unit/execution/cloudtasks/test_config.py
@@ -64,6 +64,22 @@ def test_baseline_configuration_is_accepted() -> "None":
     assert config.api_timeout == 10.0
 
 
+def test_default_route_path_resolves_from_queue_namespace_without_mutating_config() -> "None":
+    from litestar_queues import QueueConfig, WorkerConfig
+    from litestar_queues.execution.cloudtasks import CloudTasksExecutionBackend
+
+    execution = _config()
+    queue_config = QueueConfig(
+        namespace="dma",
+        queue_backend="redis",
+        execution_backend=execution,
+        worker=WorkerConfig(placement="external"),
+    )
+
+    assert CloudTasksExecutionBackend(queue_config).execution_config.route_path == "/_dma/cloud-tasks"
+    assert execution.route_path == "/_litestar-queues/cloud-tasks"
+
+
 # --------------------------------------------------------------------------- target url
 
 

--- a/src/tests/unit/execution/cloudtasks/test_config.py
+++ b/src/tests/unit/execution/cloudtasks/test_config.py
@@ -70,14 +70,25 @@ def test_default_route_path_resolves_from_queue_namespace_without_mutating_confi
 
     execution = _config()
     queue_config = QueueConfig(
-        namespace="dma",
-        queue_backend="redis",
-        execution_backend=execution,
-        worker=WorkerConfig(placement="external"),
+        namespace="dma", queue_backend="redis", execution_backend=execution, worker=WorkerConfig(placement="external")
     )
 
     assert CloudTasksExecutionBackend(queue_config).execution_config.route_path == "/_dma/cloud-tasks"
+    assert CloudTasksExecutionBackend(queue_config).execution_config.delivery_name_prefix == "dma-"
     assert execution.route_path == "/_litestar-queues/cloud-tasks"
+    assert execution.delivery_name_prefix is None
+
+
+def test_explicit_delivery_name_prefix_wins_over_queue_namespace() -> "None":
+    from litestar_queues import QueueConfig, WorkerConfig
+    from litestar_queues.execution.cloudtasks import CloudTasksExecutionBackend
+
+    execution = _config(delivery_name_prefix="custom-")
+    queue_config = QueueConfig(
+        namespace="dma", queue_backend="redis", execution_backend=execution, worker=WorkerConfig(placement="external")
+    )
+
+    assert CloudTasksExecutionBackend(queue_config).execution_config.delivery_name_prefix == "custom-"
 
 
 # --------------------------------------------------------------------------- target url
@@ -122,6 +133,12 @@ def test_explicit_audience_is_preserved() -> "None":
 def test_blank_identifiers_are_rejected(field: "str", value: "str") -> "None":
     with pytest.raises(QueueConfigurationError):
         _config(**{field: value})
+
+
+@pytest.mark.parametrize("delivery_name_prefix", ["", "dma/", "dma prefix", "dma."])
+def test_invalid_delivery_name_prefix_is_rejected(delivery_name_prefix: "str") -> "None":
+    with pytest.raises(QueueConfigurationError, match="delivery_name_prefix"):
+        _config(delivery_name_prefix=delivery_name_prefix)
 
 
 # --------------------------------------------------------------------------- service url

--- a/src/tests/unit/execution/cloudtasks/test_observability.py
+++ b/src/tests/unit/execution/cloudtasks/test_observability.py
@@ -193,6 +193,10 @@ class RecordingRuntime:
         """Record one duration sample."""
         self.durations.append((name, seconds, dict(attributes)))
 
+    def record_histogram(self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]") -> "None":
+        """Accept value histograms that are outside this test's assertions."""
+        del name, value, unit, attributes
+
     def samples(self, metric: "str") -> "list[dict[str, str]]":
         """Every attribute set recorded under ``metric``.
 

--- a/src/tests/unit/test_cli.py
+++ b/src/tests/unit/test_cli.py
@@ -105,8 +105,8 @@ def test_queues_run_task_consumes_record_via_config_factory(monkeypatch: "pytest
         queue_backend=queue_backend,
     )
     sys.modules[factory_module.__name__] = factory_module
-    monkeypatch.setenv("LITESTAR_QUEUES_CONFIG_FACTORY", f"{factory_module.__name__}:create_service")
-    monkeypatch.setenv("LITESTAR_QUEUES_TASK_ID", str(task_id))
+    monkeypatch.setenv("QUEUES_CONFIG_FACTORY", f"{factory_module.__name__}:create_service")
+    monkeypatch.setenv("QUEUES_TASK_ID", str(task_id))
     try:
         result = _runner_invoke("tests.helpers.support.cli_app:app", ["queues", "run-task"], monkeypatch)
     finally:

--- a/src/tests/unit/test_cli.py
+++ b/src/tests/unit/test_cli.py
@@ -582,7 +582,7 @@ def test_scheduler_health_returns_0_when_canary_completed_recently(monkeypatch: 
         service = plugin.get_service()
         await service.open()
         try:
-            canary_task = get_task_registry()[config.scheduler_canary_task]
+            canary_task = get_task_registry()[cast("str", config.scheduler_canary_task)]
             record = await service.enqueue(canary_task)
             await service.get_queue_backend().complete_task(record.id, result=None)
         finally:

--- a/src/tests/unit/test_consumer.py
+++ b/src/tests/unit/test_consumer.py
@@ -175,7 +175,7 @@ async def test_consume_one_claims_dispatched_record_after_queue_deadline() -> "N
     assert result.result == "completed"
 
 
-async def test_run_task_loads_factory_before_prefixed_task_id() -> "None":
+async def test_run_task_loads_factory_before_neutral_task_id() -> "None":
     from litestar_queues import QueueConfig, QueueService, task
     from litestar_queues.consumer import TaskExitCode, run_task
     from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
@@ -201,8 +201,8 @@ async def test_run_task_loads_factory_before_prefixed_task_id() -> "None":
 
             exit_code = await run_task(
                 env={
-                    "LITESTAR_QUEUES_CONFIG_FACTORY": f"{factory_module.__name__}:create_service",
-                    "PREFIX_TASK_ID": str(record.id),
+                    "QUEUES_CONFIG_FACTORY": f"{factory_module.__name__}:create_service",
+                    "QUEUES_TASK_ID": str(record.id),
                 }
             )
             await result.refresh()
@@ -217,7 +217,7 @@ async def test_run_task_loads_factory_before_prefixed_task_id() -> "None":
 async def test_run_task_requires_config_factory() -> "None":
     from litestar_queues.consumer import TaskExitCode, run_task
 
-    exit_code = await run_task(env={"LITESTAR_QUEUES_TASK_ID": str(uuid4())})
+    exit_code = await run_task(env={"QUEUES_TASK_ID": str(uuid4())})
 
     assert exit_code == TaskExitCode.MISSING_CONFIG_FACTORY
 
@@ -279,7 +279,7 @@ async def test_run_task_missing_and_invalid_task_id() -> "None":
 
     async with QueueService(QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory")) as service:
         missing = await run_task(service=service, env={})
-        invalid = await run_task(service=service, env={"LITESTAR_QUEUES_TASK_ID": "not-a-uuid"})
+        invalid = await run_task(service=service, env={"QUEUES_TASK_ID": "not-a-uuid"})
 
     assert missing == TaskExitCode.MISSING_TASK_ID
     assert invalid == TaskExitCode.INVALID_TASK_ID

--- a/src/tests/unit/test_namespace.py
+++ b/src/tests/unit/test_namespace.py
@@ -1,0 +1,160 @@
+from dataclasses import replace
+
+import pytest
+
+from litestar_queues import QueueChannels, QueueConfig, QueueNamespace, WorkerConfig
+from litestar_queues.exceptions import QueueConfigurationError
+
+
+def test_queue_config_exposes_format_specific_namespace_names() -> None:
+    config = QueueConfig(namespace="dma")
+
+    assert config.namespace == "dma"
+    assert config.names == QueueNamespace("dma")
+    assert config.names.metric("wakeups") == "dma.wakeups"
+    assert config.names.logger("worker") == "dma.worker"
+    assert config.names.channel("worker_wakeups") == "dma:worker_wakeups"
+    assert config.names.key("tasks") == "dma:tasks"
+    assert config.names.registration("service") == "dma_service"
+    assert config.names.environment("task_id") == "DMA_TASK_ID"
+    assert config.names.resource("worker") == "dma-worker"
+    assert config.names.coordination("maintenance") == "dma-maintenance"
+    assert config.service_state_key == "dma_service"
+    assert config.worker_state_key == "dma_worker"
+    assert config.event_publisher_state_key == "dma_event_publisher"
+    assert config.event_channels_state_key == "dma_event_channels"
+    assert config.observability_runtime_state_key == "dma_observability_runtime"
+    assert config.maintenance_name == "dma-maintenance"
+
+
+def test_default_namespace_preserves_legacy_name_families() -> None:
+    config = QueueConfig()
+
+    assert config.namespace == "litestar_queues"
+    assert config.names.metric("wakeups") == "litestar_queues.wakeups"
+    assert config.names.logger("worker") == "litestar_queues.worker"
+    assert config.names.channel("worker_wakeups") == "litestar_queues:worker_wakeups"
+    assert config.names.key("tasks") == "litestar_queues:tasks"
+    assert config.names.registration("service") == "queue_service"
+    assert config.names.environment("task_id") == "LITESTAR_QUEUES_TASK_ID"
+    assert config.names.resource("worker") == "litestar-queues-worker"
+    assert config.names.coordination("maintenance") == "queue-maintenance"
+    assert config.service_dependency_key == "queue_service"
+    assert config.events_dependency_key == "queue_events"
+    assert config.sync_thread_name_prefix == "litestar-queues"
+    assert config.scheduler_canary_task == "scheduler.heartbeat"
+    assert config.event_publisher_state_key == "queue_event_publisher"
+    assert config.observability_runtime_state_key == "queue_observability_runtime"
+
+
+def test_custom_namespace_derives_package_owned_config_defaults() -> None:
+    config = QueueConfig(namespace="dma")
+
+    assert config.service_dependency_key == "dma_service"
+    assert config.events_dependency_key == "dma_events"
+    assert config.sync_thread_name_prefix == "dma"
+    assert config.scheduler_canary_task == "dma.scheduler.heartbeat"
+
+
+def test_explicit_package_owned_names_override_namespace_defaults() -> None:
+    config = QueueConfig(
+        namespace="dma",
+        service_dependency_key="service",
+        events_dependency_key="events",
+        sync_thread_name_prefix="threads",
+        scheduler_canary_task="ops.healthcheck",
+    )
+
+    assert config.service_dependency_key == "service"
+    assert config.events_dependency_key == "events"
+    assert config.sync_thread_name_prefix == "threads"
+    assert config.scheduler_canary_task == "ops.healthcheck"
+
+
+@pytest.mark.parametrize(
+    "namespace",
+    ["", "DMA", " dma", "dma ", "_dma", "dma_", "dma__queues", "dma.queues", "dma-queues", "1dma"],
+)
+def test_namespace_rejects_ambiguous_roots(namespace: str) -> None:
+    with pytest.raises(QueueConfigurationError, match=r"QueueConfig\.namespace"):
+        QueueConfig(namespace=namespace)
+
+
+def test_namespace_does_not_change_user_task_or_queue_names() -> None:
+    worker = WorkerConfig(placement="external", queues=("critical", "reports"))
+    config = QueueConfig(
+        namespace="dma",
+        queue_backend="memory",
+        worker=worker,
+        scheduler_canary_task="app.scheduler.healthcheck",
+    )
+
+    assert config.worker.queues == ("critical", "reports")
+    assert config.scheduler_canary_task == "app.scheduler.healthcheck"
+    assert replace(config, namespace="analytics").worker.queues == ("critical", "reports")
+
+
+def test_namespace_does_not_change_sql_table_configuration() -> None:
+    pytest.importorskip("sqlspec")
+    from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
+
+    backend = SQLSpecBackendConfig(
+        queue_table_name="jobs",
+        event_history_table_name="job_events",
+        maintenance_table_name="job_maintenance",
+        task_reservation_table_name="job_reservations",
+    )
+    config = QueueConfig(namespace="dma", queue_backend=backend, worker=WorkerConfig(placement="external"))
+
+    assert config.queue_backend is backend
+    assert backend.queue_table_name == "jobs"
+    assert backend.event_history_table_name == "job_events"
+    assert backend.maintenance_table_name == "job_maintenance"
+    assert backend.task_reservation_table_name == "job_reservations"
+
+
+def test_queue_channels_accept_namespace_without_mutating_legacy_default() -> None:
+    assert QueueChannels.task("task-1", namespace="dma") == "dma:task:task-1:events"
+    assert QueueChannels.queue("reports", namespace=QueueNamespace("dma")) == "dma:queue:reports:events"
+    assert QueueChannels.task("task-1") == "litestar_queues:task:task-1:events"
+
+
+def test_redis_runtime_keys_derive_from_namespace_and_explicit_values_win() -> None:
+    pytest.importorskip("redis")
+    from litestar_queues.backends.redis import RedisBackendConfig, RedisQueueBackend
+
+    derived = RedisQueueBackend(
+        QueueConfig(
+            namespace="dma",
+            queue_backend=RedisBackendConfig(),
+            worker=WorkerConfig(placement="external"),
+        ),
+        backend_config=RedisBackendConfig(),
+    )
+    explicit = RedisQueueBackend(
+        QueueConfig(namespace="dma", worker=WorkerConfig(placement="external")),
+        backend_config=RedisBackendConfig(key_prefix="jobs", wakeup_channel="jobs:wakeups"),
+    )
+
+    assert derived._key_prefix == "dma"
+    assert derived._wakeup_channel == "dma:worker_wakeups"
+    assert explicit._key_prefix == "jobs"
+    assert explicit._wakeup_channel == "jobs:wakeups"
+
+
+def test_sqlspec_wakeup_channel_derives_without_changing_tables() -> None:
+    pytest.importorskip("sqlspec")
+    from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueBackend
+
+    backend_config = SQLSpecBackendConfig(queue_table_name="jobs")
+    backend = SQLSpecQueueBackend(
+        QueueConfig(
+            namespace="dma",
+            queue_backend=backend_config,
+            worker=WorkerConfig(placement="external"),
+        ),
+        backend_config=backend_config,
+    )
+
+    assert backend._wakeup_channel == "dma_tasks"
+    assert backend._queue_table_name == "jobs"

--- a/src/tests/unit/test_namespace.py
+++ b/src/tests/unit/test_namespace.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -158,3 +159,46 @@ def test_sqlspec_wakeup_channel_derives_without_changing_tables() -> None:
 
     assert backend._wakeup_channel == "dma_tasks"
     assert backend._queue_table_name == "jobs"
+
+
+def test_runtime_components_use_namespace_logger_hierarchy() -> None:
+    from litestar_queues import QueuePlugin, QueueService
+    from litestar_queues.backends.memory import InMemoryQueueBackend
+    from litestar_queues.events import QueueEventPublisher
+    from litestar_queues.worker import Worker
+    from litestar_queues.worker.supervisor import ServerWorkerSupervisor
+
+    config = QueueConfig(namespace="dma", queue_backend="memory", worker=WorkerConfig(placement="external"))
+    service = QueueService(config)
+    worker = Worker(service)
+
+    assert service._logger.name == "dma.service"
+    assert worker._logger.name == "dma.worker"
+    assert QueuePlugin(config)._logger.name == "dma.plugin"
+    assert QueueEventPublisher(namespace=config.names)._logger.name == "dma.events.publisher"
+    assert InMemoryQueueBackend(config)._logger.name == "dma.backends.InMemoryQueueBackend"
+    assert ServerWorkerSupervisor(config)._logger.name == "dma.worker.supervisor"
+
+
+def test_runtime_resource_drift_gate_keeps_legacy_literals_out_of_live_paths() -> None:
+    package_root = Path(__file__).parents[2] / "litestar_queues"
+    supervisor = (package_root / "worker" / "supervisor.py").read_text()
+    invocation = (package_root / "worker" / "invocation.py").read_text()
+    ephemeral = (package_root / "backends" / "ephemeral" / "server.py").read_text()
+
+    assert 'name="litestar-queues-' not in supervisor
+    assert "os.environ[_PROCESS_ROLE_ENV_VAR]" not in supervisor
+    assert "tempfile.mkdtemp(prefix=_DIRECTORY_PREFIX)" not in invocation
+    assert "tempfile.mkdtemp(prefix=_DIRECTORY_PREFIX)" not in ephemeral
+
+
+def test_cloudrun_environment_defaults_derive_from_namespace_and_explicit_prefix_wins() -> None:
+    from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
+
+    derived = CloudRunExecutionConfig(project_id="project", job_name="worker")
+    explicit = CloudRunExecutionConfig(project_id="project", job_name="worker", env_prefix="WORK")
+    namespace = QueueNamespace("dma")
+
+    assert derived.env_name("TASK_ID", namespace=namespace) == "QUEUES_TASK_ID"
+    assert explicit.env_name("TASK_ID", namespace=namespace) == "QUEUES_TASK_ID"
+    assert derived.env_name("TASK_ID") == "QUEUES_TASK_ID"

--- a/src/tests/unit/test_namespace.py
+++ b/src/tests/unit/test_namespace.py
@@ -73,8 +73,7 @@ def test_explicit_package_owned_names_override_namespace_defaults() -> None:
 
 
 @pytest.mark.parametrize(
-    "namespace",
-    ["", "DMA", " dma", "dma ", "_dma", "dma_", "dma__queues", "dma.queues", "dma-queues", "1dma"],
+    "namespace", ["", "DMA", " dma", "dma ", "_dma", "dma_", "dma__queues", "dma.queues", "dma-queues", "1dma"]
 )
 def test_namespace_rejects_ambiguous_roots(namespace: str) -> None:
     with pytest.raises(QueueConfigurationError, match=r"QueueConfig\.namespace"):
@@ -84,10 +83,7 @@ def test_namespace_rejects_ambiguous_roots(namespace: str) -> None:
 def test_namespace_does_not_change_user_task_or_queue_names() -> None:
     worker = WorkerConfig(placement="external", queues=("critical", "reports"))
     config = QueueConfig(
-        namespace="dma",
-        queue_backend="memory",
-        worker=worker,
-        scheduler_canary_task="app.scheduler.healthcheck",
+        namespace="dma", queue_backend="memory", worker=worker, scheduler_canary_task="app.scheduler.healthcheck"
     )
 
     assert config.worker.queues == ("critical", "reports")
@@ -125,11 +121,7 @@ def test_redis_runtime_keys_derive_from_namespace_and_explicit_values_win() -> N
     from litestar_queues.backends.redis import RedisBackendConfig, RedisQueueBackend
 
     derived = RedisQueueBackend(
-        QueueConfig(
-            namespace="dma",
-            queue_backend=RedisBackendConfig(),
-            worker=WorkerConfig(placement="external"),
-        ),
+        QueueConfig(namespace="dma", queue_backend=RedisBackendConfig(), worker=WorkerConfig(placement="external")),
         backend_config=RedisBackendConfig(),
     )
     explicit = RedisQueueBackend(
@@ -149,11 +141,7 @@ def test_sqlspec_wakeup_channel_derives_without_changing_tables() -> None:
 
     backend_config = SQLSpecBackendConfig(queue_table_name="jobs")
     backend = SQLSpecQueueBackend(
-        QueueConfig(
-            namespace="dma",
-            queue_backend=backend_config,
-            worker=WorkerConfig(placement="external"),
-        ),
+        QueueConfig(namespace="dma", queue_backend=backend_config, worker=WorkerConfig(placement="external")),
         backend_config=backend_config,
     )
 

--- a/src/tests/unit/test_observability.py
+++ b/src/tests/unit/test_observability.py
@@ -126,9 +126,13 @@ async def test_plugin_startup_resolves_runtime_with_litestar_app(monkeypatch: "p
     seen_apps: "list[Litestar | None]" = []
 
     def create_runtime(
-        config: "ObservabilityConfig | None", *, app: "Litestar | None" = None
+        config: "ObservabilityConfig | None",
+        *,
+        app: "Litestar | None" = None,
+        namespace: "object | None" = None,
     ) -> "FakeObservabilityRuntime":
         assert config is not None
+        assert namespace is not None
         seen_apps.append(app)
         return runtime
 
@@ -238,6 +242,22 @@ async def test_runtime_records_gauge_delta_with_prometheus_gauge() -> "None":
     runtime.record_gauge_delta("litestar_queues.worker.active", -1, attributes={"scope": "worker"})
 
     assert registry.get_sample_value("litestar_queues_worker_active", labels={"scope": "worker"}) == 1.0
+
+
+async def test_runtime_rewrites_package_metric_names_from_queue_namespace() -> "None":
+    prometheus_client = pytest.importorskip("prometheus_client")
+
+    from litestar_queues.observability import ObservabilityConfig, QueueObservabilityRuntime
+
+    registry = prometheus_client.CollectorRegistry()
+    runtime = QueueObservabilityRuntime(
+        ObservabilityConfig(enable_prometheus=True, prometheus_registry=registry),
+        namespace="dma",
+    )
+
+    runtime.record_counter("litestar_queues.wakeup.emitted", attributes={"queue.backend": "memory"})
+
+    assert registry.get_sample_value("dma_wakeup_emitted_total", labels={"queue.backend": "memory"}) == 1.0
 
 
 async def test_runtime_records_and_caches_value_histograms_with_explicit_units(

--- a/src/tests/unit/test_observability.py
+++ b/src/tests/unit/test_observability.py
@@ -240,6 +240,205 @@ async def test_runtime_records_gauge_delta_with_prometheus_gauge() -> "None":
     assert registry.get_sample_value("litestar_queues_worker_active", labels={"scope": "worker"}) == 1.0
 
 
+async def test_runtime_records_and_caches_value_histograms_with_explicit_units(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "None":
+    """Transport batch sizes need value histograms rather than counters or durations."""
+    from litestar_queues import observability as observability_module
+    from litestar_queues.observability import ObservabilityConfig, QueueObservabilityRuntime
+    from litestar_queues.typing import otel_metrics
+
+    meter = _FakeOtelMeter()
+
+    def get_meter(*_args: "Any", **_kwargs: "Any") -> "_FakeOtelMeter":
+        return meter
+
+    monkeypatch.setattr(observability_module, "OPENTELEMETRY_INSTALLED", True)
+    monkeypatch.setattr(otel_metrics, "get_meter", get_meter)
+
+    runtime = QueueObservabilityRuntime(ObservabilityConfig(enable_otel=True))
+    attributes = {"queue.backend": "memory", "queue.operation": "enqueue_many"}
+    runtime.record_histogram(
+        "litestar_queues.enqueue.batch.size", 5, unit="records", attributes=attributes
+    )
+    runtime.record_histogram(
+        "litestar_queues.enqueue.batch.size", 2, unit="records", attributes=attributes
+    )
+
+    assert meter.created_histograms == [("litestar_queues.enqueue.batch.size", "records")]
+    assert meter.histogram.samples == [
+        (5, attributes),
+        (2, attributes),
+    ]
+
+
+async def test_value_histogram_uses_unit_specific_prometheus_name_and_buckets() -> "None":
+    prometheus_client = pytest.importorskip("prometheus_client")
+
+    from litestar_queues.observability import ObservabilityConfig, QueueObservabilityRuntime
+
+    registry = prometheus_client.CollectorRegistry()
+    runtime = QueueObservabilityRuntime(
+        ObservabilityConfig(enable_prometheus=True, prometheus_registry=registry)
+    )
+    attributes = {"queue.backend": "memory", "queue.operation": "enqueue_many"}
+
+    runtime.record_histogram(
+        "litestar_queues.enqueue.batch.size", 25, unit="records", attributes=attributes
+    )
+
+    assert (
+        registry.get_sample_value(
+            "litestar_queues_enqueue_batch_size_records_bucket",
+            labels={**attributes, "le": "25.0"},
+        )
+        == 1.0
+    )
+    assert (
+        registry.get_sample_value(
+            "litestar_queues_enqueue_batch_size_records_bucket",
+            labels={**attributes, "le": "10.0"},
+        )
+        == 0.0
+    )
+
+
+def test_transport_metric_contract_locks_kind_unit_and_exact_attributes() -> "None":
+    from litestar_queues.observability import _TRANSPORT_METRIC_SPECS
+
+    expected = {
+        "litestar_queues.enqueue.batch.size": (
+            "histogram",
+            "records",
+            frozenset({"queue.backend", "queue.operation"}),
+        ),
+        "litestar_queues.wakeup.emitted": (
+            "counter",
+            "hints",
+            frozenset({"queue.backend", "queue.transport"}),
+        ),
+        "litestar_queues.wakeup.coalesced": (
+            "counter",
+            "hints",
+            frozenset({"queue.backend", "queue.transport"}),
+        ),
+        "litestar_queues.worker.poll.empty": ("counter", "polls", frozenset({"queue.backend"})),
+        "litestar_queues.worker.poll.delay": (
+            "histogram",
+            "s",
+            frozenset({"queue.backend", "worker.wait.kind"}),
+        ),
+        "litestar_queues.worker.wait.duration": (
+            "duration",
+            "s",
+            frozenset({"queue.backend", "worker.wait.kind"}),
+        ),
+        "litestar_queues.worker.wakeup_to_claim.duration": (
+            "duration",
+            "s",
+            frozenset({"queue.backend", "queue.transport"}),
+        ),
+        "litestar_queues.listener.reconnect": (
+            "counter",
+            "reconnects",
+            frozenset({"queue.backend", "queue.transport"}),
+        ),
+        "litestar_queues.listener.error": (
+            "counter",
+            "errors",
+            frozenset({"queue.backend", "queue.transport", "queue.outcome"}),
+        ),
+        "litestar_queues.claim.batch.size": (
+            "histogram",
+            "records",
+            frozenset({"queue.backend", "queue.operation"}),
+        ),
+        "litestar_queues.event.flush.size": (
+            "histogram",
+            "events",
+            frozenset({"queue.transport", "queue.outcome"}),
+        ),
+        "litestar_queues.event.flush.duration": (
+            "duration",
+            "s",
+            frozenset({"queue.transport", "queue.outcome"}),
+        ),
+        "litestar_queues.event.dropped": (
+            "counter",
+            "events",
+            frozenset({"queue.transport", "queue.outcome"}),
+        ),
+    }
+
+    assert {
+        name: (spec.kind, spec.unit, spec.attributes)
+        for name, spec in _TRANSPORT_METRIC_SPECS.items()
+    } == expected
+
+
+@pytest.mark.parametrize(
+    "extra_attribute",
+    ["queue.task.id", "queue.channel", "queue.payload", "db.statement", "url.full", "error.message"],
+)
+def test_transport_metric_contract_rejects_unbounded_attributes(extra_attribute: "str") -> "None":
+    from litestar_queues.observability import _validate_transport_metric
+
+    attributes = {
+        "queue.backend": "memory",
+        "queue.operation": "enqueue_many",
+        extra_attribute: "unbounded-value",
+    }
+
+    with pytest.raises(ValueError, match="attributes"):
+        _validate_transport_metric(
+            "litestar_queues.enqueue.batch.size",
+            kind="histogram",
+            unit="records",
+            attributes=attributes,
+        )
+
+
+def test_transport_metric_contract_rejects_missing_attributes_wrong_kind_and_wrong_unit() -> "None":
+    from litestar_queues.observability import _validate_transport_metric
+
+    with pytest.raises(ValueError, match="attributes"):
+        _validate_transport_metric(
+            "litestar_queues.enqueue.batch.size",
+            kind="histogram",
+            unit="records",
+            attributes={"queue.backend": "memory"},
+        )
+    with pytest.raises(ValueError, match="kind"):
+        _validate_transport_metric(
+            "litestar_queues.enqueue.batch.size",
+            kind="counter",
+            unit="records",
+            attributes={"queue.backend": "memory", "queue.operation": "enqueue_many"},
+        )
+    with pytest.raises(ValueError, match="unit"):
+        _validate_transport_metric(
+            "litestar_queues.enqueue.batch.size",
+            kind="histogram",
+            unit="events",
+            attributes={"queue.backend": "memory", "queue.operation": "enqueue_many"},
+        )
+
+
+def test_disabled_runtime_skips_histogram_validation_and_instrument_allocation() -> "None":
+    from litestar_queues.observability import QueueObservabilityRuntime
+
+    runtime = QueueObservabilityRuntime(None)
+
+    runtime.record_histogram(
+        "litestar_queues.enqueue.batch.size",
+        1,
+        unit="records",
+        attributes={"unbounded": "ignored"},
+    )
+
+    assert runtime._histograms == {}
+
+
 async def test_cloudrun_dispatch_records_span_and_metrics() -> "None":
     """Cloud Run dispatch should emit package-level dispatch telemetry."""
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
@@ -353,18 +552,27 @@ class _FakeOtelMetric:
     __slots__ = ("samples",)
 
     def __init__(self) -> "None":
-        self.samples: "list[tuple[int, dict[str, str]]]" = []
+        self.samples: "list[tuple[float, dict[str, str]]]" = []
 
-    def add(self, delta: "int", *, attributes: "dict[str, str]") -> "None":
+    def add(self, delta: "float", *, attributes: "dict[str, str]") -> "None":
         self.samples.append((delta, dict(attributes)))
+
+    def record(self, value: "float", *, attributes: "dict[str, str]") -> "None":
+        self.samples.append((value, dict(attributes)))
 
 
 class _FakeOtelMeter:
-    __slots__ = ("created_up_down_counters", "up_down_counter")
+    __slots__ = ("created_histograms", "created_up_down_counters", "histogram", "up_down_counter")
 
     def __init__(self) -> "None":
+        self.created_histograms: "list[tuple[str, str]]" = []
         self.created_up_down_counters: "list[str]" = []
+        self.histogram = _FakeOtelMetric()
         self.up_down_counter = _FakeOtelMetric()
+
+    def create_histogram(self, name: "str", *, unit: "str") -> "_FakeOtelMetric":
+        self.created_histograms.append((name, unit))
+        return self.histogram
 
     def create_up_down_counter(self, name: "str") -> "_FakeOtelMetric":
         self.created_up_down_counters.append(name)

--- a/src/tests/unit/test_observability.py
+++ b/src/tests/unit/test_observability.py
@@ -126,10 +126,7 @@ async def test_plugin_startup_resolves_runtime_with_litestar_app(monkeypatch: "p
     seen_apps: "list[Litestar | None]" = []
 
     def create_runtime(
-        config: "ObservabilityConfig | None",
-        *,
-        app: "Litestar | None" = None,
-        namespace: "object | None" = None,
+        config: "ObservabilityConfig | None", *, app: "Litestar | None" = None, namespace: "object | None" = None
     ) -> "FakeObservabilityRuntime":
         assert config is not None
         assert namespace is not None
@@ -251,8 +248,7 @@ async def test_runtime_rewrites_package_metric_names_from_queue_namespace() -> "
 
     registry = prometheus_client.CollectorRegistry()
     runtime = QueueObservabilityRuntime(
-        ObservabilityConfig(enable_prometheus=True, prometheus_registry=registry),
-        namespace="dma",
+        ObservabilityConfig(enable_prometheus=True, prometheus_registry=registry), namespace="dma"
     )
 
     runtime.record_counter("litestar_queues.wakeup.emitted", attributes={"queue.backend": "memory"})
@@ -278,18 +274,11 @@ async def test_runtime_records_and_caches_value_histograms_with_explicit_units(
 
     runtime = QueueObservabilityRuntime(ObservabilityConfig(enable_otel=True))
     attributes = {"queue.backend": "memory", "queue.operation": "enqueue_many"}
-    runtime.record_histogram(
-        "litestar_queues.enqueue.batch.size", 5, unit="records", attributes=attributes
-    )
-    runtime.record_histogram(
-        "litestar_queues.enqueue.batch.size", 2, unit="records", attributes=attributes
-    )
+    runtime.record_histogram("litestar_queues.enqueue.batch.size", 5, unit="records", attributes=attributes)
+    runtime.record_histogram("litestar_queues.enqueue.batch.size", 2, unit="records", attributes=attributes)
 
     assert meter.created_histograms == [("litestar_queues.enqueue.batch.size", "records")]
-    assert meter.histogram.samples == [
-        (5, attributes),
-        (2, attributes),
-    ]
+    assert meter.histogram.samples == [(5, attributes), (2, attributes)]
 
 
 async def test_value_histogram_uses_unit_specific_prometheus_name_and_buckets() -> "None":
@@ -298,26 +287,20 @@ async def test_value_histogram_uses_unit_specific_prometheus_name_and_buckets() 
     from litestar_queues.observability import ObservabilityConfig, QueueObservabilityRuntime
 
     registry = prometheus_client.CollectorRegistry()
-    runtime = QueueObservabilityRuntime(
-        ObservabilityConfig(enable_prometheus=True, prometheus_registry=registry)
-    )
+    runtime = QueueObservabilityRuntime(ObservabilityConfig(enable_prometheus=True, prometheus_registry=registry))
     attributes = {"queue.backend": "memory", "queue.operation": "enqueue_many"}
 
-    runtime.record_histogram(
-        "litestar_queues.enqueue.batch.size", 25, unit="records", attributes=attributes
-    )
+    runtime.record_histogram("litestar_queues.enqueue.batch.size", 25, unit="records", attributes=attributes)
 
     assert (
         registry.get_sample_value(
-            "litestar_queues_enqueue_batch_size_records_bucket",
-            labels={**attributes, "le": "25.0"},
+            "litestar_queues_enqueue_batch_size_records_bucket", labels={**attributes, "le": "25.0"}
         )
         == 1.0
     )
     assert (
         registry.get_sample_value(
-            "litestar_queues_enqueue_batch_size_records_bucket",
-            labels={**attributes, "le": "10.0"},
+            "litestar_queues_enqueue_batch_size_records_bucket", labels={**attributes, "le": "10.0"}
         )
         == 0.0
     )
@@ -327,32 +310,12 @@ def test_transport_metric_contract_locks_kind_unit_and_exact_attributes() -> "No
     from litestar_queues.observability import _TRANSPORT_METRIC_SPECS
 
     expected = {
-        "litestar_queues.enqueue.batch.size": (
-            "histogram",
-            "records",
-            frozenset({"queue.backend", "queue.operation"}),
-        ),
-        "litestar_queues.wakeup.emitted": (
-            "counter",
-            "hints",
-            frozenset({"queue.backend", "queue.transport"}),
-        ),
-        "litestar_queues.wakeup.coalesced": (
-            "counter",
-            "hints",
-            frozenset({"queue.backend", "queue.transport"}),
-        ),
+        "litestar_queues.enqueue.batch.size": ("histogram", "records", frozenset({"queue.backend", "queue.operation"})),
+        "litestar_queues.wakeup.emitted": ("counter", "hints", frozenset({"queue.backend", "queue.transport"})),
+        "litestar_queues.wakeup.coalesced": ("counter", "hints", frozenset({"queue.backend", "queue.transport"})),
         "litestar_queues.worker.poll.empty": ("counter", "polls", frozenset({"queue.backend"})),
-        "litestar_queues.worker.poll.delay": (
-            "histogram",
-            "s",
-            frozenset({"queue.backend", "worker.wait.kind"}),
-        ),
-        "litestar_queues.worker.wait.duration": (
-            "duration",
-            "s",
-            frozenset({"queue.backend", "worker.wait.kind"}),
-        ),
+        "litestar_queues.worker.poll.delay": ("histogram", "s", frozenset({"queue.backend", "worker.wait.kind"})),
+        "litestar_queues.worker.wait.duration": ("duration", "s", frozenset({"queue.backend", "worker.wait.kind"})),
         "litestar_queues.worker.wakeup_to_claim.duration": (
             "duration",
             "s",
@@ -368,53 +331,26 @@ def test_transport_metric_contract_locks_kind_unit_and_exact_attributes() -> "No
             "errors",
             frozenset({"queue.backend", "queue.transport", "queue.outcome"}),
         ),
-        "litestar_queues.claim.batch.size": (
-            "histogram",
-            "records",
-            frozenset({"queue.backend", "queue.operation"}),
-        ),
-        "litestar_queues.event.flush.size": (
-            "histogram",
-            "events",
-            frozenset({"queue.transport", "queue.outcome"}),
-        ),
-        "litestar_queues.event.flush.duration": (
-            "duration",
-            "s",
-            frozenset({"queue.transport", "queue.outcome"}),
-        ),
-        "litestar_queues.event.dropped": (
-            "counter",
-            "events",
-            frozenset({"queue.transport", "queue.outcome"}),
-        ),
+        "litestar_queues.claim.batch.size": ("histogram", "records", frozenset({"queue.backend", "queue.operation"})),
+        "litestar_queues.event.flush.size": ("histogram", "events", frozenset({"queue.transport", "queue.outcome"})),
+        "litestar_queues.event.flush.duration": ("duration", "s", frozenset({"queue.transport", "queue.outcome"})),
+        "litestar_queues.event.dropped": ("counter", "events", frozenset({"queue.transport", "queue.outcome"})),
     }
 
-    assert {
-        name: (spec.kind, spec.unit, spec.attributes)
-        for name, spec in _TRANSPORT_METRIC_SPECS.items()
-    } == expected
+    assert {name: (spec.kind, spec.unit, spec.attributes) for name, spec in _TRANSPORT_METRIC_SPECS.items()} == expected
 
 
 @pytest.mark.parametrize(
-    "extra_attribute",
-    ["queue.task.id", "queue.channel", "queue.payload", "db.statement", "url.full", "error.message"],
+    "extra_attribute", ["queue.task.id", "queue.channel", "queue.payload", "db.statement", "url.full", "error.message"]
 )
 def test_transport_metric_contract_rejects_unbounded_attributes(extra_attribute: "str") -> "None":
     from litestar_queues.observability import _validate_transport_metric
 
-    attributes = {
-        "queue.backend": "memory",
-        "queue.operation": "enqueue_many",
-        extra_attribute: "unbounded-value",
-    }
+    attributes = {"queue.backend": "memory", "queue.operation": "enqueue_many", extra_attribute: "unbounded-value"}
 
     with pytest.raises(ValueError, match="attributes"):
         _validate_transport_metric(
-            "litestar_queues.enqueue.batch.size",
-            kind="histogram",
-            unit="records",
-            attributes=attributes,
+            "litestar_queues.enqueue.batch.size", kind="histogram", unit="records", attributes=attributes
         )
 
 
@@ -450,10 +386,7 @@ def test_disabled_runtime_skips_histogram_validation_and_instrument_allocation()
     runtime = QueueObservabilityRuntime(None)
 
     runtime.record_histogram(
-        "litestar_queues.enqueue.batch.size",
-        1,
-        unit="records",
-        attributes={"unbounded": "ignored"},
+        "litestar_queues.enqueue.batch.size", 1, unit="records", attributes={"unbounded": "ignored"}
     )
 
     assert runtime._histograms == {}
@@ -566,6 +499,9 @@ class FakeObservabilityRuntime:
 
     def record_duration(self, name: "str", seconds: "float", *, attributes: "Mapping[str, str]") -> "None":
         self.durations.append((name, seconds, dict(attributes)))
+
+    def record_histogram(self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]") -> "None":
+        del name, value, unit, attributes
 
 
 class _FakeOtelMetric:

--- a/src/tests/unit/test_plugin.py
+++ b/src/tests/unit/test_plugin.py
@@ -121,6 +121,24 @@ def test_queue_config_get_service_requires_opened_app_state_service() -> "None":
     assert config.get_service(app_config.state) is service
 
 
+def test_custom_namespace_registers_disjoint_dependencies_and_state() -> "None":
+    from litestar.config.app import AppConfig
+
+    from litestar_queues import QueueConfig, QueuePlugin
+
+    alpha = QueueConfig(namespace="alpha", worker=WorkerConfig(placement="external"), queue_backend="memory")
+    beta = QueueConfig(namespace="beta", worker=WorkerConfig(placement="external"), queue_backend="memory")
+    app_config = AppConfig()
+
+    QueuePlugin(alpha).on_app_init(app_config)
+    QueuePlugin(beta).on_app_init(app_config)
+
+    assert {"alpha_service", "alpha_events", "beta_service", "beta_events"} <= app_config.dependencies.keys()
+    assert app_config.state["alpha_service"] is alpha
+    assert app_config.state["beta_service"] is beta
+    assert "queue_service" not in app_config.state
+
+
 async def test_plugin_worker_receives_configured_poll_backoff_settings() -> "None":
     """Backoff settings are passed explicitly into the plugin-started worker, not read from config in the loop."""
     from litestar_queues import QueueConfig, QueuePlugin

--- a/src/tests/unit/test_server_worker.py
+++ b/src/tests/unit/test_server_worker.py
@@ -278,7 +278,14 @@ def test_process_context_never_selects_fork(methods: list[str], expected: str) -
 def test_launch_spec_contains_only_primitive_data_and_hides_environment() -> None:
     spec = _spec("postgres://user:credential@example")
 
-    assert tuple(item.name for item in fields(spec)) == ("app_path", "app_dir", "sys_path", "environment", "log_level")
+    assert tuple(item.name for item in fields(spec)) == (
+        "app_path",
+        "app_dir",
+        "sys_path",
+        "environment",
+        "log_level",
+        "namespace",
+    )
     assert "credential" not in repr(spec)
     assert all(
         isinstance(value, (str, int, tuple))

--- a/src/tests/unit/test_stream_plugin.py
+++ b/src/tests/unit/test_stream_plugin.py
@@ -56,6 +56,32 @@ def test_enabled_stream_config_respects_configured_scopes() -> None:
     assert _stream_paths(app) == {"/events/tasks/{task_id:str}", "/events/sse/tasks/{task_id:str}"}
 
 
+def test_namespaced_plugins_register_disjoint_default_stream_paths() -> None:
+    channels = _channels_arbitrary()
+    plugins = [
+        QueuePlugin(
+            QueueConfig(
+                namespace=namespace,
+                worker=WorkerConfig(placement="external"),
+                queue_backend="memory",
+                events=QueueEventsConfig(
+                    channels=channels, delivery=EventDeliveryConfig(), stream=EventStreamConfig(scopes={"task"})
+                ),
+            )
+        )
+        for namespace in ("alpha", "beta")
+    ]
+
+    app = Litestar(plugins=[channels, *plugins], openapi_config=None)
+
+    assert _stream_paths(app) == {
+        "/alpha/events/tasks/{task_id:str}",
+        "/alpha/events/sse/tasks/{task_id:str}",
+        "/beta/events/tasks/{task_id:str}",
+        "/beta/events/sse/tasks/{task_id:str}",
+    }
+
+
 def test_disabled_stream_config_registers_no_routes() -> None:
     sys.modules.pop("litestar_queues.events.streaming", None)
     default_app = Litestar(
@@ -189,7 +215,7 @@ def test_bare_channels_plugin_without_arbitrary_channels_raises() -> None:
 
 
 def _stream_paths(app: Litestar) -> set[str]:
-    return {route.path for route in app.routes if route.path.startswith(("/queues/events", "/events"))}
+    return {route.path for route in app.routes}
 
 
 def _channels_arbitrary() -> ChannelsPlugin:

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -1050,10 +1050,10 @@ async def test_plugin_logs_when_app_worker_task_dies(monkeypatch: "pytest.Monkey
         messages.append((message, kwargs))
 
     monkeypatch.setattr(plugin_module, "Worker", _FailingWorker)
-    monkeypatch.setattr(plugin_module.logger, "error", log_error)
     plugin = QueuePlugin(
         QueueConfig(queue_backend="memory", worker=WorkerConfig(placement="asgi"), execution_backend="local")
     )
+    monkeypatch.setattr(plugin._logger, "error", log_error)
     app = Litestar(plugins=[plugin])
 
     async with plugin._lifespan(app):

--- a/src/tests/unit/test_worker_placement.py
+++ b/src/tests/unit/test_worker_placement.py
@@ -233,6 +233,26 @@ def test_server_context_sets_two_separate_variables_and_clears_them() -> "None":
 
 
 @pytest.mark.usefixtures("clean_proof_environment")
+def test_server_context_derives_private_environment_and_resource_names() -> "None":
+    from litestar_queues import QueueNamespace
+    from litestar_queues.worker.invocation import server_context, server_context_active
+
+    names = QueueNamespace("dma")
+    nonce_env = names.environment("server", "nonce")
+    marker_env = names.environment("server", "marker")
+
+    with server_context(names) as nonce:
+        marker = Path(os.environ[marker_env])
+        assert os.environ[nonce_env] == nonce
+        assert marker.parent.name.startswith("dma-server-")
+        assert server_context_active(names) is True
+
+    assert nonce_env not in os.environ
+    assert marker_env not in os.environ
+    assert server_context_active(names) is False
+
+
+@pytest.mark.usefixtures("clean_proof_environment")
 def test_marker_holds_the_exact_json_shape() -> "None":
     from litestar_queues.worker.invocation import MARKER_ENV_VAR, server_context
 


### PR DESCRIPTION
## Summary

- add `QueueConfig(namespace="dma")` as the single source of truth for package-owned runtime identity
- derive Litestar state/DI/route registrations and default stream paths, event channels, maintenance coordination, Redis/Valkey keys, backend wakeups, Cloud Tasks delivery resources, telemetry, logger hierarchies, SQLCommenter attribution, and process/thread/temp resources from that config
- use stable brand-neutral `QUEUES_CONFIG_FACTORY` and `QUEUES_TASK_ID` variables for external bootstrap, then apply the loaded config namespace to post-bootstrap runtime names
- preserve existing identifiers for the default `litestar_queues` namespace and keep explicit component settings authoritative
- leave SQL table names, ORM model classes, user task names, and user queue names unchanged
- add the bounded 13-metric transport contract and value-histogram runtime required by the transport-observability work

## Why the namespace lives on QueueConfig

`QueueConfig` is shared by plugin-managed and standalone services, workers, consumers, queue backends, and execution backends. Keeping the namespace there means it is set once and does not need to be repeated on `QueuePlugin` or individual components.

## Bootstrap compatibility

`QUEUES_CONFIG_FACTORY` and `QUEUES_TASK_ID` are intentionally stable rather than namespace-derived: the external consumer must discover the config factory and task id before it can load `QueueConfig.namespace`. After config loading, package-owned environment names and other runtime identity derive from that namespace.

SQL table/model names remain controlled by their existing backend settings and are not derived from `namespace`.