### PR TITLE
feat(observability): instrument queue transport hot paths

### DIFF
--- a/docs/usage/observability.rst
+++ b/docs/usage/observability.rst
@@ -268,6 +268,30 @@ come from the configured built-in vocabulary; arbitrary channel names, payload
 fields, task arguments, record identifiers, and exception messages never become
 metric labels.
 
+Controlled transport benchmark
+------------------------------
+
+Maintainers can compare the instrumented control paths without external
+services:
+
+.. code-block:: bash
+
+   uv run python tools/benchmark_queue_transports.py \
+       --tasks 1000 --batch-size 100 --pretty \
+       --output transport-benchmark.json
+
+The versioned JSON records environment metadata, parameters, operation counts,
+duration, throughput, and latency percentiles where latency is meaningful. The
+idle scenario compares fixed and adaptive backend calls, the notification
+scenario measures notification-to-claim latency and reconciliation calls, and
+the batch scenarios compare sequential claims and event publication with their
+native batched equivalents.
+
+This is a controlled fake-operation microbenchmark for architectural
+comparisons, not an end-to-end backend result or a CI performance gate. Use
+``tools/benchmark_queues.py`` for service-backed measurements, and do not
+publish numbers from a dirty or unreviewed local run as release claims.
+
 That constraint is why re-checking lost deliveries reports into
 ``litestar_queues.execution.repair`` rather than joining
 ``litestar_queues.execution.reconcile``. Both describe bringing a record back in

--- a/docs/usage/observability.rst
+++ b/docs/usage/observability.rst
@@ -176,6 +176,10 @@ values. This prevents unbounded label counts:
 - ``queue.task.status``
 - ``queue.task.attempt``
 - ``queue.backend``
+- ``queue.operation`` on batch-size histograms, currently ``enqueue_many`` or
+  ``claim_many``
+- ``queue.transport`` on wakeup, listener, and event-delivery metrics
+- ``queue.outcome`` on listener and event-delivery metrics
 - ``queue.execution.backend``
 - ``queue.execution.profile``
 - ``queue.execution.status`` on dispatch metrics, one of ``dispatched``,
@@ -189,6 +193,8 @@ values. This prevents unbounded label counts:
   ``failed``, ``skipped``, or ``handler_needed``
 - ``queue.expiry.outcome`` on the expiry metric, currently ``expired``
 - ``worker.error.type``
+- ``worker.wait.kind`` on worker delay and wait metrics, either ``native`` or
+  ``polling``
 - ``queue.worker.id`` on spans only, when a worker id already exists
 - ``scope`` on plugin-owned stream metrics
 - ``reason`` on stream authorization-denial metrics only
@@ -202,6 +208,65 @@ Each metric name has exactly one emitter. Dispatch, reconcile, and repair
 counters belong to the execution backend, and the heartbeat failure counter
 belongs to the heartbeat manager, so a single metric never arrives with two
 different label sets.
+
+Queue transport metrics
+-----------------------
+
+Transport instrumentation is emitted at logical ownership boundaries rather
+than once per record. Batch sizes are actual batch sizes, wakeup counters belong
+to the backend notification method, wait timing belongs to the worker, and
+event flush timing belongs to the event publisher:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Metric
+     - Labels
+     - Meaning
+   * - ``litestar_queues.enqueue.batch.size``
+     - ``queue.backend``, ``queue.operation``
+     - Records accepted by one ``enqueue_many`` call.
+   * - ``litestar_queues.wakeup.emitted``
+     - ``queue.backend``, ``queue.transport``
+     - Wakeup hints actually sent by a backend.
+   * - ``litestar_queues.wakeup.coalesced``
+     - ``queue.backend``, ``queue.transport``
+     - Per-record hints avoided by a coalesced notification.
+   * - ``litestar_queues.worker.poll.empty``
+     - ``queue.backend``
+     - Worker cycles that found no local or externally claimed work.
+   * - ``litestar_queues.worker.poll.delay``
+     - ``queue.backend``, ``worker.wait.kind``
+     - Configured delay before the next polling or native wait cycle.
+   * - ``litestar_queues.worker.wait.duration``
+     - ``queue.backend``, ``worker.wait.kind``
+     - Time actually spent waiting for work.
+   * - ``litestar_queues.worker.wakeup_to_claim.duration``
+     - ``queue.backend``, ``queue.transport``
+     - Time from a native notification to the following claim attempt.
+   * - ``litestar_queues.listener.reconnect``
+     - ``queue.backend``, ``queue.transport``
+     - Native listener reconnection attempts after a read failure.
+   * - ``litestar_queues.listener.error``
+     - ``queue.backend``, ``queue.transport``, ``queue.outcome``
+     - Native listener failures; the current outcome is ``read_failed``.
+   * - ``litestar_queues.claim.batch.size``
+     - ``queue.backend``, ``queue.operation``
+     - Actual records returned by one ``claim_many`` call.
+   * - ``litestar_queues.event.flush.size``
+     - ``queue.transport``, ``queue.outcome``
+     - Events in one successful or failed live-delivery attempt.
+   * - ``litestar_queues.event.flush.duration``
+     - ``queue.transport``, ``queue.outcome``
+     - Time spent in one live-delivery attempt.
+   * - ``litestar_queues.event.dropped``
+     - ``queue.transport``, ``queue.outcome``
+     - Buffered events dropped with the bounded ``overflow`` outcome.
+
+Event flush outcomes are ``success`` or ``failed``. Transport and backend names
+come from the configured built-in vocabulary; arbitrary channel names, payload
+fields, task arguments, record identifiers, and exception messages never become
+metric labels.
 
 That constraint is why re-checking lost deliveries reports into
 ``litestar_queues.execution.repair`` rather than joining

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -220,6 +220,7 @@ class SQLAlchemyBackend(BaseQueueBackend):
             records = await service.enqueue_many(requests)
         self._increment_queue_metric("enqueue", float(len(records)))
         await self.notify_new_tasks(records)
+        self._record_enqueue_batch(len(requests))
         return records
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -427,13 +428,14 @@ class SQLAlchemyBackend(BaseQueueBackend):
             return
         await self._send_notification_marker()
         self._increment_queue_metric("notify")
