### PR TITLE
docs: align queue transport contracts and drift gates

### DIFF
--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -59,6 +59,75 @@ PostgreSQL batch claim. Every backend inherits a safe single-record loop when
 its storage cannot preserve bounded ordering and ownership in one batch;
 Redis and Valkey intentionally use that fallback.
 
+Worker-wakeup capability matrix
+================================
+
+This matrix is checked against the runtime's explicit SQLSpec adapter mapping,
+canonical transport set, and Advanced Alchemy driver set:
+
+.. transport-capability-matrix-start
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 18 22 10 28
+
+   * - Backend or adapter
+     - Enabling setting
+     - Effective strategy
+     - Durable wakeup
+     - Ownership
+
+   * - Memory
+     - Always
+     - asyncio-event
+     - No
+     - Process-local hint
+   * - SQLSpec: asyncpg, psycopg, psqlpy
+     - Default
+     - notify_queue
+     - Yes
+     - Durable queue plus PostgreSQL push
+   * - SQLSpec: DuckDB
+     - Default
+     - poll_queue
+     - Yes
+     - Durable embedded queue
+   * - SQLSpec: other adapters
+     - Default
+     - Polling
+     - N/A
+     - Durable task-state polling
+   * - SQLSpec: Oracle
+     - Explicit only
+     - aq or txeventq
+     - Yes
+     - Application-provisioned Oracle queue
+   * - Advanced Alchemy: asyncpg, psycopg
+     - worker_wakeups=True
+     - postgres-listen-notify
+     - No
+     - Transient marker
+   * - Advanced Alchemy: other drivers
+     - Any
+     - Polling
+     - N/A
+     - Durable task-state polling
+   * - Redis
+     - Default
+     - Redis pub/sub
+     - No
+     - Transient marker
+   * - Valkey
+     - Default
+     - Valkey pub/sub
+     - No
+     - Transient marker
+
+.. transport-capability-matrix-end
+
+``Durable wakeup`` describes the notification transport, not the queue record.
+Queue records remain authoritative in every row.
+
 Install extras
 ==============
 

--- a/docs/usage/backends.rst
+++ b/docs/usage/backends.rst
@@ -52,6 +52,13 @@ The queue backend stores task records. ``local`` runs work in a worker process.
 does not store the queue. Backend notifications wake workers, but they do not
 send task events to browsers.
 
+Batch claims are also a persistence capability, not an execution-placement
+choice. Memory claims a batch under its process-local lock. SQLSpec uses a
+single returning claim on capable stores, and Advanced Alchemy uses a native
+PostgreSQL batch claim. Every backend inherits a safe single-record loop when
+its storage cannot preserve bounded ordering and ownership in one batch;
+Redis and Valkey intentionally use that fallback.
+
 Install extras
 ==============
 

--- a/docs/usage/backends/advanced-alchemy.rst
+++ b/docs/usage/backends/advanced-alchemy.rst
@@ -90,10 +90,16 @@ database lifecycle as the queue model.
 Wakeups and heartbeats
 ======================
 
-``worker_wakeups=True`` enables direct PostgreSQL wakeup hints when the dialect
-supports them. The task table remains the source of truth, so workers keep
-polling. ``heartbeat_session_maker`` may use a separate session for heartbeat
-writes. The application owns and closes its engine.
+``worker_wakeups=True`` enables transient PostgreSQL ``LISTEN``/``NOTIFY``
+hints for both ``postgresql+asyncpg`` and ``postgresql+psycopg``. The marker has
+no task payload and is not durable: it only asks the worker to reconcile the
+task table. SQLite, MySQL, and Oracle remain polling-only; Advanced Alchemy does
+not expose SQLSpec's Oracle AQ or TxEventQ transports.
+
+PostgreSQL also uses a native bounded batch claim. Other dialects use the safe
+single-record fallback while preserving ordering and ownership semantics.
+``heartbeat_session_maker`` may use a separate session for heartbeat writes.
+The application owns and closes its engine.
 
 This direct PostgreSQL hint is not task storage and not browser delivery. See
 :doc:`../worker-wakeups` and :doc:`../event-streams`.

--- a/docs/usage/backends/sqlspec.rst
+++ b/docs/usage/backends/sqlspec.rst
@@ -117,14 +117,26 @@ adapter capability; an adapter without a push transport continues interval
 polling.
 
 Overrides remain available under ``worker_wakeups``: ``transport`` pins a
