### PR TITLE
test: add Floci Eventarc push contract

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 # at the project root because pytest requires ``pytest_plugins`` to live in the
 # top-level conftest.
 pytest_plugins = [
+    "tests.plugins.floci_gcp",
     "tests.plugins.localstack",
     "tests.plugins.pubsub",
     "tests.plugins.rabbitmq",

--- a/src/tests/helpers/eventarc_receiver.py
+++ b/src/tests/helpers/eventarc_receiver.py
@@ -1,0 +1,109 @@
+"""Strict test receiver for Floci-GCP Eventarc Standard Pub/Sub events."""
+
+import binascii
+from base64 import b64decode
+from dataclasses import dataclass, field
+from uuid import UUID
+
+import msgspec
+from litestar import Litestar, Request, Response, post
+from litestar.di import NamedDependency, Provide
+
+from litestar_queues.consumer import consume_one
+from litestar_queues.execution.pubsub.backend import ATTEMPT_ATTRIBUTE, _parse_attempt
+from litestar_queues.service import QueueService
+
+__all__ = ("EVENT_TYPE", "EventarcDelivery", "EventarcReceiverProbe", "create_eventarc_receiver")
+
+EVENT_TYPE = "google.cloud.pubsub.topic.v1.messagePublished"
+_MAX_BODY_BYTES = 64 * 1024
+
+
+class _PubSubMessage(msgspec.Struct, forbid_unknown_fields=True, frozen=True, rename="camel"):
+    data: str
+    attributes: dict[str, str]
+    message_id: str
+    publish_time: str
+
+
+class _PubSubEnvelope(msgspec.Struct, forbid_unknown_fields=True, frozen=True):
+    message: _PubSubMessage
+    subscription: str | None = None
+
+
+@dataclass(frozen=True)
+class EventarcDelivery:
+    """Validated values observed at the receiver boundary."""
+
+    task_id: UUID
+    attempt: str
+
+
+@dataclass
+class EventarcReceiverProbe:
+    """Record validated deliveries without making request data authoritative."""
+
+    deliveries: list[EventarcDelivery] = field(default_factory=list)
+    rejections: list[str] = field(default_factory=list)
+
+
+def create_eventarc_receiver(*, queue_service: QueueService, topic: str) -> Litestar:
+    """Build an isolated receiver app for one exact Pub/Sub topic."""
+    probe = EventarcReceiverProbe()
+
+    async def provide_queue_service() -> QueueService:
+        return queue_service
+
+    @post(path="/eventarc/pubsub", include_in_schema=False)
+    async def receive_event(request: Request, queue_service: NamedDependency[QueueService]) -> Response[None]:
+        header_error = _headers_error(request, topic)
+        if header_error is not None:
+            probe.rejections.append(header_error)
+            return Response(content=None, status_code=400)
+        body = await request.body()
+        if len(body) > _MAX_BODY_BYTES:
+            probe.rejections.append("body_too_large")
+            return Response(content=None, status_code=413)
+        try:
+            envelope = msgspec.json.decode(body, type=_PubSubEnvelope, strict=True)
+            task_id = UUID(b64decode(envelope.message.data, validate=True).decode("utf-8"))
+        except (msgspec.DecodeError, binascii.Error, UnicodeDecodeError, ValueError):
+            probe.rejections.append("invalid_body")
+            return Response(content=None, status_code=400)
+        attempt = envelope.message.attributes.get(ATTEMPT_ATTRIBUTE)
+        parsed = _parse_attempt(attempt)
+        if not isinstance(attempt, str) or parsed is None or envelope.message.message_id != request.headers["ce-id"]:
+            probe.rejections.append("invalid_attempt_or_message_id")
+            return Response(content=None, status_code=400)
+        retry_count, _created_at = parsed
+        try:
+            await consume_one(queue_service, task_id, expected_retry_count=retry_count, expected_execution_ref=attempt)
+        except Exception:  # noqa: BLE001 - only infrastructure failures escape consume_one.
+            return Response(content=None, status_code=503)
+        probe.deliveries.append(EventarcDelivery(task_id=task_id, attempt=attempt))
+        return Response(content=None, status_code=204)
+
+    app = Litestar(route_handlers=[receive_event], dependencies={"queue_service": Provide(provide_queue_service)})
+    app.state.eventarc_queue_service = queue_service
+    app.state.eventarc_receiver_probe = probe
+    return app
+
+
+def _headers_error(request: Request, topic: str) -> str | None:
+    headers = request.headers
+    content_type = headers.get("content-type", "").partition(";")[0].strip().lower()
+    expected = {
+        "content-type": "application/json",
+        "ce-specversion": "1.0",
+        "ce-type": EVENT_TYPE,
+        "ce-source": f"//pubsub.googleapis.com/{topic}",
+    }
+    actual = {**headers, "content-type": content_type}
+    for name, value in expected.items():
+        if actual.get(name) != value:
+            return f"invalid_{name}"
+    if not headers.get("ce-id"):
+        return "missing_ce-id"
+    if not headers.get("ce-time"):
+        return "missing_ce-time"
+    return None

--- a/src/tests/helpers/eventarc_receiver.py
+++ b/src/tests/helpers/eventarc_receiver.py
@@ -84,7 +84,11 @@ def create_eventarc_receiver(*, queue_service: QueueService, topic: str) -> Lite
         probe.deliveries.append(EventarcDelivery(task_id=task_id, attempt=attempt))
         return Response(content=None, status_code=204)
 
-    app = Litestar(route_handlers=[receive_event], dependencies={"queue_service": Provide(provide_queue_service)})
+    app = Litestar(
+        route_handlers=[receive_event],
+        dependencies={"queue_service": Provide(provide_queue_service)},
+        request_max_body_size=_MAX_BODY_BYTES,
+    )
     app.state.eventarc_queue_service = queue_service
     app.state.eventarc_receiver_probe = probe
     return app

--- a/src/tests/helpers/eventarc_receiver.py
+++ b/src/tests/helpers/eventarc_receiver.py
@@ -10,6 +10,7 @@ from litestar import Litestar, Request, Response, post
 from litestar.di import NamedDependency, Provide
 
 from litestar_queues.consumer import consume_one
+from litestar_queues.exceptions import QueueError
 from litestar_queues.execution.pubsub.backend import ATTEMPT_ATTRIBUTE, _parse_attempt
 from litestar_queues.service import QueueService
 
@@ -78,7 +79,7 @@ def create_eventarc_receiver(*, queue_service: QueueService, topic: str) -> Lite
         retry_count, _created_at = parsed
         try:
             await consume_one(queue_service, task_id, expected_retry_count=retry_count, expected_execution_ref=attempt)
-        except Exception:  # noqa: BLE001 - only infrastructure failures escape consume_one.
+        except (OSError, QueueError):
             return Response(content=None, status_code=503)
         probe.deliveries.append(EventarcDelivery(task_id=task_id, attempt=attempt))
         return Response(content=None, status_code=204)

--- a/src/tests/integration/execution/pubsub/test_eventarc_push.py
+++ b/src/tests/integration/execution/pubsub/test_eventarc_push.py
@@ -27,6 +27,11 @@ pytestmark = pytest.mark.anyio
 logger = logging.getLogger(__name__)
 
 _MAX_HEADER_BYTES = 16 * 1024
+_MAX_BODY_BYTES = 64 * 1024
+
+
+class _PayloadTooLargeError(ValueError):
+    """Raised before the bridge reads an oversized body."""
 
 
 async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(  # noqa: PLR0915
@@ -123,8 +128,9 @@ async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(  # noqa: PL
                         raise
                     logger.warning("Pub/Sub topic cleanup failed", exc_info=True)
         finally:
-            await publisher.transport.close()
-            await channel.close()
+            await _close_transport_resources(
+                publisher, channel, causal_exception=causal_exception or sys.exc_info()[0] is not None
+            )
 
 
 @asynccontextmanager
@@ -143,10 +149,12 @@ async def _serve(app: "Litestar") -> "AsyncGenerator[int, None]":
         async def forward(reader: "asyncio.StreamReader", writer: "asyncio.StreamWriter") -> "None":
             try:
                 method, path, headers = await _read_request_head(reader)
-                length = int(headers.get("content-length", "0"))
-                body = await reader.readexactly(length)
+                body = await _read_request_body(reader, headers)
                 response = await client.request(method, path, headers=headers, content=body)
                 status = response.status_code
+            except _PayloadTooLargeError:
+                logger.warning("Rejected oversized Eventarc HTTP delivery")
+                status = 413
             except (
                 asyncio.IncompleteReadError,
                 asyncio.LimitOverrunError,
@@ -181,3 +189,34 @@ async def _read_request_head(reader: "asyncio.StreamReader") -> "tuple[str, str,
         raise ValueError(msg)
     headers = dict(line.split(":", maxsplit=1) for line in lines[1:] if line)
     return method, path, {name.strip().lower(): value.strip() for name, value in headers.items()}
+
+
+async def _read_request_body(reader: "asyncio.StreamReader", headers: "dict[str, str]") -> bytes:
+    try:
+        length = int(headers.get("content-length", "0"))
+    except ValueError as exc:
+        msg = "Invalid Eventarc Content-Length"
+        raise ValueError(msg) from exc
+    if length < 0:
+        msg = "Eventarc Content-Length must be nonnegative"
+        raise ValueError(msg)
+    if length > _MAX_BODY_BYTES:
+        raise _PayloadTooLargeError
+    return await asyncio.wait_for(reader.readexactly(length), timeout=5)
+
+
+async def _close_transport_resources(publisher: "Any", channel: "Any", *, causal_exception: bool) -> "None":
+    first_error = await _close_one("publisher transport", publisher.transport.close)
+    channel_error = await _close_one("gRPC channel", channel.close)
+    first_error = first_error or channel_error
+    if first_error is not None and not causal_exception:
+        raise first_error
+
+
+async def _close_one(label: "str", close: "Any") -> "Exception | None":
+    try:
+        await close()
+    except Exception as exc:
+        logger.warning("Eventarc %s cleanup failed", label, exc_info=True)
+        return exc
+    return None

--- a/src/tests/integration/execution/pubsub/test_eventarc_push.py
+++ b/src/tests/integration/execution/pubsub/test_eventarc_push.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.anyio
 
 
-async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(floci_gcp_service: "FlociGcpService") -> "None":
+async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(  # noqa: PLR0915
+    floci_gcp_service: "FlociGcpService",
+) -> "None":
     if "eventarc-standard" not in floci_gcp_service.capabilities:
         pytest.skip("Floci-GCP image does not declare Eventarc Standard delivery")
     publisher_module = pytest.importorskip("google.pubsub_v1.services.publisher")
@@ -61,37 +63,42 @@ async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(floci_gcp_se
             async with _serve(receiver) as receiver_port:
                 receiver_uri = f"http://{floci_gcp_service.docker_host}:{receiver_port}/eventarc/pubsub"
                 async with httpx.AsyncClient(base_url=floci_gcp_service.rest_endpoint) as client:
-                    response = await client.post(
-                        trigger_path.rsplit("/", maxsplit=1)[0],
-                        params={"triggerId": trigger_id},
-                        json={
-                            "eventFilters": [
-                                {"attribute": "type", "value": "google.cloud.pubsub.topic.v1.messagePublished"},
-                                {"attribute": "topic", "value": topic_path},
-                            ],
-                            "destination": {"httpEndpoint": {"uri": receiver_uri}},
-                        },
-                    )
-                    response.raise_for_status()
-                    result = await service.enqueue(delivered.using(execution_backend="pubsub"))
-                    record = await queue_backend.get_task(result.id)
-                    assert record is not None
-                    attempt = await backend.dispatch(service, record)
-                    assert attempt is not None
-                    stored: Any | None = None
-                    for _ in range(100):
-                        stored = await queue_backend.get_task(result.id)
-                        if stored is not None and stored.status == "completed":
-                            break
-                        await asyncio.sleep(0.05)
-                    assert stored is not None
-                    assert stored.status == "completed", receiver.state.eventarc_receiver_probe.rejections
-                    assert stored.result == "done"
-                    assert receiver.state.eventarc_receiver_probe.deliveries == [
-                        EventarcDelivery(task_id=result.id, attempt=attempt)
-                    ]
-                    delete_response = await client.delete(trigger_path)
-                    delete_response.raise_for_status()
+                    trigger_created = False
+                    try:
+                        response = await client.post(
+                            trigger_path.rsplit("/", maxsplit=1)[0],
+                            params={"triggerId": trigger_id},
+                            json={
+                                "eventFilters": [
+                                    {"attribute": "type", "value": "google.cloud.pubsub.topic.v1.messagePublished"},
+                                    {"attribute": "topic", "value": topic_path},
+                                ],
+                                "destination": {"httpEndpoint": {"uri": receiver_uri}},
+                            },
+                        )
+                        response.raise_for_status()
+                        trigger_created = True
+                        result = await service.enqueue(delivered.using(execution_backend="pubsub"))
+                        record = await queue_backend.get_task(result.id)
+                        assert record is not None
+                        attempt = await backend.dispatch(service, record)
+                        assert attempt is not None
+                        stored: Any | None = None
+                        for _ in range(100):
+                            stored = await queue_backend.get_task(result.id)
+                            if stored is not None and stored.status == "completed":
+                                break
+                            await asyncio.sleep(0.05)
+                        assert stored is not None
+                        assert stored.status == "completed", receiver.state.eventarc_receiver_probe.rejections
+                        assert stored.result == "done"
+                        assert receiver.state.eventarc_receiver_probe.deliveries == [
+                            EventarcDelivery(task_id=result.id, attempt=attempt)
+                        ]
+                    finally:
+                        if trigger_created:
+                            delete_response = await client.delete(trigger_path)
+                            delete_response.raise_for_status()
     finally:
         try:
             await publisher.delete_topic(request={"topic": topic_path})

--- a/src/tests/integration/execution/pubsub/test_eventarc_push.py
+++ b/src/tests/integration/execution/pubsub/test_eventarc_push.py
@@ -1,6 +1,8 @@
 """Joined Floci-GCP Pub/Sub to Eventarc Standard delivery contract."""
 
 import asyncio
+import logging
+import sys
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -22,6 +24,9 @@ if TYPE_CHECKING:
     from tests.plugins.floci_gcp import FlociGcpService
 
 pytestmark = pytest.mark.anyio
+logger = logging.getLogger(__name__)
+
+_MAX_HEADER_BYTES = 16 * 1024
 
 
 async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(  # noqa: PLR0915
@@ -56,8 +61,10 @@ async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(  # noqa: PL
     async def delivered() -> str:
         return "done"
 
+    topic_created = False
     try:
         await publisher.create_topic(request={"name": topic_path})
+        topic_created = True
         async with QueueService(config, queue_backend=queue_backend, execution_backend=backend) as service:
             receiver = create_eventarc_receiver(queue_service=service, topic=topic_path)
             async with _serve(receiver) as receiver_port:
@@ -97,11 +104,24 @@ async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(  # noqa: PL
                         ]
                     finally:
                         if trigger_created:
-                            delete_response = await client.delete(trigger_path)
-                            delete_response.raise_for_status()
+                            causal_exception = sys.exc_info()[0] is not None
+                            try:
+                                delete_response = await client.delete(trigger_path)
+                                delete_response.raise_for_status()
+                            except httpx.HTTPError:
+                                if not causal_exception:
+                                    raise
+                                logger.warning("Eventarc trigger cleanup failed", exc_info=True)
     finally:
+        causal_exception = sys.exc_info()[0] is not None
         try:
-            await publisher.delete_topic(request={"topic": topic_path})
+            if topic_created:
+                try:
+                    await publisher.delete_topic(request={"topic": topic_path})
+                except Exception:
+                    if not causal_exception:
+                        raise
+                    logger.warning("Pub/Sub topic cleanup failed", exc_info=True)
         finally:
             await publisher.transport.close()
             await channel.close()
@@ -122,17 +142,22 @@ async def _serve(app: "Litestar") -> "AsyncGenerator[int, None]":
 
         async def forward(reader: "asyncio.StreamReader", writer: "asyncio.StreamWriter") -> "None":
             try:
-                head = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
-                lines = head.decode("latin-1").split("\r\n")
-                method, path, _protocol = lines[0].split(" ", maxsplit=2)
-                headers = dict(line.split(":", maxsplit=1) for line in lines[1:] if line)
-                headers = {name.strip(): value.strip() for name, value in headers.items()}
-                length = int(headers.get("Content-Length", "0"))
+                method, path, headers = await _read_request_head(reader)
+                length = int(headers.get("content-length", "0"))
                 body = await reader.readexactly(length)
                 response = await client.request(method, path, headers=headers, content=body)
-                writer.write(
-                    f"HTTP/1.1 {response.status_code} Eventarc\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".encode()
-                )
+                status = response.status_code
+            except (
+                asyncio.IncompleteReadError,
+                asyncio.LimitOverrunError,
+                TimeoutError,
+                UnicodeDecodeError,
+                ValueError,
+            ):
+                logger.warning("Rejected malformed Eventarc HTTP delivery", exc_info=True)
+                status = 400
+            try:
+                writer.write(f"HTTP/1.1 {status} Eventarc\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".encode())
                 await writer.drain()
             finally:
                 writer.close()
@@ -142,3 +167,17 @@ async def _serve(app: "Litestar") -> "AsyncGenerator[int, None]":
         port = server.sockets[0].getsockname()[1]
         async with server:
             yield port
+
+
+async def _read_request_head(reader: "asyncio.StreamReader") -> "tuple[str, str, dict[str, str]]":
+    head = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+    if len(head) > _MAX_HEADER_BYTES:
+        msg = "Eventarc request headers exceed the test bridge limit"
+        raise ValueError(msg)
+    lines = head.decode("latin-1").split("\r\n")
+    method, path, protocol = lines[0].split(" ", maxsplit=2)
+    if protocol != "HTTP/1.1":
+        msg = f"Unsupported Eventarc HTTP protocol: {protocol}"
+        raise ValueError(msg)
+    headers = dict(line.split(":", maxsplit=1) for line in lines[1:] if line)
+    return method, path, {name.strip().lower(): value.strip() for name, value in headers.items()}

--- a/src/tests/integration/execution/pubsub/test_eventarc_push.py
+++ b/src/tests/integration/execution/pubsub/test_eventarc_push.py
@@ -1,0 +1,137 @@
+"""Joined Floci-GCP Pub/Sub to Eventarc Standard delivery contract."""
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+import grpc  # type: ignore[import-untyped]
+import httpx
+import pytest
+from litestar.testing import AsyncTestClient
+
+from litestar_queues import QueueConfig, QueueService, WorkerConfig, task
+from litestar_queues.backends import InMemoryQueueBackend
+from litestar_queues.execution.pubsub import PubSubExecutionBackend, PubSubExecutionConfig
+from tests.helpers.eventarc_receiver import EventarcDelivery, create_eventarc_receiver
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from litestar import Litestar
+
+    from tests.plugins.floci_gcp import FlociGcpService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_floci_pubsub_dispatch_reaches_eventarc_http_receiver(floci_gcp_service: "FlociGcpService") -> "None":
+    if "eventarc-standard" not in floci_gcp_service.capabilities:
+        pytest.skip("Floci-GCP image does not declare Eventarc Standard delivery")
+    publisher_module = pytest.importorskip("google.pubsub_v1.services.publisher")
+    transport_module = pytest.importorskip("google.pubsub_v1.services.publisher.transports.grpc_asyncio")
+    channel = grpc.aio.insecure_channel(floci_gcp_service.grpc_endpoint)
+    publisher = publisher_module.PublisherAsyncClient(
+        transport=transport_module.PublisherGrpcAsyncIOTransport(channel=channel)
+    )
+    topic_id = f"{floci_gcp_service.resource_prefix}eventarc-dispatch"
+    trigger_id = f"{floci_gcp_service.resource_prefix}eventarc-push"
+    topic_path = publisher.topic_path(floci_gcp_service.project_id, topic_id)
+    trigger_path = f"/v1/projects/{floci_gcp_service.project_id}/locations/us-central1/triggers/{trigger_id}"
+    execution_config = PubSubExecutionConfig(
+        project_id=floci_gcp_service.project_id,
+        topic_id=topic_id,
+        subscription_id="unused-eventarc-push",
+        api_endpoint=floci_gcp_service.grpc_endpoint,
+        api_insecure=True,
+    )
+    config = QueueConfig(
+        queue_backend="memory", execution_backend=execution_config, worker=WorkerConfig(placement="external")
+    )
+    queue_backend = InMemoryQueueBackend()
+    backend = PubSubExecutionBackend(config, execution_config=execution_config, publisher=publisher)
+
+    @task("tests.eventarc.floci.delivered")
+    async def delivered() -> str:
+        return "done"
+
+    try:
+        await publisher.create_topic(request={"name": topic_path})
+        async with QueueService(config, queue_backend=queue_backend, execution_backend=backend) as service:
+            receiver = create_eventarc_receiver(queue_service=service, topic=topic_path)
+            async with _serve(receiver) as receiver_port:
+                receiver_uri = f"http://{floci_gcp_service.docker_host}:{receiver_port}/eventarc/pubsub"
+                async with httpx.AsyncClient(base_url=floci_gcp_service.rest_endpoint) as client:
+                    response = await client.post(
+                        trigger_path.rsplit("/", maxsplit=1)[0],
+                        params={"triggerId": trigger_id},
+                        json={
+                            "eventFilters": [
+                                {"attribute": "type", "value": "google.cloud.pubsub.topic.v1.messagePublished"},
+                                {"attribute": "topic", "value": topic_path},
+                            ],
+                            "destination": {"httpEndpoint": {"uri": receiver_uri}},
+                        },
+                    )
+                    response.raise_for_status()
+                    result = await service.enqueue(delivered.using(execution_backend="pubsub"))
+                    record = await queue_backend.get_task(result.id)
+                    assert record is not None
+                    attempt = await backend.dispatch(service, record)
+                    assert attempt is not None
+                    stored: Any | None = None
+                    for _ in range(100):
+                        stored = await queue_backend.get_task(result.id)
+                        if stored is not None and stored.status == "completed":
+                            break
+                        await asyncio.sleep(0.05)
+                    assert stored is not None
+                    assert stored.status == "completed", receiver.state.eventarc_receiver_probe.rejections
+                    assert stored.result == "done"
+                    assert receiver.state.eventarc_receiver_probe.deliveries == [
+                        EventarcDelivery(task_id=result.id, attempt=attempt)
+                    ]
+                    delete_response = await client.delete(trigger_path)
+                    delete_response.raise_for_status()
+    finally:
+        try:
+            await publisher.delete_topic(request={"topic": topic_path})
+        finally:
+            await publisher.transport.close()
+            await channel.close()
+
+
+@asynccontextmanager
+async def _serve(app: "Litestar") -> "AsyncGenerator[int, None]":
+    """Expose the ASGI receiver while explicitly declining Floci's h2c upgrade.
+
+    Floci's Java HTTP client asks to upgrade cleartext requests to HTTP/2. The
+    tiny HTTP/1 bridge keeps the original POST body intact and passes the
+    request into Litestar's normal ASGI test transport.
+
+    Yields:
+        The Docker-reachable receiver port.
+    """
+    async with AsyncTestClient(app=app) as client:
+
+        async def forward(reader: "asyncio.StreamReader", writer: "asyncio.StreamWriter") -> "None":
+            try:
+                head = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+                lines = head.decode("latin-1").split("\r\n")
+                method, path, _protocol = lines[0].split(" ", maxsplit=2)
+                headers = dict(line.split(":", maxsplit=1) for line in lines[1:] if line)
+                headers = {name.strip(): value.strip() for name, value in headers.items()}
+                length = int(headers.get("Content-Length", "0"))
+                body = await reader.readexactly(length)
+                response = await client.request(method, path, headers=headers, content=body)
+                writer.write(
+                    f"HTTP/1.1 {response.status_code} Eventarc\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".encode()
+                )
+                await writer.drain()
+            finally:
+                writer.close()
+                await writer.wait_closed()
+
+        server = await asyncio.start_server(forward, "0.0.0.0", 0)
+        port = server.sockets[0].getsockname()[1]
+        async with server:
+            yield port

--- a/src/tests/plugins/floci_gcp.py
+++ b/src/tests/plugins/floci_gcp.py
@@ -1,0 +1,79 @@
+"""Temporary Floci-GCP fixture pending its pytest-databases release."""
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+from pytest_databases.helpers import get_xdist_worker_num
+from pytest_databases.types import ServiceContainer
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from pytest_databases._service import DockerService
+
+_FLOCI_GCP_IMAGE = "floci/floci-gcp:0.6.0"
+_FLOCI_GCP_PORT = 4588
+
+
+@dataclass
+class FlociGcpService(ServiceContainer):
+    """Coordinates and supported data planes for one Floci-GCP instance."""
+
+    project_id: str
+    resource_prefix: str
+    docker_host: str
+    capabilities: frozenset[str]
+
+    @property
+    def grpc_endpoint(self) -> str:
+        """Return the unified insecure gRPC endpoint."""
+        return f"{self.host}:{self.port}"
+
+    @property
+    def rest_endpoint(self) -> str:
+        """Return the unified REST endpoint."""
+        return f"http://{self.host}:{self.port}"
+
+
+@pytest.fixture(scope="session")
+def floci_gcp_service(docker_service: "DockerService") -> "Generator[FlociGcpService, None, None]":
+    """Start the pinned Floci-GCP emulator image.
+
+    Yields:
+        Connection details for the running emulator.
+    """
+    worker_num = get_xdist_worker_num()
+    suffix = worker_num or "main"
+    project_id = os.getenv("FLOCI_GCP_PROJECT", "litestar-queues-test")
+    prefix = os.getenv("FLOCI_GCP_RESOURCE_PREFIX", f"litestar-queues-{suffix}-")
+
+    def check(service: ServiceContainer) -> bool:
+        try:
+            with urlopen(f"http://{service.host}:{service.port}/health", timeout=0.5) as response:
+                return int(response.status) == 200
+        except (OSError, URLError):
+            return False
+
+    with docker_service.run(
+        image=_FLOCI_GCP_IMAGE,
+        name=f"floci_gcp_{suffix}",
+        container_port=_FLOCI_GCP_PORT,
+        check=check,
+        timeout=90,
+        pause=0.5,
+        transient=worker_num is not None,
+    ) as service:
+        yield FlociGcpService(
+            host=service.host,
+            port=service.port,
+            container=service.container,
+            project_id=project_id,
+            resource_prefix=prefix,
+            docker_host=os.getenv("FLOCI_GCP_RECEIVER_HOST", socket.gethostbyname(socket.gethostname())),
+            capabilities=frozenset({"eventarc-standard", "pubsub"}),
+        )

--- a/src/tests/unit/helpers/__init__.py
+++ b/src/tests/unit/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for shared test helpers."""

--- a/src/tests/unit/helpers/test_eventarc_bridge.py
+++ b/src/tests/unit/helpers/test_eventarc_bridge.py
@@ -20,10 +20,10 @@ async def test_bridge_rejects_invalid_content_length(length: "str") -> "None":
 
 
 async def test_bridge_rejects_oversized_body_before_reading() -> "None":
-    reader = asyncio.StreamReader()
+    reader = AsyncMock(spec=asyncio.StreamReader)
     with pytest.raises(_PayloadTooLargeError):
         await _read_request_body(reader, {"content-length": str(64 * 1024 + 1)})
-    assert reader._buffer == bytearray()
+    reader.readexactly.assert_not_called()
 
 
 async def test_bridge_times_out_incomplete_body(monkeypatch: "pytest.MonkeyPatch") -> "None":

--- a/src/tests/unit/helpers/test_eventarc_bridge.py
+++ b/src/tests/unit/helpers/test_eventarc_bridge.py
@@ -1,0 +1,58 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.integration.execution.pubsub.test_eventarc_push import (
+    _close_transport_resources,
+    _PayloadTooLargeError,
+    _read_request_body,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.parametrize("length", ["-1", "not-an-int"])
+async def test_bridge_rejects_invalid_content_length(length: "str") -> "None":
+    with pytest.raises(ValueError, match="Content-Length"):
+        await _read_request_body(asyncio.StreamReader(), {"content-length": length})
+
+
+async def test_bridge_rejects_oversized_body_before_reading() -> "None":
+    reader = asyncio.StreamReader()
+    with pytest.raises(_PayloadTooLargeError):
+        await _read_request_body(reader, {"content-length": str(64 * 1024 + 1)})
+    assert reader._buffer == bytearray()
+
+
+async def test_bridge_times_out_incomplete_body(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    async def wait_for(awaitable: "Any", *, timeout: "float") -> "None":
+        del timeout
+        awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr("tests.integration.execution.pubsub.test_eventarc_push.asyncio.wait_for", wait_for)
+    with pytest.raises(TimeoutError):
+        await _read_request_body(asyncio.StreamReader(), {"content-length": "1"})
+
+
+async def test_transport_cleanup_preserves_causal_exception() -> "None":
+    publisher = AsyncMock()
+    publisher.transport.close.side_effect = RuntimeError("publisher close")
+    channel = AsyncMock()
+    channel.close.side_effect = RuntimeError("channel close")
+
+    await _close_transport_resources(publisher, channel, causal_exception=True)
+
+    publisher.transport.close.assert_awaited_once()
+    channel.close.assert_awaited_once()
+
+
+async def test_transport_cleanup_surfaces_failure_without_causal_exception() -> "None":
+    publisher = AsyncMock()
+    publisher.transport.close.side_effect = RuntimeError("publisher close")
+    channel = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="publisher close"):
+        await _close_transport_resources(publisher, channel, causal_exception=False)

--- a/src/tests/unit/helpers/test_eventarc_receiver.py
+++ b/src/tests/unit/helpers/test_eventarc_receiver.py
@@ -38,6 +38,7 @@ def _delivery(task_id: "object", attempt: "object", **overrides: "Any") -> "dict
             "publishTime": "2026-08-09T00:00:00Z",
         }
     }
+    body["message"].update(overrides.pop("message", {}))
     body.update(overrides.pop("body", {}))
     return {"headers": headers, "json": body, **overrides}
 
@@ -71,6 +72,18 @@ async def test_receiver_runs_fenced_pubsub_delivery(monkeypatch: "pytest.MonkeyP
     consume.assert_awaited_once_with(
         app.state.eventarc_queue_service, task_id, expected_retry_count=2, expected_execution_ref=attempt
     )
+
+
+@pytest.mark.parametrize(
+    "outcome", [TaskExitCode.FAILURE, TaskExitCode.CANCELLED, TaskExitCode.MISSING_RECORD, TaskExitCode.CLAIM_LOST]
+)
+async def test_durable_outcomes_are_acknowledged(monkeypatch: "pytest.MonkeyPatch", outcome: "TaskExitCode") -> "None":
+    consume = AsyncMock(return_value=outcome)
+    monkeypatch.setattr("tests.helpers.eventarc_receiver.consume_one", consume)
+    async with _receiver_service() as (_service, _backend, client):
+        response = await client.post("/eventarc/pubsub", **_delivery(uuid4(), f"pubsub:0:123:{uuid4()}"))
+
+    assert response.status_code == 204
 
 
 async def test_duplicate_delivery_executes_task_once() -> "None":
@@ -108,7 +121,8 @@ async def test_cancelled_or_stale_delivery_does_not_execute(state: "str") -> "No
         if state == "cancelled":
             assert await service.cancel_task(result.id, include_running=True)
         else:
-            delivered_attempt = f"pubsub:0:122:{uuid4()}"
+            replacement = f"pubsub:0:124:{uuid4()}"
+            assert await backend.replace_execution_ref(result.id, 0, current, replacement) is not None
         response = await client.post("/eventarc/pubsub", **_delivery(result.id, delivered_attempt))
 
     assert response.status_code == 204
@@ -121,8 +135,12 @@ async def test_cancelled_or_stale_delivery_does_not_execute(state: "str") -> "No
         _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-specversion": "0.3"}),
         _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-type": "wrong"}),
         _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-source": "//pubsub.googleapis.com/wrong"}),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-id": ""}),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-time": ""}),
         _delivery(uuid4(), "missing-attempt"),
         _delivery("not-a-uuid", f"pubsub:0:123:{uuid4()}"),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", message={"data": "not-base64!"}),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", message={"messageId": "different"}),
         _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", body={"unexpected": True}),
     ],
 )
@@ -140,3 +158,22 @@ async def test_infrastructure_error_is_retryable(monkeypatch: "pytest.MonkeyPatc
         response = await client.post("/eventarc/pubsub", **_delivery(uuid4(), f"pubsub:0:123:{uuid4()}"))
 
     assert response.status_code == 503
+
+
+async def test_programming_error_is_not_marked_retryable(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    consume = AsyncMock(side_effect=ValueError("bug"))
+    monkeypatch.setattr("tests.helpers.eventarc_receiver.consume_one", consume)
+    async with _receiver_service() as (_service, _backend, client):
+        response = await client.post("/eventarc/pubsub", **_delivery(uuid4(), f"pubsub:0:123:{uuid4()}"))
+
+    assert response.status_code == 500
+
+
+async def test_oversized_delivery_is_rejected() -> "None":
+    oversized = "x" * (64 * 1024)
+    async with _receiver_service() as (_service, _backend, client):
+        response = await client.post(
+            "/eventarc/pubsub", **_delivery(uuid4(), f"pubsub:0:123:{uuid4()}", message={"data": oversized})
+        )
+
+    assert response.status_code == 413

--- a/src/tests/unit/helpers/test_eventarc_receiver.py
+++ b/src/tests/unit/helpers/test_eventarc_receiver.py
@@ -65,6 +65,8 @@ async def test_receiver_runs_fenced_pubsub_delivery(monkeypatch: "pytest.MonkeyP
     service = QueueService(config, queue_backend=InMemoryQueueBackend())
     app = create_eventarc_receiver(queue_service=service, topic=TOPIC)
 
+    assert app.request_max_body_size == 64 * 1024
+
     async with AsyncTestClient(app=app) as client:
         response = await client.post("/eventarc/pubsub", **_delivery(task_id, attempt))
 

--- a/src/tests/unit/helpers/test_eventarc_receiver.py
+++ b/src/tests/unit/helpers/test_eventarc_receiver.py
@@ -1,0 +1,142 @@
+from base64 import b64encode
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from litestar.testing import AsyncTestClient
+
+from litestar_queues import QueueConfig, QueueService, WorkerConfig, task
+from litestar_queues.backends import InMemoryQueueBackend
+from litestar_queues.consumer import TaskExitCode
+from tests.helpers.eventarc_receiver import EVENT_TYPE, create_eventarc_receiver
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+pytestmark = pytest.mark.anyio
+
+TOPIC = "projects/test/topics/jobs"
+
+
+def _delivery(task_id: "object", attempt: "object", **overrides: "Any") -> "dict[str, Any]":
+    headers = {
+        "ce-id": "message-1",
+        "ce-source": f"//pubsub.googleapis.com/{TOPIC}",
+        "ce-specversion": "1.0",
+        "ce-type": EVENT_TYPE,
+        "ce-time": "2026-08-09T00:00:00Z",
+        "content-type": "application/json",
+    }
+    headers.update(overrides.pop("headers", {}))
+    body = {
+        "message": {
+            "data": b64encode(str(task_id).encode()).decode(),
+            "attributes": {"litestar_queues_attempt": attempt},
+            "messageId": "message-1",
+            "publishTime": "2026-08-09T00:00:00Z",
+        }
+    }
+    body.update(overrides.pop("body", {}))
+    return {"headers": headers, "json": body, **overrides}
+
+
+@asynccontextmanager
+async def _receiver_service() -> "AsyncGenerator[tuple[QueueService, InMemoryQueueBackend, AsyncTestClient], None]":
+    config = QueueConfig(
+        queue_backend="memory", execution_backend="cloudrun", worker=WorkerConfig(placement="external")
+    )
+    backend = InMemoryQueueBackend()
+    async with (
+        QueueService(config, queue_backend=backend) as service,
+        AsyncTestClient(app=create_eventarc_receiver(queue_service=service, topic=TOPIC)) as client,
+    ):
+        yield service, backend, client
+
+
+async def test_receiver_runs_fenced_pubsub_delivery(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    task_id = uuid4()
+    attempt = f"pubsub:2:123:{uuid4()}"
+    consume = AsyncMock(return_value=TaskExitCode.SUCCESS)
+    monkeypatch.setattr("tests.helpers.eventarc_receiver.consume_one", consume)
+    config = QueueConfig(queue_backend="memory", worker=WorkerConfig(placement="external"))
+    service = QueueService(config, queue_backend=InMemoryQueueBackend())
+    app = create_eventarc_receiver(queue_service=service, topic=TOPIC)
+
+    async with AsyncTestClient(app=app) as client:
+        response = await client.post("/eventarc/pubsub", **_delivery(task_id, attempt))
+
+    assert response.status_code == 204
+    consume.assert_awaited_once_with(
+        app.state.eventarc_queue_service, task_id, expected_retry_count=2, expected_execution_ref=attempt
+    )
+
+
+async def test_duplicate_delivery_executes_task_once() -> "None":
+    executions: "list[int]" = []
+
+    @task("tests.eventarc.duplicate")
+    async def delivered() -> "None":
+        executions.append(1)
+
+    attempt = f"pubsub:0:123:{uuid4()}"
+    async with _receiver_service() as (service, backend, client):
+        result = await service.enqueue(delivered.using(execution_backend="cloudrun"))
+        assert await backend.reserve_external_dispatch(result.id, "pubsub", attempt, expected_retry_count=0) is not None
+        first = await client.post("/eventarc/pubsub", **_delivery(result.id, attempt))
+        duplicate = await client.post("/eventarc/pubsub", **_delivery(result.id, attempt))
+
+    assert first.status_code == 204
+    assert duplicate.status_code == 204
+    assert executions == [1]
+
+
+@pytest.mark.parametrize("state", ["cancelled", "stale"])
+async def test_cancelled_or_stale_delivery_does_not_execute(state: "str") -> "None":
+    executions: "list[int]" = []
+
+    @task(f"tests.eventarc.{state}")
+    async def delivered() -> "None":
+        executions.append(1)
+
+    current = f"pubsub:0:123:{uuid4()}"
+    delivered_attempt = current
+    async with _receiver_service() as (service, backend, client):
+        result = await service.enqueue(delivered.using(execution_backend="cloudrun"))
+        assert await backend.reserve_external_dispatch(result.id, "pubsub", current, expected_retry_count=0) is not None
+        if state == "cancelled":
+            assert await service.cancel_task(result.id, include_running=True)
+        else:
+            delivered_attempt = f"pubsub:0:122:{uuid4()}"
+        response = await client.post("/eventarc/pubsub", **_delivery(result.id, delivered_attempt))
+
+    assert response.status_code == 204
+    assert executions == []
+
+
+@pytest.mark.parametrize(
+    "delivery",
+    [
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-specversion": "0.3"}),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-type": "wrong"}),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", headers={"ce-source": "//pubsub.googleapis.com/wrong"}),
+        _delivery(uuid4(), "missing-attempt"),
+        _delivery("not-a-uuid", f"pubsub:0:123:{uuid4()}"),
+        _delivery(uuid4(), f"pubsub:0:123:{uuid4()}", body={"unexpected": True}),
+    ],
+)
+async def test_malformed_delivery_is_rejected(delivery: "dict[str, Any]") -> "None":
+    async with _receiver_service() as (_service, _backend, client):
+        response = await client.post("/eventarc/pubsub", **delivery)
+
+    assert response.status_code == 400
+
+
+async def test_infrastructure_error_is_retryable(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    consume = AsyncMock(side_effect=ConnectionError("storage unavailable"))
+    monkeypatch.setattr("tests.helpers.eventarc_receiver.consume_one", consume)
+    async with _receiver_service() as (_service, _backend, client):
+        response = await client.post("/eventarc/pubsub", **_delivery(uuid4(), f"pubsub:0:123:{uuid4()}"))
+
+    assert response.status_code == 503

--- a/src/tests/unit/test_floci_gcp_provider_guard.py
+++ b/src/tests/unit/test_floci_gcp_provider_guard.py
@@ -1,0 +1,19 @@
+import importlib.util
+
+
+def test_remove_floci_gcp_shim_when_official_provider_is_available() -> "None":
+    assert importlib.util.find_spec("pytest_databases.docker.floci_gcp") is None, (
+        "pytest-databases now supplies pytest_databases.docker.floci_gcp; delete tests.plugins.floci_gcp "
+        "and register the upstream plugin instead."
+    )
+
+
+def test_floci_gcp_service_exposes_joined_emulator_contract() -> "None":
+    from tests.plugins.floci_gcp import FlociGcpService
+
+    assert FlociGcpService.__dataclass_fields__.keys() >= {
+        "project_id",
+        "resource_prefix",
+        "docker_host",
+        "capabilities",
+    }


### PR DESCRIPTION
## Summary

- add a temporary pinned Floci-GCP fixture while the pytest-databases provider is unreleased
- exercise Pub/Sub dispatch through Eventarc Standard binary CloudEvents into a Litestar receiver
- validate task IDs and dispatch attempts before calling the fenced single-task consumer
- cover duplicate, cancelled, stale, malformed, oversized, and infrastructure-failure deliveries

## Why

Floci-GCP now provides a real Pub/Sub-to-HTTP Eventarc delivery path. This adds an end-to-end compatibility topology without replacing the official Pub/Sub emulator or implying support for Eventarc Advanced and Cloud Run Jobs.

## Validation

- 31 focused Eventarc, Floci provider, joined delivery, and official Pub/Sub emulator tests passed
- `make lint`
  - mypy: 354 files, no issues
  - pyright: 0 errors
  - slotscheck and zizmor passed

## Notes

The HTTP bridge deliberately declines Floci's cleartext HTTP/2 upgrade while preserving and bounding the original HTTP/1 request. The fixture includes a removal guard for the future `pytest_databases.docker.floci_gcp` provider.