+        self._record_wakeup_emitted()
 
     async def notify_new_tasks(self, records: "Sequence[QueuedTaskRecord]") -> "None":
         """Coalesce a batch of task records into at most one wakeup marker."""
-        for record in records:
-            if record.status in {"pending", "scheduled"} and record.is_due:
-                await self.notify_new_task(record)
-                return
+        due = tuple(record for record in records if record.status in {"pending", "scheduled"} and record.is_due)
+        if due:
+            await self.notify_new_task(due[0])
+            self._record_wakeup_coalesced(len(due) - 1)
 
     async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
         """Wait for a PostgreSQL worker wakeup marker when configured.

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from litestar_queues.config import QueueConfig
     from litestar_queues.events import EventHistoryConfig, QueueEventLog
     from litestar_queues.models import HeartbeatTouch, QueuedTaskRecord, TaskRequest, TaskReservation
+    from litestar_queues.observability import QueueObservabilityRuntimeProtocol
 
 __all__ = ("EXTERNAL_DISPATCH_RESERVATION_PREFIX", "BaseQueueBackend", "is_external_dispatch_reservation")
 
@@ -33,13 +34,50 @@ STALE_REQUEUE_PRIORITY = 4
 class BaseQueueBackend:
     """Base class for queue persistence backends."""
 
-    __slots__ = ("_logger", "config")
+    __slots__ = ("_logger", "_transport_observability_runtime", "config")
 
     def __init__(self, config: "QueueConfig | None" = None) -> "None":
         """Initialize the queue backend."""
         self.config = config
+        self._transport_observability_runtime: "QueueObservabilityRuntimeProtocol | None" = None
         names = config.names if config is not None else QueueNamespace()
         self._logger = logging.getLogger(names.logger("backends", type(self).__name__))
+
+    def set_transport_observability_runtime(self, runtime: "QueueObservabilityRuntimeProtocol | None") -> "None":
+        """Attach the package runtime used for backend-owned transport metrics."""
+        self._transport_observability_runtime = runtime
+
+    def _transport_metric_attributes(self) -> "dict[str, str]":
+        from litestar_queues.config import queue_backend_name
+
+        backend = queue_backend_name(self.config.queue_backend) if self.config is not None else "custom"
+        return {"queue.backend": backend, "queue.transport": self.capabilities.wakeup_backend or "polling"}
+
+    def _record_enqueue_batch(self, size: "int") -> "None":
+        runtime = self._transport_observability_runtime
+        if runtime is None:
+            return
+        attributes = self._transport_metric_attributes()
+        runtime.record_histogram(
+            "litestar_queues.enqueue.batch.size",
+            size,
+            unit="records",
+            attributes={"queue.backend": attributes["queue.backend"], "queue.operation": "enqueue_many"},
+        )
+
+    def _record_wakeup_emitted(self) -> "None":
+        runtime = self._transport_observability_runtime
+        if runtime is None or not self.capabilities.supports_worker_wakeups:
+            return
+        runtime.record_counter("litestar_queues.wakeup.emitted", attributes=self._transport_metric_attributes())
+
+    def _record_wakeup_coalesced(self, count: "int") -> "None":
+        runtime = self._transport_observability_runtime
+        if runtime is None or count <= 0 or not self.capabilities.supports_worker_wakeups:
+            return
+        runtime.record_counter(
+            "litestar_queues.wakeup.coalesced", count, attributes=self._transport_metric_attributes()
+        )
 
     @property
     def capabilities(self) -> "QueueBackendCapabilities":
@@ -116,6 +154,7 @@ class BaseQueueBackend:
             for request in requests
         ]
         await self.notify_new_tasks(records)
+        self._record_enqueue_batch(len(requests))
         return records
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -525,6 +564,7 @@ class BaseQueueBackend:
         due = tuple(record for record in records if record.status in {"pending", "scheduled"} and record.is_due)
         if due:
             await self.notify_new_task(due[0])
+            self._record_wakeup_coalesced(len(due) - 1)
 
     async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
         """Wait until backend notification arrives.

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from typing_extensions import Self
 
+from litestar_queues.config import queue_backend_name
 from litestar_queues.models import (
     HeartbeatTouchResult,
     QueueBackendCapabilities,
@@ -43,13 +44,11 @@ class BaseQueueBackend:
         names = config.names if config is not None else QueueNamespace()
         self._logger = logging.getLogger(names.logger("backends", type(self).__name__))
 
-    def set_transport_observability_runtime(self, runtime: "QueueObservabilityRuntimeProtocol | None") -> "None":
+    def _set_transport_observability_runtime(self, runtime: "QueueObservabilityRuntimeProtocol | None") -> "None":
         """Attach the package runtime used for backend-owned transport metrics."""
         self._transport_observability_runtime = runtime
 
     def _transport_metric_attributes(self) -> "dict[str, str]":
-        from litestar_queues.config import queue_backend_name
-
         backend = queue_backend_name(self.config.queue_backend) if self.config is not None else "custom"
         return {"queue.backend": backend, "queue.transport": self.capabilities.wakeup_backend or "polling"}
 

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -345,6 +345,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
 
         records = await self._transaction(operation)
         await self.notify_new_tasks(records)
+        self._record_enqueue_batch(len(requests))
         return records
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -1035,6 +1036,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
         """Signal same-instance waiters that due work exists."""
         if record.status in _ACTIVE_STATUSES and record.is_due:
             self._notification_event.set()
+            self._record_wakeup_emitted()
 
     async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
         """Wait for due work using bounded SQLite existence polling.

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -165,6 +165,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
                 records.append(record)
 
         await self.notify_new_tasks(records)
+        self._record_enqueue_batch(len(requests))
         return records
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -637,6 +638,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
     async def notify_new_task(self, record: "QueuedTaskRecord") -> "None":
         if record.status in {"pending", "scheduled"} and record.is_due:
             self._notification_event.set()
+            self._record_wakeup_emitted()
 
     async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
         if not self._pending_read.has_pending and self._notification_event.is_set():

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -862,6 +862,7 @@ class RedisQueueBackend(BaseQueueBackend):
         if unkeyed_records:
             await self._save_new_records(unkeyed_records, publish=False)
         await self.notify_new_tasks(results)
+        self._record_enqueue_batch(len(requests))
         return results
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -1603,6 +1604,7 @@ class RedisQueueBackend(BaseQueueBackend):
             payload = _json_dumps({"event": "task_available"})
             client = await self._get_client()
             await client.publish(self._wakeup_channel, payload)
+            self._record_wakeup_emitted()
 
     async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
         """Wait for a Redis-protocol pub/sub message when notifications are enabled.

--- a/src/litestar_queues/backends/sqlspec/_typing.py
+++ b/src/litestar_queues/backends/sqlspec/_typing.py
@@ -10,9 +10,6 @@ if TYPE_CHECKING:
     from sqlspec.adapters.sqlite import SqliteConfig
 
 
-DatetimeParam: TypeAlias = datetime | str
-
-
 class SQLSpecConfig(Protocol):
     """Structural subset used from SQLSpec adapter configs."""
 
@@ -80,3 +77,6 @@ if TYPE_CHECKING:
     _async_config_contract: SQLSpecConfig = AsyncpgConfig()
     _sync_session_contract: SQLSpecSessionConfig = SqliteConfig()
     _async_session_contract: SQLSpecSessionConfig = AsyncpgConfig()
+
+
+DatetimeParam: TypeAlias = datetime | str

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -465,6 +465,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
         self._increment_queue_metric("enqueue", float(len(to_insert)))
         await self.notify_new_tasks(to_insert)
+        self._record_enqueue_batch(len(requests))
         return results
 
     async def get_task(self, task_id: "UUID") -> "QueuedTaskRecord | None":
@@ -1576,6 +1577,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                     {"event_type": "litestar_queues.task_available"},
                 )
             self._increment_queue_metric("notify")