-specific SQLSpec transport, ``channel_name`` sets the LISTEN/NOTIFY channel
-(default ``litestar_queues_tasks``), and ``poll_interval`` controls durable
-queue polling in seconds. Oracle can opt in to explicitly provisioned ``aq`` or
-``txeventq`` queues through ``transport`` and ``settings``. Oracle stays on
-polling by default because Advanced Queuing requires provisioning that the
-backend does not create.
+specific native SQLSpec transport. The canonical names are ``notify``,
+``notify_queue``, ``poll_queue``, ``aq``, and ``txeventq``. ``channel_name``
+sets the LISTEN/NOTIFY channel (default ``litestar_queues_tasks``), and
+``poll_interval`` controls durable queue polling in seconds. Oracle can opt in
+to explicitly provisioned ``aq`` or ``txeventq`` queues through ``transport``
+and ``settings``. The application or database operator owns queue creation,
+startup, privileges, payload type, and retention; Litestar Queues only opens
+the configured SQLSpec event channel. Oracle stays on interval polling by
+default because the backend does not provision Advanced Queuing.
 Durable queue transports are competing-consumer queues; do not use them as
 multi-process browser fan-out. See :doc:`../worker-wakeups`.
+
+Batch claiming
+==============
+
+SQLSpec stores that advertise a returning claim use one bounded
+``UPDATE ... RETURNING`` operation for ``claim_many``. Stores without that
+primitive inherit the backend-neutral single-record claim loop. Both paths
+preserve the same priority, filtering, ownership, and actual-short-batch
+contract; only the number of database operations differs.
 
 Heartbeat isolation
 ===================

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -99,6 +99,12 @@ and known scheduled or retry work clamps the wait to its due time. Set
 ``poll_backoff_max=None`` to retain fixed-interval polling when latency matters
 more than idle load.
 
+Validation requires ``poll_interval > 0``,
+``poll_backoff_max >= poll_interval`` when a maximum is set,
+``poll_backoff_multiplier >= 1.0``, and ``0.0 <= poll_jitter <= 1.0``. The
+stored interval resets to ``poll_interval`` on startup, claimed work, a native
+notification, and recoverable backend or listener errors.
+
 Defaults favor zero-configuration background execution: ephemeral SQLite,
 local execution, and one server-owned worker started by ``litestar run``.
 Choose persistent storage and placement explicitly for durable deployments.

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -58,21 +58,58 @@ Tasks do not need to call ``beat()`` to remain alive, and a progress update
 should not also be copied into a generic custom event. Use ``beat(detail)``
 only when a short, last-value diagnostic helps recovery or operations.
 
+The context methods make those boundaries explicit:
+
 .. code-block:: python
 
    from litestar_queues import task
-   from litestar_queues.events import publish_task_log, publish_task_progress
+   from litestar_queues.events import TaskExecutionContext
 
 
-   @task("imports.process", timeout=300)
-   async def process_import(path: str) -> None:
-       await publish_task_log("Import started", payload={"path": path})
-       await publish_task_progress(current=50, total=100, message="Halfway")
+   @task("crawl.run", timeout=300)
+   async def crawl(*, _task_context: TaskExecutionContext) -> dict[str, int]:
+       ctx = _task_context
+
+       # Standardized progress state for status pages and UI consumers.
+       await ctx.progress(
+           current=3,
+           total=6,
+           message="3/6 pages",
+           payload={"page": 3},
+       )
+
+       # An application occurrence; it does not update progress or terminal
+       # task state. False keeps ordinary events eligible for buffering.
+       await ctx.event(
+           "crawl.page_discovered",
+           message="Discovered the queue guide",
+           payload={"url": "https://example.invalid/queues"},
+           immediate=False,
+       )
+
+       # Optional last-value diagnostic for the next automatic heartbeat.
+       ctx.beat("Parsing the final page")
+       return {"pages": 6}
+
+``ctx.progress(current=..., total=..., message=..., payload=...)`` publishes
+``task.progress`` and derives a percentage when ``current`` and ``total`` are
+available. ``ctx.event(name, message=..., payload=..., immediate=False)``
+publishes the supplied application event name. A custom event does not update
+progress or terminal task state. Set ``immediate=True`` only when that event
+must bypass the ordinary live-event buffer.
+
+Automatic worker heartbeats keep active jobs live. ``ctx.beat(detail)`` is an
+optional, last-value-wins detail update for the next heartbeat write; it is not
+a liveness requirement and does not publish a task event by itself.
 
 The active task context adds the task ID, task name, queue, worker ID, attempt,
 execution backend, and sequence. Use ``publish_task_event()`` for a custom
 event type. Accept ``_task_context`` when you prefer to call the context
 methods directly.