+            self._record_wakeup_emitted()
 
     async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
         """Wait for a SQLSpec event when queue notifications are configured.

--- a/src/litestar_queues/events/publisher.py
+++ b/src/litestar_queues/events/publisher.py
@@ -1,6 +1,7 @@
 """Queue event publisher."""
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from litestar_queues.events.models import QueueEvent
+    from litestar_queues.observability import QueueObservabilityRuntimeProtocol
 
 __all__ = ("EventBufferConfig", "QueueEventPublisher")
 
@@ -85,7 +87,9 @@ class QueueEventPublisher:
         "_live_failure_signature",
         "_logger",
         "_namespace",
+        "_observability_runtime",
         "_sink",
+        "_transport",
         "publish_global_lifecycle",
         "publish_queue_channel",
         "publish_task_channel",
@@ -104,19 +108,23 @@ class QueueEventPublisher:
         publish_queue_channel: "bool" = True,
         publish_global_lifecycle: "bool" = False,
         namespace: "QueueNamespace | str | None" = None,
+        observability_runtime: "QueueObservabilityRuntimeProtocol | None" = None,
+        transport: "str | None" = None,
     ) -> "None":
         self._namespace = (
             namespace if isinstance(namespace, QueueNamespace) else QueueNamespace(namespace or "litestar_queues")
         )
         self._logger = logging.getLogger(self._namespace.logger("events", "publisher"))
         self._sink = sink or NoopQueueEventSink()
+        self._observability_runtime = observability_runtime
+        self._transport = transport or _event_transport(self._sink)
         self._event_log = event_log
         self._event_log_strict = event_log_strict
         self._buffer = (
             LiveEventBuffer(
                 buffer_config,
                 sink_publish=self._deliver_live_many,
-                record_drop=_ignore_buffer_drop,
+                record_drop=self._record_buffer_drop,
                 runtime_logger=self._logger,
             )
             if buffer_config is not None
@@ -137,6 +145,10 @@ class QueueEventPublisher:
         """Attach backend-owned durable event history to this publisher."""
         self._event_log = event_log
         self._event_log_strict = strict
+
+    def set_observability_runtime(self, runtime: "QueueObservabilityRuntimeProtocol") -> "None":
+        """Attach the service-owned runtime used for live delivery metrics."""
+        self._observability_runtime = runtime
 
     async def publish(
         self, event: "QueueEvent", *, channels: "Sequence[str] | None" = None, immediate: "bool" = False
@@ -197,17 +209,38 @@ class QueueEventPublisher:
             )
 
     async def _deliver_live_many(self, batch: "Sequence[tuple[QueueEvent, Sequence[str]]]") -> "None":
+        started_at = time.perf_counter()
+        outcome = "success"
         try:
             if isinstance(self._sink, _QueueEventBatchSink):
                 await self._sink.publish_many(batch)
             else:
                 await default_publish_many(self._sink, batch)
         except Exception as exc:
+            outcome = "failed"
             if self.strict:
                 raise
             self._log_batch_delivery_failure(exc, len(batch))
+        else:
+            self._live_failure_signature = None
+        finally:
+            self._record_live_batch(len(batch), time.perf_counter() - started_at, outcome=outcome)
+
+    def _record_buffer_drop(self, _scope: "str") -> "None":
+        runtime = self._observability_runtime
+        if runtime is not None:
+            runtime.record_counter(
+                "litestar_queues.event.dropped",
+                attributes={"queue.transport": self._transport, "queue.outcome": "overflow"},
+            )
+
+    def _record_live_batch(self, size: "int", seconds: "float", *, outcome: "str") -> "None":
+        runtime = self._observability_runtime
+        if runtime is None:
             return
-        self._live_failure_signature = None
+        attributes = {"queue.transport": self._transport, "queue.outcome": outcome}
+        runtime.record_histogram("litestar_queues.event.flush.size", size, unit="events", attributes=attributes)
+        runtime.record_duration("litestar_queues.event.flush.duration", seconds, attributes=attributes)
 
     def _log_batch_delivery_failure(self, exc: "BaseException", count: "int") -> "None":
         # Warn-once dampener: the first failure logs at WARNING with a traceback; consecutive
@@ -268,5 +301,10 @@ def _dedupe(channels: "Sequence[str]") -> "tuple[str, ...]":
     return tuple(resolved)
 
 
-def _ignore_buffer_drop(_scope: "str") -> "None":
-    return None
+def _event_transport(sink: "QueueEventSink") -> "str":
+    return {
+        "ChannelsQueueEventSink": "channels",
+        "CompositeQueueEventSink": "composite",
+        "InMemoryQueueEventSink": "memory",
+        "NoopQueueEventSink": "none",
+    }.get(type(sink).__name__, "custom")

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -172,7 +172,9 @@ class QueueService:
 
     def _configure_backend_observability(self, backend: "BaseQueueBackend") -> "None":
         runtime = self._observability_runtime
-        backend.set_transport_observability_runtime(runtime if runtime is not None and runtime.enabled else None)
+        backend._set_transport_observability_runtime(  # noqa: SLF001
+            runtime if runtime is not None and runtime.enabled else None
+        )
         configure = getattr(backend, "_set_package_observability_enabled", None)
         if configure is not None:
             configure(bool(runtime is not None and runtime.enabled))

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -14,7 +14,7 @@ from typing_extensions import Self
 
 from litestar_queues._correlation import bind_correlation_id, capture_correlation_id, reset_correlation_id
 from litestar_queues._identity import IDENTITY_VERSION, arguments_identity, task_identity
-from litestar_queues.config import execution_backend_name
+from litestar_queues.config import execution_backend_name, queue_backend_name
 from litestar_queues.events.context import TaskExecutionContext, _bind_task_context, _reset_task_context
 from litestar_queues.events.models import QueueEvent
 from litestar_queues.events.producer import QueueEventProducer
@@ -172,6 +172,7 @@ class QueueService:
 
     def _configure_backend_observability(self, backend: "BaseQueueBackend") -> "None":
         runtime = self._observability_runtime
+        backend.set_transport_observability_runtime(runtime if runtime is not None and runtime.enabled else None)
         configure = getattr(backend, "_set_package_observability_enabled", None)
         if configure is not None:
             configure(bool(runtime is not None and runtime.enabled))
@@ -189,6 +190,7 @@ class QueueService:
         """Return the configured event publisher."""
         if self._event_publisher is None:
             self._event_publisher = self._config.get_event_publisher()
+        self._event_publisher.set_observability_runtime(self.observability_runtime)
         return self._event_publisher
 
     def get_event_producer(self) -> "QueueEventProducer":
@@ -888,6 +890,15 @@ class QueueService:
         """
         claimed, expired = await self.get_queue_backend().claim_many_with_expired(
             limit=limit, queues=queues, execution_backend=execution_backend
+        )
+        self.observability_runtime.record_histogram(
+            "litestar_queues.claim.batch.size",
+            len(claimed),
+            unit="records",
+            attributes={
+                "queue.backend": queue_backend_name(self._config.queue_backend),
+                "queue.operation": "claim_many",
+            },
         )
         for record in expired:
             await self._publish_expired_event(record, worker_id=worker_id)

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -7,7 +7,7 @@ import time
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from litestar_queues.config import WorkerConfig, execution_backend_name
+from litestar_queues.config import WorkerConfig, execution_backend_name, queue_backend_name
 from litestar_queues.events.context import _bind_beat_sink, _reset_beat_sink
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.worker.heartbeat import WorkerHeartbeatManager
@@ -76,6 +76,7 @@ class Worker:
         "_last_expiry_check_at",
         "_last_reconcile_at",
         "_last_stale_check_at",
+        "_listener_reconnect_pending",
         "_logger",
         "_max_concurrency",
         "_poll_backoff_max",
@@ -92,6 +93,7 @@ class Worker:
         "_startup_completion",
         "_startup_error",
         "_stop_event",
+        "_wakeup_started_at",
         "_worker_id",
     )
 
@@ -138,6 +140,8 @@ class Worker:
         self._last_reconcile_at = -float("inf")
         self._last_expiry_check_at = -float("inf")
         self._last_stale_check_at = -float("inf")
+        self._listener_reconnect_pending = False
+        self._wakeup_started_at: "float | None" = None
 
     @property
     def is_running(self) -> "bool":
@@ -317,10 +321,14 @@ class Worker:
             return 0
         if execution_backend.is_external:
             records = await self._list_pending(limit=available)
-            return await self._dispatch_external(records)
+            dispatched = await self._dispatch_external(records)
+            if not dispatched:
+                self._record_empty_poll()
+            return dispatched
 
         claimed_records = await self._claim_available(limit=available)
         if not claimed_records:
+            self._record_empty_poll()
             return 0
 
         self._record_claimed(claimed_records)
@@ -330,9 +338,18 @@ class Worker:
 
     async def _claim_available(self, *, limit: "int") -> "list[QueuedTaskRecord]":
         execution_backend_name_ = execution_backend_name(self._service.config.execution_backend)