+
+Keep payloads small and JSON-serializable. Put large files, crawled documents,
+and model artifacts in external storage and send a stable reference in the
+payload.
 
 Buffering and external producers
 ================================
@@ -89,6 +126,13 @@ failure are separate terminal paths; consumers should not infer persisted
 result data from the event payload alone. After any terminal event, refresh the
 :class:`~litestar_queues.TaskResult` when the record, result, or error is
 needed.
+
+Returning normally stores the return value and publishes ``task.completed``.
+Raising follows the task's retry policy: ``task.failed`` reports
+``will_retry=true`` when the record was requeued, and a later attempt publishes
+another ``task.started``. With no retry remaining, the record and event are
+terminally failed. Task code should not publish its own completed or failed
+lifecycle event.
 
 Code outside a worker should use this context manager:
 

--- a/docs/usage/migration.rst
+++ b/docs/usage/migration.rst
@@ -16,6 +16,19 @@ When moving from memory to a persistent backend:
 See :doc:`backends` for the current support matrix and :doc:`event-history`
 for event-history ownership.
 
+SQLSpec worker-wakeup transport names
+=====================================
+
+.. retired-sqlspec-transport-names-start
+
+Pre-release SQLSpec wakeup configuration used ``listen_notify``,
+``listen_notify_durable``, and ``table_queue``. Replace them with ``notify``,
+``notify_queue``, and ``poll_queue`` respectively. These retired spellings are
+accepted nowhere in current configuration and appear only in this migration
+paragraph.
+
+.. retired-sqlspec-transport-names-end
+
 Forever-uniqueness reservations
 ===============================
 

--- a/docs/usage/tasks.rst
+++ b/docs/usage/tasks.rst
@@ -42,6 +42,21 @@ The task module must still be imported before execution. Set
 ``QueueConfig(task_modules=("myapp.tasks",))`` or call
 :func:`~litestar_queues.discover_tasks` during startup.
 
+Completion and failure
+======================
+
+A return value becomes the completed result stored on the queue record, and
+the queue publishes the automatic ``task.completed`` lifecycle event when live
+delivery is configured. A raised exception follows the configured retry policy.
+An attempt that will retry publishes ``task.failed`` with
+``will_retry=true`` and returns the record to pending; the final exhausted
+attempt leaves it failed with ``will_retry=false``.
+
+Consumers should use lifecycle events for timely notification, then refresh
+the :class:`~litestar_queues.TaskResult` for the authoritative result, error,
+and terminal status. Task functions do not publish their own completed or
+failed events.
+
 Choose where defaults live
 ==========================
 

--- a/docs/usage/worker-wakeups.rst
+++ b/docs/usage/worker-wakeups.rst
@@ -3,7 +3,7 @@ Worker wakeups
 ==============
 
 When no work is available, a worker asks the queue backend to wait for a
-notification with ``WorkerConfig.poll_interval`` as the timeout:
+notification. The timeout begins at ``WorkerConfig.poll_interval``:
 
 .. code-block:: python
 
@@ -25,9 +25,40 @@ falls back to polling elsewhere. Advanced Alchemy can use PostgreSQL
 notification hints when enabled. The message only tells the worker to check. The
 saved task record has the real state.
 
-Notifications may arrive late or not at all. The worker stays correct by
-checking the saved task state. Do not set the poll interval higher than the
-delay your service can tolerate.
+Notifications may arrive late, be coalesced, or not arrive at all. Every worker
+cycle checks durable queue state before it waits, so a later polling pass still
+claims the task. The same reconciliation also discovers due scheduled and retry
+records; those known due times can shorten the next wait.
+
+Native listener lifetime
+========================
+
+A normal wait timeout does not tear down and recreate a native listener. Memory,
+Redis, Valkey, SQLSpec, and Advanced Alchemy retain at most one in-flight native
+read and resume it on the next wait. Shutdown cancels that read. A listener read
+failure is logged, resets adaptive backoff, and lets the next wait establish a
+clean listener while durable polling continues to provide correctness.
+
+Adaptive polling
+================
+
+After a fully empty cycle, the worker multiplies its stored interval by
+``poll_backoff_multiplier`` until ``poll_backoff_max``. Jitter changes only the
+sampled wait and remains clamped between the base and maximum; it never changes
+the stored exponential state. Claimed work, a native notification, worker
+startup, or a recoverable listener/backend error resets the interval
+immediately.
+
+The defaults are ``poll_interval=0.1``, ``poll_backoff_max=30.0``,
+``poll_backoff_multiplier=2.0``, and ``poll_jitter=0.15``. Configuration
+requires a positive base interval, a maximum at least as large as the base, a
+multiplier of at least ``1.0``, and jitter from ``0.0`` through ``1.0``. Set
+``poll_backoff_max=None`` for fixed-interval polling.
+
+For a polling-only backend with no already-known due time,
+``poll_backoff_max`` is the worst-case discovery delay. Native hints can end
+the wait sooner. Choose a maximum no higher than the delay the service can
+tolerate.
 
 Separate from task events
 =========================
@@ -35,3 +66,7 @@ Separate from task events
 Worker wakeups are not ``QueueEvent`` delivery, browser fan-out, or durable
 event history. A Redis queue backend does not automatically configure Redis
 Channels for SSE or WebSocket consumers. See :doc:`events`.
+
+Transport counters and timings use the bounded label contract documented in
+:doc:`observability`; backend pages link to that single canonical metric
+reference rather than redefining it.

--- a/docs/usage/workers.rst
+++ b/docs/usage/workers.rst
@@ -131,6 +131,13 @@ for running records and checks external work. ``Worker.run_once()`` returns
 after it schedules claimed tasks; it does not wait for them to finish. Use
 :doc:`results` when a caller must observe the final state.
 
+``batch_size`` is the maximum requested claim size, not a promise that every
+backend performs one storage operation. Memory, capable SQLSpec stores, and
+PostgreSQL Advanced Alchemy have native bounded batch paths. Other stores use
+the safe ``claim_next`` loop and may return a shorter batch as soon as no
+eligible record remains. Both paths preserve exclusive ownership and the same
+queue/execution filters.
+
 Shutdown
 ========
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,25 @@ event transport. Set `LITESTAR_QUEUES_EXAMPLE_PLACEMENT` to `server`, `asgi`,
 or `external` only with a queue and Channels backend appropriate for that
 process topology.
 
+## Task context contract
+
+Every app uses the same runnable task semantics:
+
+- Automatic heartbeats keep active jobs live; the basic loop does not call
+  `ctx.beat()`. Use `ctx.beat(detail)` only to replace the short diagnostic
+  detail written by the next heartbeat.
+- `ctx.progress(current=..., total=..., message=..., payload=...)` publishes
+  standardized progress for status and UI consumers.
+- `ctx.event(name, message=..., payload=..., immediate=False)` publishes an
+  application event. It does not change progress or terminal task state.
+- Returning completes the task, stores the returned result, and produces the
+  queue-owned `task.completed` event. Raising follows retry policy:
+  `task.failed` carries `will_retry`, and another `task.started` can follow for
+  the next attempt.
+
+The demo payloads are intentionally small. Store large pages, files, or model
+artifacts outside the queue and publish a stable reference.
+
 Start with the README in the directory you want to run. Every example uses the
 `examples` dev dependency group (`uv sync --group examples --group dev`) and
 local frontend dependencies from its own `package.json`.

--- a/src/tests/unit/examples/test_htmx_realtime_example.py
+++ b/src/tests/unit/examples/test_htmx_realtime_example.py
@@ -182,8 +182,7 @@ def test_realtime_examples_and_guides_lock_task_context_lifecycle_semantics() ->
         app_source = (EXAMPLES_ROOT / name / "app.py").read_text()
         assert "ctx.beat(" not in app_source, name
         assert (
-            "ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={\"line\": message})"
-            in app_source
+            'ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={"line": message})' in app_source
         ), name
         assert '"crawl.page_discovered",' in app_source, name
         assert 'payload={"url": DISCOVERED_PAGE_URL},' in app_source, name
@@ -204,10 +203,10 @@ def test_realtime_examples_and_guides_lock_task_context_lifecycle_semantics() ->
         "ctx.progress(",
         "current=3,",
         "total=6,",