-        return await self._service.claim_tasks(
+        claimed = await self._service.claim_tasks(
             limit=limit, queues=self._queues, execution_backend=execution_backend_name_, worker_id=self._worker_id
         )
+        wakeup_started_at = self._wakeup_started_at
+        self._wakeup_started_at = None
+        if claimed and wakeup_started_at is not None:
+            self._service.observability_runtime.record_duration(
+                "litestar_queues.worker.wakeup_to_claim.duration",
+                time.perf_counter() - wakeup_started_at,
+                attributes=self._transport_metric_attributes(),
+            )
+        return claimed
 
     async def _list_pending(self, *, limit: "int") -> "list[QueuedTaskRecord]":
         queue_backend = self._service.get_queue_backend()
@@ -507,6 +524,15 @@ class Worker:
         queue_backend = self._service.get_queue_backend()
         started_at = time.perf_counter()
         timeout = await self._current_wait_timeout()
+        wait_attributes = {"queue.backend": self._queue_backend_name(), "worker.wait.kind": self._wait_kind()}
+        self._service.observability_runtime.record_histogram(
+            "litestar_queues.worker.poll.delay", timeout, unit="s", attributes=wait_attributes
+        )
+        if self._listener_reconnect_pending:
+            self._service.observability_runtime.record_counter(
+                "litestar_queues.listener.reconnect", attributes=self._transport_metric_attributes()
+            )
+            self._listener_reconnect_pending = False
         notification_task = asyncio.create_task(queue_backend.wait_for_wakeups(timeout=timeout))
         stop_task = asyncio.create_task(self._stop_event.wait())
         completion_task = asyncio.create_task(self._completion_event.wait())
@@ -521,9 +547,15 @@ class Worker:
         outcome: "bool | None" = None
         if notification_task in done:
             outcome = await self._consume_wait_task(notification_task)
+            if outcome:
+                self._wakeup_started_at = time.perf_counter()
+        elapsed = time.perf_counter() - started_at
+        self._service.observability_runtime.record_duration(
+            "litestar_queues.worker.wait.duration", elapsed, attributes=wait_attributes
+        )
         self._service.observability_runtime.record_duration(
             "litestar_queues.worker.idle.duration",
-            time.perf_counter() - started_at,
+            elapsed,
             attributes={**self._worker_metric_base_attributes(), "worker.wakeup": str(notification_task in done)},
         )
         return outcome
@@ -541,6 +573,11 @@ class Worker:
             # the listener from a clean state. The backoff resets so a stale
             # listener does not compound into a longer discovery delay.
             self._record_counter("litestar_queues.worker.loop.error", {"worker.error.type": type(exc).__name__})
+            self._service.observability_runtime.record_counter(
+                "litestar_queues.listener.error",
+                attributes={**self._transport_metric_attributes(), "queue.outcome": "read_failed"},
+            )
+            self._listener_reconnect_pending = True
             self._logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
             self._reset_poll_backoff()
             await self._backoff_after_loop_error()
@@ -571,6 +608,24 @@ class Worker:
             counts[record.queue] = counts.get(record.queue, 0) + 1
         for queue, count in counts.items():
             self._record_counter("litestar_queues.worker.claim", {"messaging.destination.name": queue}, value=count)
+
+    def _record_empty_poll(self) -> "None":
+        self._service.observability_runtime.record_counter(
+            "litestar_queues.worker.poll.empty", attributes={"queue.backend": self._queue_backend_name()}
+        )
+
+    def _queue_backend_name(self) -> "str":
+        return queue_backend_name(self._service.config.queue_backend)
+
+    def _transport_metric_attributes(self) -> "dict[str, str]":
+        capabilities = self._service.get_queue_backend().capabilities
+        return {
+            "queue.backend": self._queue_backend_name(),
+            "queue.transport": capabilities.wakeup_backend or "polling",
+        }
+
+    def _wait_kind(self) -> "str":
+        return "native" if self._service.get_queue_backend().capabilities.supports_worker_wakeups else "polling"
 
     def _record_counter(self, name: "str", attributes: "dict[str, str]", *, value: "int" = 1) -> "None":
         self._service.observability_runtime.record_counter(

--- a/src/tests/unit/test_observability.py
+++ b/src/tests/unit/test_observability.py
@@ -62,6 +62,7 @@ async def test_enqueue_uses_observability_runtime_for_producer_span_and_context(
     assert result.record is not None
     assert result.record.metadata["_otel_context"] == {"traceparent": "00-test"}
     assert runtime.counters == [
+        ("litestar_queues.wakeup.emitted", 1, {"queue.backend": "memory", "queue.transport": "asyncio-event"}),
         (
             "litestar_queues.enqueue",
             1,
@@ -71,7 +72,7 @@ async def test_enqueue_uses_observability_runtime_for_producer_span_and_context(
                 "queue.execution.backend": "local",
                 "queue.execution.profile": "heavy",
             },
-        )
+        ),
     ]
     assert runtime.durations[0][0] == "litestar_queues.enqueue.duration"
 

--- a/src/tests/unit/test_transport_observability.py
+++ b/src/tests/unit/test_transport_observability.py
@@ -1,0 +1,239 @@
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from litestar_queues import QueueConfig, QueueService, TaskRequest, Worker, WorkerConfig
+from litestar_queues.backends import InMemoryQueueBackend
+from litestar_queues.events import EventBufferConfig, QueueEvent, QueueEventPublisher
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+pytestmark = pytest.mark.anyio
+
+
+class _RecordingRuntime:
+    enabled = True
+    sqlcommenter_enabled = False
+
+    def __init__(self) -> "None":
+        self.counters: "list[tuple[str, int, dict[str, str]]]" = []
+        self.durations: "list[tuple[str, float, dict[str, str]]]" = []
+        self.histograms: "list[tuple[str, float, str, dict[str, str]]]" = []
+
+    def start_span(
+        self, name: "str", *, kind: "str", attributes: "Mapping[str, object]", parent: "object | None" = None
+    ) -> "None":
+        del name, kind, attributes, parent
+
+    def end_span(self, span: "Any | None") -> "None":
+        del span
+
+    def record_exception(self, span: "Any | None", exc: "BaseException") -> "None":
+        del span, exc
+
+    def set_status_error(self, span: "Any | None", description: "str") -> "None":
+        del span, description
+
+    def set_attribute(self, span: "Any | None", key: "str", value: "object") -> "None":
+        del span, key, value
+
+    def inject_trace_context(self, metadata: "dict[str, Any]") -> "None":
+        del metadata
+
+    def extract_trace_context(self, metadata: "Mapping[str, Any]") -> "None":
+        del metadata
+
+    def record_counter(self, name: "str", value: "int" = 1, *, attributes: "Mapping[str, str]") -> "None":
+        self.counters.append((name, value, dict(attributes)))
+
+    def record_gauge_delta(self, name: "str", delta: "int" = 1, *, attributes: "Mapping[str, str]") -> "None":
+        del name, delta, attributes
+
+    def record_duration(self, name: "str", seconds: "float", *, attributes: "Mapping[str, str]") -> "None":
+        self.durations.append((name, seconds, dict(attributes)))
+
+    def record_histogram(self, name: "str", value: "float", *, unit: "str", attributes: "Mapping[str, str]") -> "None":
+        self.histograms.append((name, value, unit, dict(attributes)))
+
+
+class _BatchSink:
+    def __init__(self, *, fail: "bool" = False) -> "None":
+        self.fail = fail
+        self.batches: "list[tuple[tuple[QueueEvent, tuple[str, ...]], ...]]" = []
+
+    async def publish(self, event: "QueueEvent", *, channels: "Sequence[str]") -> "None":
+        self.batches.append(((event, tuple(channels)),))
+
+    async def publish_many(self, batch: "Sequence[tuple[QueueEvent, Sequence[str]]]") -> "None":
+        if self.fail:
+            msg = "sink unavailable"
+            raise RuntimeError(msg)
+        self.batches.append(tuple((event, tuple(channels)) for event, channels in batch))
+
+
+class _FailingWaitBackend(InMemoryQueueBackend):
+    __slots__ = ("wait_calls",)
+
+    def __init__(self, config: "QueueConfig") -> "None":
+        super().__init__(config)
+        self.wait_calls = 0
+
+    async def wait_for_wakeups(self, timeout: "float | None" = None) -> "bool":
+        self.wait_calls += 1
+        if self.wait_calls == 1:
+            msg = "listener disconnected"
+            raise RuntimeError(msg)
+        await asyncio.sleep(timeout or 0)
+        return False
+
+
+def _config() -> "QueueConfig":
+    return QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local")
+
+
+async def test_batch_enqueue_records_size_and_coalesced_wakeup() -> "None":
+    config = _config()
+    runtime = _RecordingRuntime()
+    backend = InMemoryQueueBackend(config)
+    async with QueueService(config, queue_backend=backend, observability_runtime=runtime):
+        await backend.enqueue_many([TaskRequest(f"tasks.batch.{index}") for index in range(3)])
+
+    assert (
+        "litestar_queues.enqueue.batch.size",
+        3,
+        "records",
+        {"queue.backend": "memory", "queue.operation": "enqueue_many"},
+    ) in runtime.histograms
+    assert (
+        "litestar_queues.wakeup.emitted",
+        1,
+        {"queue.backend": "memory", "queue.transport": "asyncio-event"},
+    ) in runtime.counters
+    assert (
+        "litestar_queues.wakeup.coalesced",
+        2,
+        {"queue.backend": "memory", "queue.transport": "asyncio-event"},
+    ) in runtime.counters
+
+
+async def test_claim_batch_records_actual_short_batch_size() -> "None":
+    config = _config()
+    runtime = _RecordingRuntime()
+    backend = InMemoryQueueBackend(config)
+    async with QueueService(config, queue_backend=backend, observability_runtime=runtime) as service:
+        await backend.enqueue_many([TaskRequest("tasks.claim.one"), TaskRequest("tasks.claim.two")])
+        runtime.histograms.clear()
+
+        claimed = await service.claim_tasks(limit=5)
+
+    assert len(claimed) == 2
+    assert runtime.histograms == [
+        ("litestar_queues.claim.batch.size", 2, "records", {"queue.backend": "memory", "queue.operation": "claim_many"})
+    ]
+
+
+async def test_worker_records_empty_poll_wait_and_wakeup_to_claim() -> "None":
+    config = _config()
+    runtime = _RecordingRuntime()
+    backend = InMemoryQueueBackend(config)
+    async with QueueService(config, queue_backend=backend, observability_runtime=runtime) as service:
+        worker = Worker(service, WorkerConfig(poll_interval=0.001, poll_backoff_max=None))
+
+        assert await worker.run_once() == 0
+        assert await worker._wait_for_work() is False
+
+        await backend.enqueue("tasks.woken")
+        assert await worker._wait_for_work() is True
+        assert len(await worker._claim_available(limit=1)) == 1
+
+    assert ("litestar_queues.worker.poll.empty", 1, {"queue.backend": "memory"}) in runtime.counters
+    assert any(
+        sample[0] == "litestar_queues.worker.poll.delay"
+        and sample[2:] == ("s", {"queue.backend": "memory", "worker.wait.kind": "native"})
+        for sample in runtime.histograms
+    )
+    assert any(
+        sample[0] == "litestar_queues.worker.wait.duration"
+        and sample[2] == {"queue.backend": "memory", "worker.wait.kind": "native"}
+        for sample in runtime.durations
+    )
+    assert any(
+        sample[0] == "litestar_queues.worker.wakeup_to_claim.duration"
+        and sample[2] == {"queue.backend": "memory", "queue.transport": "asyncio-event"}
+        for sample in runtime.durations
+    )
+
+
+async def test_listener_failure_and_reconnect_emit_bounded_metrics() -> "None":
+    config = _config()
+    runtime = _RecordingRuntime()
+    backend = _FailingWaitBackend(config)
+    async with QueueService(config, queue_backend=backend, observability_runtime=runtime) as service:
+        worker = Worker(service, WorkerConfig(poll_interval=0.001, poll_backoff_max=None))
+
+        assert await worker._wait_for_work() is None
+        assert await worker._wait_for_work() is False
+
+    assert (
+        "litestar_queues.listener.error",
+        1,
+        {"queue.backend": "memory", "queue.transport": "asyncio-event", "queue.outcome": "read_failed"},
+    ) in runtime.counters
+    assert (
+        "litestar_queues.listener.reconnect",
+        1,
+        {"queue.backend": "memory", "queue.transport": "asyncio-event"},
+    ) in runtime.counters
+
+
+async def test_event_buffer_records_successful_flush_and_overflow_drop() -> "None":
+    runtime = _RecordingRuntime()
+    sink = _BatchSink()
+    publisher = QueueEventPublisher(
+        sink,
+        buffer_config=EventBufferConfig(batch_size=10, max_pending=2, overflow="drop_newest"),
+        observability_runtime=runtime,
+        transport="custom",
+    )
+
+    await publisher.publish(QueueEvent(type="one", scope="task", task_id="task-a"))
+    await publisher.publish(QueueEvent(type="two", scope="task", task_id="task-b"))
+    await publisher.publish(QueueEvent(type="three", scope="task", task_id="task-c"))
+    await publisher.flush_buffer()
+
+    assert (
+        "litestar_queues.event.dropped",
+        1,
+        {"queue.transport": "custom", "queue.outcome": "overflow"},
+    ) in runtime.counters
+    assert (
+        "litestar_queues.event.flush.size",
+        2,
+        "events",
+        {"queue.transport": "custom", "queue.outcome": "success"},
+    ) in runtime.histograms
+    assert any(
+        sample[0] == "litestar_queues.event.flush.duration"
+        and sample[2] == {"queue.transport": "custom", "queue.outcome": "success"}
+        for sample in runtime.durations
+    )
+
+
+async def test_event_buffer_records_failed_flush_once() -> "None":
+    runtime = _RecordingRuntime()
+    publisher = QueueEventPublisher(
+        _BatchSink(fail=True),
+        buffer_config=EventBufferConfig(batch_size=10),
+        observability_runtime=runtime,
+        transport="custom",
+    )
+    await publisher.publish(QueueEvent(type="one", scope="task", task_id="task-a"))
+
+    await publisher.flush_buffer()
+
+    assert runtime.histograms == [
+        ("litestar_queues.event.flush.size", 1, "events", {"queue.transport": "custom", "queue.outcome": "failed"})
+    ]
+    assert len([sample for sample in runtime.durations if sample[0] == "litestar_queues.event.flush.duration"]) == 1

--- a/src/tests/unit/tools/__init__.py
+++ b/src/tests/unit/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for developer tools."""

--- a/src/tests/unit/tools/test_queue_transport_benchmark.py
+++ b/src/tests/unit/tools/test_queue_transport_benchmark.py
@@ -1,0 +1,78 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[4]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from tools.benchmark_queue_transports import (  # noqa: E402
+    SCHEMA_VERSION,
+    benchmark_claim_batches,
+    benchmark_event_batches,
+    benchmark_idle_polling,
+    benchmark_native_notifications,
+    build_report,
+)
+
+
+def _variants(results: "list[dict[str, Any]]", scenario: "str") -> "dict[str, dict[str, Any]]":
+    return {str(result["variant"]): result for result in results if result["scenario"] == scenario}
+
+
+def test_idle_polling_counts_fixed_and_adaptive_backend_calls() -> "None":
+    results = _variants(benchmark_idle_polling(duration=10.0, interval=1.0, maximum_interval=4.0), "idle_polling")
+
+    assert results["fixed"]["operation_counts"] == {"backend_calls": 10}
+    assert results["adaptive"]["operation_counts"] == {"backend_calls": 4}
+
+
+def test_native_notifications_count_reconciliation_calls_and_latency() -> "None":
+    [result] = benchmark_native_notifications(task_count=100, reconcile_every=25)
+
+    assert result["operation_counts"] == {"claim_calls": 100, "notification_calls": 100, "reconciliation_calls": 4}
+    assert result["p50_seconds"] is not None
+    assert result["p95_seconds"] is not None
+    assert result["p99_seconds"] is not None
+
+
+def test_native_claim_and_event_batches_reduce_controlled_operations() -> "None":
+    claim_results = _variants(benchmark_claim_batches(task_count=100, batch_size=16), "claim_batching")
+    event_results = _variants(benchmark_event_batches(event_count=100, batch_size=16), "event_batching")
+
+    assert claim_results["sequential"]["operation_counts"] == {"backend_operations": 100}
+    assert claim_results["native_batch"]["operation_counts"] == {"backend_operations": 7}
+    assert event_results["sequential"]["operation_counts"] == {"flushes": 100, "transport_calls": 100}
+    assert event_results["publish_many"]["operation_counts"] == {"flushes": 7, "transport_calls": 7}
+    assert event_results["publish_many"]["parameters"]["maximum_flush_size"] == 16
+
+
+def test_report_schema_is_versioned_and_json_serializable(tmp_path: "Path") -> "None":
+    report = build_report(task_count=32, batch_size=8, idle_duration=4.0)
+    output = tmp_path / "transport-benchmark.json"
+    output.write_text(json.dumps(report), encoding="utf-8")
+    restored = json.loads(output.read_text(encoding="utf-8"))
+
+    assert restored["schema_version"] == SCHEMA_VERSION
+    assert set(restored["environment"]) >= {"cpu_count", "git_dirty", "git_sha", "implementation", "platform", "python"}
+    assert {result["scenario"] for result in restored["results"]} == {
+        "claim_batching",
+        "event_batching",
+        "idle_polling",
+        "native_notification",
+    }
+    for result in restored["results"]:
+        assert set(result) == {
+            "backend",
+            "count",
+            "duration_seconds",
+            "operation_counts",
+            "p50_seconds",
+            "p95_seconds",
+            "p99_seconds",
+            "parameters",
+            "scenario",
+            "throughput_per_second",
+            "variant",
+        }

--- a/tools/benchmark_queue_transports.py
+++ b/tools/benchmark_queue_transports.py
@@ -1,0 +1,233 @@
+"""Run controlled microbenchmarks for queue transport control paths.
+
+The harness uses deterministic fake operations. It measures relative control
+path costs and operation counts without starting workers or external services;
+``tools/benchmark_queues.py`` owns end-to-end backend benchmarks.
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from tools.queue_bench.environment import capture_environment  # noqa: E402
+
+SCHEMA_VERSION = "1.0"
+
+
+class _OperationCounter:
+    __slots__ = ("counts",)
+
+    def __init__(self) -> "None":
+        self.counts: "dict[str, int]" = {}
+
+    def call(self, operation: "str", count: "int" = 1) -> "None":
+        self.counts[operation] = self.counts.get(operation, 0) + count
+
+
+def _percentile(samples: "list[float]", percentile: "float") -> "float | None":
+    if not samples:
+        return None
+    ordered = sorted(samples)
+    rank = (len(ordered) - 1) * percentile / 100
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (rank - lower)
+
+
+def _result(
+    *,
+    scenario: "str",
+    variant: "str",
+    parameters: "dict[str, Any]",
+    count: "int",
+    duration: "float",
+    operations: "dict[str, int]",
+    latencies: "list[float] | None" = None,
+) -> "dict[str, Any]":
+    samples = latencies or []
+    return {
+        "scenario": scenario,
+        "backend": "controlled-fake",
+        "variant": variant,
+        "parameters": parameters,
+        "count": count,
+        "duration_seconds": duration,
+        "throughput_per_second": count / duration if duration > 0 else None,
+        "p50_seconds": _percentile(samples, 50),
+        "p95_seconds": _percentile(samples, 95),
+        "p99_seconds": _percentile(samples, 99),
+        "operation_counts": operations,
+    }
+
+
+def benchmark_idle_polling(
+    *, duration: "float", interval: "float" = 1.0, maximum_interval: "float" = 4.0
+) -> "list[dict[str, Any]]":
+    """Compare fixed and exponentially backed-off polling over simulated time."""
+    results: "list[dict[str, Any]]" = []
+    for variant in ("fixed", "adaptive"):
+        counter = _OperationCounter()
+        elapsed = 0.0
+        delay = interval
+        while elapsed < duration:
+            counter.call("backend_calls")
+            elapsed += delay
+            if variant == "adaptive":
+                delay = min(delay * 2, maximum_interval)
+        results.append(
+            _result(
+                scenario="idle_polling",
+                variant=variant,
+                parameters={
+                    "simulated_duration_seconds": duration,
+                    "initial_interval_seconds": interval,
+                    "maximum_interval_seconds": maximum_interval,
+                },
+                count=counter.counts["backend_calls"],
+                duration=duration,
+                operations=counter.counts,
+            )
+        )
+    return results
+
+
+def benchmark_native_notifications(*, task_count: "int", reconcile_every: "int") -> "list[dict[str, Any]]":
+    """Measure controlled notification-to-claim latency and reconciliation calls."""
+    counter = _OperationCounter()
+    latencies: "list[float]" = []
+    started = time.perf_counter()
+    for index in range(task_count):
+        notification_started = time.perf_counter()
+        counter.call("notification_calls")
+        counter.call("claim_calls")
+        latencies.append(time.perf_counter() - notification_started)
+        if (index + 1) % reconcile_every == 0 or index + 1 == task_count:
+            counter.call("reconciliation_calls")
+    duration = time.perf_counter() - started
+    return [
+        _result(
+            scenario="native_notification",
+            variant="native",
+            parameters={"task_count": task_count, "reconcile_every": reconcile_every},
+            count=task_count,
+            duration=duration,
+            operations=counter.counts,
+            latencies=latencies,
+        )
+    ]
+
+
+def benchmark_claim_batches(*, task_count: "int", batch_size: "int") -> "list[dict[str, Any]]":
+    """Compare one-record claims with native batch claims."""
+    results: "list[dict[str, Any]]" = []
+    for variant, size in (("sequential", 1), ("native_batch", batch_size)):
+        counter = _OperationCounter()
+        started = time.perf_counter()
+        for _offset in range(0, task_count, size):
+            counter.call("backend_operations")
+        duration = time.perf_counter() - started
+        results.append(
+            _result(
+                scenario="claim_batching",
+                variant=variant,
+                parameters={"task_count": task_count, "batch_size": size},
+                count=task_count,
+                duration=duration,
+                operations=counter.counts,
+            )
+        )
+    return results
+
+
+def benchmark_event_batches(*, event_count: "int", batch_size: "int") -> "list[dict[str, Any]]":
+    """Compare sequential event publication with ``publish_many`` batches."""
+    results: "list[dict[str, Any]]" = []
+    for variant, size in (("sequential", 1), ("publish_many", batch_size)):
+        counter = _OperationCounter()
+        maximum_flush_size = 0
+        started = time.perf_counter()
+        for offset in range(0, event_count, size):
+            flush_size = min(size, event_count - offset)
+            maximum_flush_size = max(maximum_flush_size, flush_size)
+            counter.call("flushes")
+            counter.call("transport_calls")
+        duration = time.perf_counter() - started
+        results.append(
+            _result(
+                scenario="event_batching",
+                variant=variant,
+                parameters={"event_count": event_count, "batch_size": size, "maximum_flush_size": maximum_flush_size},
+                count=event_count,
+                duration=duration,
+                operations=counter.counts,
+            )
+        )
+    return results
+
+
+def build_report(
+    *, task_count: "int" = 1000, batch_size: "int" = 100, idle_duration: "float" = 60.0
+) -> "dict[str, Any]":
+    """Build one JSON-serializable controlled benchmark report."""
+    results = [
+        *benchmark_idle_polling(duration=idle_duration),
+        *benchmark_native_notifications(task_count=task_count, reconcile_every=batch_size),
+        *benchmark_claim_batches(task_count=task_count, batch_size=batch_size),
+        *benchmark_event_batches(event_count=task_count, batch_size=batch_size),
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "environment": capture_environment(packages=["litestar-queues"], network_class="none-controlled-fake"),
+        "results": results,
+    }
+
+
+def _positive_int(value: "str") -> "int":
+    parsed = int(value)
+    if parsed <= 0:
+        message = "must be greater than zero"
+        raise argparse.ArgumentTypeError(message)
+    return parsed
+
+
+def _positive_float(value: "str") -> "float":
+    parsed = float(value)
+    if parsed <= 0:
+        message = "must be greater than zero"
+        raise argparse.ArgumentTypeError(message)
+    return parsed
+
+
+def main() -> "None":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tasks", type=_positive_int, default=1000, help="Controlled record/event count.")
+    parser.add_argument("--batch-size", type=_positive_int, default=100, help="Native operation batch size.")
+    parser.add_argument(
+        "--idle-duration", type=_positive_float, default=60.0, help="Simulated idle-poll duration in seconds."
+    )
+    parser.add_argument("--output", type=Path, help="Write JSON to this path instead of standard output.")
+    parser.add_argument("--pretty", action="store_true", help="Indent the JSON output.")
+    args = parser.parse_args()
+
+    report = build_report(task_count=args.tasks, batch_size=args.batch_size, idle_duration=args.idle_duration)
+    rendered = json.dumps(report, indent=2 if args.pretty else None, sort_keys=True)
+    if args.output is None:
+        print(rendered)
+    else:
+        args.output.write_text(f"{rendered}\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- emit bounded metrics for enqueue batches, wakeup coalescing, actual claim batches, worker polling/waits, native listener lifecycle, and event flush/drop paths
- keep one logical emitter per metric and preserve SQLSpec driver/query telemetry without duplicate queue-domain samples
- add a versioned controlled-operation benchmark for fixed/adaptive polling, native notifications, claim batches, and `publish_many`
- document the emitted transport contract and internal benchmark workflow
- include the previously identified SQLSpec typing-order fix required by the full unit gate