-        "message=\"3/6 pages\",",
-        "payload={\"page\": 3},",
+        'message="3/6 pages",',
+        'payload={"page": 3},',
         "ctx.event(",
-        "\"crawl.page_discovered\",",
+        '"crawl.page_discovered",',
         "immediate=False,",
     ):
         assert marker in events_guide

--- a/src/tests/unit/examples/test_htmx_realtime_example.py
+++ b/src/tests/unit/examples/test_htmx_realtime_example.py
@@ -173,6 +173,49 @@ def test_htmx_realtime_examples_keep_simple_queue_and_vite_config() -> None:
         assert 'placement="asgi"' in single_process_app, name
 
 
+def test_realtime_examples_and_guides_lock_task_context_lifecycle_semantics() -> None:
+    examples_readme = (EXAMPLES_ROOT / "README.md").read_text()
+    events_guide = (ROOT / "docs" / "usage" / "events.rst").read_text()
+    tasks_guide = (ROOT / "docs" / "usage" / "tasks.rst").read_text()
+
+    for name in EXAMPLE_VARIANTS:
+        app_source = (EXAMPLES_ROOT / name / "app.py").read_text()
+        assert "ctx.beat(" not in app_source, name
+        assert (
+            "ctx.progress(current=step, total=DEMO_STEPS, message=message, payload={\"line\": message})"
+            in app_source
+        ), name
+        assert '"crawl.page_discovered",' in app_source, name
+        assert 'payload={"url": DISCOVERED_PAGE_URL},' in app_source, name
+        assert 'return {"task_id": ctx.task_id, "status": "complete"}' in app_source, name
+        assert 'ctx.event("task.completed"' not in app_source, name
+        assert 'ctx.event("task.failed"' not in app_source, name
+
+    for marker in (
+        "Automatic heartbeats keep active jobs live",
+        "ctx.beat(detail)",
+        "ctx.progress(current=..., total=..., message=..., payload=...)",
+        "ctx.event(name, message=..., payload=..., immediate=False)",
+        "Returning completes the task",
+        "Raising follows retry policy",
+    ):
+        assert marker in examples_readme
+    for marker in (
+        "ctx.progress(",
+        "current=3,",
+        "total=6,",
+        "message=\"3/6 pages\",",
+        "payload={\"page\": 3},",
+        "ctx.event(",
+        "\"crawl.page_discovered\",",
+        "immediate=False,",
+    ):
+        assert marker in events_guide
+    assert "does not update progress or terminal task state" in " ".join(events_guide.split())
+    assert "A return value becomes the completed result" in tasks_guide
+    assert "A raised exception follows the configured retry policy" in tasks_guide
+
+
 def test_htmx_realtime_examples_keep_live_channels_process_local_by_default() -> None:
     for name in EXAMPLE_VARIANTS:
         app_source = (EXAMPLES_ROOT / name / "app.py").read_text()

--- a/src/tests/unit/test_docs_structure.py
+++ b/src/tests/unit/test_docs_structure.py
@@ -1,9 +1,19 @@
 import ast
 import re
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 DOCS = ROOT / "docs"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.docs_audit import (  # noqa: E402
+    CANONICAL_SQLSPEC_TRANSPORTS,
+    SQLSPEC_DEFAULT_WAKEUP_TRANSPORTS,
+    capability_matrix_errors,
+    retired_transport_errors,
+)
 
 
 def _quickstart_python_block() -> str:
@@ -94,3 +104,54 @@ def test_event_config_modules_have_one_canonical_reference_location() -> None:
         "litestar_queues.events.stream_config",
     ):
         assert reference_source.count(f".. automodule:: {module}\n") == 1
+
+
+def test_transport_capability_matrix_matches_runtime_sources() -> None:
+    from litestar_queues.backends.advanced_alchemy._notifications import SUPPORTED_NOTIFY_DRIVERS
+    from litestar_queues.backends.sqlspec.backend import _adapter_wakeup_transport
+    from litestar_queues.backends.sqlspec.config import WAKEUP_TRANSPORTS
+
+    assert frozenset(WAKEUP_TRANSPORTS) - {"polling"} == CANONICAL_SQLSPEC_TRANSPORTS
+    assert frozenset({"postgresql+asyncpg", "postgresql+psycopg"}) == SUPPORTED_NOTIFY_DRIVERS
+    assert {
+        adapter: _adapter_wakeup_transport(adapter) for adapter in SQLSPEC_DEFAULT_WAKEUP_TRANSPORTS
+    } == SQLSPEC_DEFAULT_WAKEUP_TRANSPORTS
+    assert capability_matrix_errors(DOCS) == []
+
+
+def test_retired_transport_names_are_limited_to_migration_paragraph(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    usage = docs / "usage"
+    usage.mkdir(parents=True)
+    migration = usage / "migration.rst"
+    migration.write_text(
+        """
+.. retired-sqlspec-transport-names-start
+
+Map ``listen_notify`` to ``notify``, ``listen_notify_durable`` to
+``notify_queue``, and ``table_queue`` to ``poll_queue``.
+
+.. retired-sqlspec-transport-names-end
+""",
+        encoding="utf-8",
+    )
+    page = usage / "worker-wakeups.rst"
+    page.write_text("Canonical transport names only.\n", encoding="utf-8")
+
+    assert retired_transport_errors(docs) == []
+
+    for term in ("listen_notify", "listen_notify_durable", "table_queue"):
+        page.write_text(f"Retired outside migration: ``{term}``.\n", encoding="utf-8")
+        errors = retired_transport_errors(docs)
+        assert len(errors) == 1
+        assert term in errors[0]
+        page.write_text("Canonical transport names only.\n", encoding="utf-8")
+
+        migration.write_text(
+            migration.read_text(encoding="utf-8") + f"\nRetired outside the allowed paragraph: ``{term}``.\n",
+            encoding="utf-8",
+        )
+        errors = retired_transport_errors(docs)
+        assert len(errors) == 1
+        assert term in errors[0]
+        migration.write_text(migration.read_text(encoding="utf-8").rsplit("\n", 2)[0] + "\n", encoding="utf-8")

--- a/tools/docs_audit.py
+++ b/tools/docs_audit.py
@@ -16,6 +16,31 @@ CANONICAL_TERMS = ("queue backend", "execution backend", "worker wakeup", "task 
 OLD_TRANSPORT_TERMS = ("listen_notify", "listen_notify_durable", "table_queue")
 OBSOLETE_HISTORY_TERMS = ("SQLiteQueueEventSink", "standalone SQLite", "queue-events.db")
 QUICKSTART_DUPLICATE_THRESHOLD = 4
+CANONICAL_SQLSPEC_TRANSPORTS = frozenset({"aq", "notify", "notify_queue", "poll_queue", "txeventq"})
+SQLSPEC_DEFAULT_WAKEUP_TRANSPORTS = {
+    "asyncpg": "notify_queue",
+    "psycopg": "notify_queue",
+    "psqlpy": "notify_queue",
+    "duckdb": "poll_queue",
+    "aiosqlite": "polling",
+    "asyncmy": "polling",
+    "oracledb": "polling",
+}
+TRANSPORT_CAPABILITY_MATRIX_ROWS = (
+    ("Memory", "Always", "asyncio-event", "No", "Process-local hint"),
+    ("SQLSpec: asyncpg, psycopg, psqlpy", "Default", "notify_queue", "Yes", "Durable queue plus PostgreSQL push"),
+    ("SQLSpec: DuckDB", "Default", "poll_queue", "Yes", "Durable embedded queue"),
+    ("SQLSpec: other adapters", "Default", "Polling", "N/A", "Durable task-state polling"),
+    ("SQLSpec: Oracle", "Explicit only", "aq or txeventq", "Yes", "Application-provisioned Oracle queue"),
+    ("Advanced Alchemy: asyncpg, psycopg", "worker_wakeups=True", "postgres-listen-notify", "No", "Transient marker"),
+    ("Advanced Alchemy: other drivers", "Any", "Polling", "N/A", "Durable task-state polling"),
+    ("Redis", "Default", "Redis pub/sub", "No", "Transient marker"),
+    ("Valkey", "Default", "Valkey pub/sub", "No", "Transient marker"),
+)
+RETIRED_TRANSPORT_START = ".. retired-sqlspec-transport-names-start"
+RETIRED_TRANSPORT_END = ".. retired-sqlspec-transport-names-end"
+CAPABILITY_MATRIX_START = ".. transport-capability-matrix-start"
+CAPABILITY_MATRIX_END = ".. transport-capability-matrix-end"
 
 
 @dataclass(slots=True)
@@ -89,6 +114,8 @@ def audit(docs_root: Path, readme: Path) -> int:
         if member == "no":
             errors.append(f"page is not in a toctree: {page.relative_path}")
         errors.extend(_literalinclude_errors(page, docs_root))
+    errors.extend(retired_transport_errors(docs_root))
+    errors.extend(capability_matrix_errors(docs_root))
 
     print("\nReview prompts")
     prompts = [f"{page.relative_path}: {prompt}" for page in pages for prompt in page.prompts]
@@ -109,6 +136,74 @@ def audit(docs_root: Path, readme: Path) -> int:
     for error in errors or ["none"]:
         print(f"- {error}")
     return 1 if errors else 0
+
+
+def retired_transport_errors(docs_root: Path) -> list[str]:
+    """Return retired SQLSpec transport occurrences outside one migration paragraph."""
+    errors: list[str] = []
+    migration_path = docs_root / "usage" / "migration.rst"
+    for path in sorted(docs_root.rglob("*.rst")):
+        source = path.read_text(encoding="utf-8")
+        searchable = source
+        if path == migration_path:
+            start_count = source.count(RETIRED_TRANSPORT_START)
+            end_count = source.count(RETIRED_TRANSPORT_END)
+            if start_count != 1 or end_count != 1:
+                errors.append("migration.rst must contain exactly one retired-transport paragraph boundary")
+            else:
+                before, remainder = source.split(RETIRED_TRANSPORT_START, 1)
+                allowed, after = remainder.split(RETIRED_TRANSPORT_END, 1)
+                errors.extend(
+                    f"migration retired-transport paragraph must map {term} exactly once"
+                    for term in OLD_TRANSPORT_TERMS
+                    if len(_exact_term_matches(allowed, term)) != 1
+                )
+                searchable = f"{before}\n{after}"
+        for term in OLD_TRANSPORT_TERMS:
+            for match in _exact_term_matches(searchable, term):
+                line = searchable.count("\n", 0, match.start()) + 1
+                errors.append(f"retired SQLSpec transport outside migration paragraph: {path}:{line}:{term}")
+    return errors
+
+
+def capability_matrix_errors(docs_root: Path) -> list[str]:
+    """Return drift between the explicit matrix data and its delimited RST block."""
+    path = docs_root / "usage" / "backends.rst"
+    source = path.read_text(encoding="utf-8")
+    if source.count(CAPABILITY_MATRIX_START) != 1 or source.count(CAPABILITY_MATRIX_END) != 1:
+        return ["backends.rst must contain exactly one transport capability matrix boundary"]
+    rendered = source.split(CAPABILITY_MATRIX_START, 1)[1].split(CAPABILITY_MATRIX_END, 1)[0].strip()
+    expected = render_transport_capability_matrix_rows().strip()
+    return [] if rendered == expected else ["backends.rst transport capability matrix differs from explicit audit data"]
+
+
+def render_transport_capability_matrix_rows() -> str:
+    """Render the machine-checked public RST list-table."""
+    lines = [
+        ".. list-table::",
+        "   :header-rows: 1",
+        "   :widths: 28 18 22 10 28",
+        "",
+        "   * - Backend or adapter",
+        "     - Enabling setting",
+        "     - Effective strategy",
+        "     - Durable wakeup",
+        "     - Ownership",
+        "",
+    ]
+    for component, setting, transport, durable, ownership in TRANSPORT_CAPABILITY_MATRIX_ROWS:
+        lines.extend((
+            f"   * - {component}",
+            f"     - {setting}",
+            f"     - {transport}",
+            f"     - {durable}",
+            f"     - {ownership}",
+        ))
+    return "\n".join(lines)
+
+
+def _exact_term_matches(source: str, term: str) -> list[re.Match[str]]:
+    return list(re.finditer(rf"(?<![A-Za-z0-9_]){re.escape(term)}(?![A-Za-z0-9_])", source))
 
 
 def _headings(source: str) -> list[tuple[int, str]]:


### PR DESCRIPTION
## Summary

- align worker wakeup, polling, batching, SQLSpec, and Advanced Alchemy documentation with the shipped runtime contracts
- document exact `ctx.progress(...)`, `ctx.event(...)`, optional heartbeat, result, retry, and terminal-event behavior across all ten realtime examples
- add deterministic enforcement for migration-only retired transport names and a source-backed backend capability matrix