### PR TITLE
feat: standalone events adoption surface

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,16 @@ Unreleased
 
 **Added:**
 
+* Event history stores the event actor and can filter on it.
+  ``QueueEventLogRecord`` carries ``actor_type`` and ``actor_id``, and
+  ``QueueEventLog.list_events()`` accepts ``actor_id=`` and ``actor_type=``,
+  ANDed with the task filters. The actor's display ``name`` is deliberately not
+  stored, because it is mutable text that would go stale against the event it
+  was stamped on, so it stays on the live event envelope. **Breaking:** the
+  event-history table gains ``actor_type`` and ``actor_id`` columns plus an
+  ``(actor_id, occurred_at)`` index, so the schema must be recreated; adopters
+  declaring their own event-history columns can no longer use those two names,
+  while ``actor`` is no longer reserved. See :doc:`usage/event-history`.
 * Google Cloud Pub/Sub is available as an optional execution backend through
   ``litestar-queues[pubsub]``. Dispatch publishes only the task UUID and an
   attempt fence; ``litestar queues run-consumer --backend pubsub`` processes

--- a/docs/usage/event-history.rst
+++ b/docs/usage/event-history.rst
@@ -157,6 +157,11 @@ Query it with the additive ``extra`` filter on the SQLSpec event log:
 undeclared key raises ``ValueError`` naming the declared columns, so the filter
 never reaches SQL unvalidated.
 
+A declared name must be a valid unquoted SQL identifier and must not collide
+with a column the package already owns. The names ``scope``, ``scope_key``,
+``actor``, and ``entity`` are also rejected: they are reserved for built-in
+scoping dimensions. The check ignores case, because unquoted SQL identifiers do.
+
 Three things to know:
 
 * Values are stored as text and read from the event payload. They stay in

--- a/docs/usage/event-history.rst
+++ b/docs/usage/event-history.rst
@@ -160,7 +160,11 @@ never reaches SQL unvalidated.
 A declared name must be a valid unquoted SQL identifier and must not collide
 with a column the package already owns. The names ``scope``, ``scope_key``,
 ``actor``, and ``entity`` are also rejected: they are reserved for built-in
-scoping dimensions. The check ignores case, because unquoted SQL identifiers do.
+scoping dimensions. Every name check — package-owned columns, reserved names,
+and duplicates between your own declarations — ignores case, because unquoted
+SQL identifiers fold case, so ``TASK_ID`` and ``task_id`` are one column to the
+database. A rejected declaration raises ``QueueConfigurationError`` when the
+config is built, rather than failing later against the database.
 
 Three things to know:
 

--- a/docs/usage/event-history.rst
+++ b/docs/usage/event-history.rst
@@ -78,6 +78,111 @@ Memory history is bounded by ``memory_capacity`` and disappears with the process
 SQLSpec, Advanced Alchemy, Redis, and Valkey history is durable or shared, so
 those deployments should include cleanup in their backup and privacy policies.
 
+Extra scoping dimensions
+========================
+
+Some deployments scope events by a dimension the queue does not model — a
+tenant, project, or account. There are two supported ways to handle that.
+
+Implement ``QueueEventLog`` yourself
+------------------------------------
+
+This is the supported path for arbitrary dimensions, custom indexes, or scoped
+aggregates. ``QueueEventLog`` is a ``Protocol``, so any object with the right
+methods satisfies it — no subclassing and no package change:
+
+.. code-block:: python
+
+   from datetime import datetime
+
+   from litestar_queues.events import QueueEvent, QueueEventLogRecord, QueueEventStageSummary
+
+
+   class TenantEventLog:
+       def __init__(self, tenant_id: str) -> None:
+           self.tenant_id = tenant_id
+
+       async def publish_event(self, event: QueueEvent) -> None:
+           ...  # write the event with your own tenant column and indexes
+
+       async def flush_events(self) -> None:
+           ...
+
+       async def list_events(
+           self, *, task_id=None, task_name=None, limit=None
+       ) -> list[QueueEventLogRecord]:
+           ...  # your own query surface, scoped however you need
+
+       async def summarize_stages(self, *, task_name=None) -> list[QueueEventStageSummary]:
+           ...
+
+       async def cleanup_before(self, before: datetime, *, limit=None) -> int:
+           ...
+
+You own the storage, the schema, and the query API, and you can expose scoped
+aggregates the built-in store does not.
+
+Declaring extra columns on the built-in SQLSpec store
+------------------------------------------------------
+
+If you want to keep the built-in SQLSpec store and only need indexed, filterable
+columns, declare them on the backend config:
+
+.. code-block:: python
+
+   from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig
+
+   backend_config = SQLSpecBackendConfig(
+       sqlspec_config=sqlspec_config,
+       event_history_extra_columns=(
+           EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),
+       ),
+   )
+
+Each declaration adds one column to the event-history table. ``source`` is the
+key read from the event payload, so publishing carries the value automatically:
+
+.. code-block:: python
+
+   await publish_task_log("importing", payload={"tenant_id": "acme"})
+
+Query it with the additive ``extra`` filter on the SQLSpec event log:
+
+.. code-block:: python
+
+   event_log = backend.get_event_log(history_config)
+   records = await event_log.list_events(extra={"tenant_id": "acme"})
+
+``extra`` uses equality and is ANDed with ``task_id`` and ``task_name``. An
+undeclared key raises ``ValueError`` naming the declared columns, so the filter
+never reaches SQL unvalidated.
+
+Three things to know:
+
+* Values are stored as text and read from the event payload. They stay in
+  ``detail`` too — the column is an indexable, filterable copy, and ``detail``
+  remains the complete record.
+* The ``extra`` filter lives on the concrete SQLSpec event log, not on the
+  ``QueueEventLog`` protocol. Code holding the protocol type sees the unchanged
+  signature; code that filters holds the concrete store from
+  ``SQLSpecQueueBackend.get_event_log()``.
+* ``summarize_stages`` does not accept the filter. Scoped aggregates are a
+  reason to implement the protocol instead.
+
+Both the managed schema and the packaged migration emit the same DDL for
+declared columns, so a migrated database and a backend-created one match.
+
+Choosing between them
+---------------------
+
+Extra columns give you indexed, filterable, authorization-pushdown-capable
+dimensions with no protocol churn — but only equality filtering, only text
+values, and only on the concrete SQLSpec store. Implementing ``QueueEventLog``
+costs more code and gives you everything: any number of dimensions, any types,
+your own indexes, and your own query and aggregate surface. Start with the
+columns if a tenant id and an equality filter is the whole requirement; move to
+the protocol when it is not.
+
 History versus live delivery
 ============================
 

--- a/docs/usage/event-history.rst
+++ b/docs/usage/event-history.rst
@@ -48,10 +48,42 @@ Support matrix
 Query and cleanup
 =================
 
-Use ``QueueEventLog`` to find events by task ID or task name, review stages,
-flush pending writes, and delete old records. Choose retention rules that fit
-your audit and privacy needs. Deleting finished task records does not delete
-event history, and vice versa.
+Use ``QueueEventLog`` to find events by task ID, task name, or actor, review
+stages, flush pending writes, and delete old records. Choose retention rules
+that fit your audit and privacy needs. Deleting finished task records does not
+delete event history, and vice versa.
+
+Filtering by actor
+==================
+
+An event may carry a ``QueueEventActor`` naming who or what caused it. History
+stores the actor's ``type`` and ``id`` and lets you filter on either:
+
+.. code-block:: python
+
+   from litestar_queues.events import QueueEvent, QueueEventActor
+
+   await publisher.publish(
+       QueueEvent(
+           type="task.log",
+           scope="task",
+           task_id=task_id,
+           message="importing",
+           actor=QueueEventActor(type="user", id="u-1", name="Alice"),
+       )
+   )
+
+   records = await event_log.list_events(actor_id="u-1")
+   service_records = await event_log.list_events(actor_type="service", task_name="tasks.import")
+
+Filters use equality and are ANDed together. Every backend stores the actor and
+answers the filter; the SQLSpec and Advanced Alchemy tables index
+``(actor_id, occurred_at)`` to match the time-ordered read pattern.
+
+The actor's ``name`` is not stored. It is mutable display text that would go
+stale against the event it was stamped on, so it travels on the live event
+envelope only. Resolve names from your own user or service directory when you
+render history.
 
 Configure a bounded event-history phase and run it from one external schedule:
 
@@ -109,7 +141,7 @@ methods satisfies it — no subclassing and no package change:
            ...
 
        async def list_events(
-           self, *, task_id=None, task_name=None, limit=None
+           self, *, task_id=None, task_name=None, actor_id=None, actor_type=None, limit=None
        ) -> list[QueueEventLogRecord]:
            ...  # your own query surface, scoped however you need
 
@@ -153,14 +185,15 @@ Query it with the additive ``extra`` filter on the SQLSpec event log:
    event_log = backend.get_event_log(history_config)
    records = await event_log.list_events(extra={"tenant_id": "acme"})
 
-``extra`` uses equality and is ANDed with ``task_id`` and ``task_name``. An
+``extra`` uses equality and is ANDed with the built-in ``task_id``,
+``task_name``, ``actor_id``, and ``actor_type`` filters. An
 undeclared key raises ``ValueError`` naming the declared columns, so the filter
 never reaches SQL unvalidated.
 
 A declared name must be a valid unquoted SQL identifier and must not collide
-with a column the package already owns. The names ``scope``, ``scope_key``,
-``actor``, and ``entity`` are also rejected: they are reserved for built-in
-scoping dimensions. Every name check — package-owned columns, reserved names,
+with a column the package already owns — including ``actor_type`` and
+``actor_id``. The names ``scope``, ``scope_key``, and ``entity`` are also
+rejected: they are reserved for built-in scoping dimensions. Every name check — package-owned columns, reserved names,
 and duplicates between your own declarations — ignores case, because unquoted
 SQL identifiers fold case, so ``TASK_ID`` and ``task_id`` are one column to the
 database. A rejected declaration raises ``QueueConfigurationError`` when the

--- a/docs/usage/events-standalone.rst
+++ b/docs/usage/events-standalone.rst
@@ -1,0 +1,95 @@
+==========================
+Events without the queue
+==========================
+
+.. note::
+
+   This page is only for runtimes that never run this package's worker. If you
+   enqueue work with ``@task`` and a queue backend, none of this applies:
+   publishing is the one-line call in :doc:`events`, and the service binds a
+   context for you before it calls your task body. Constructing a
+   ``TaskExecutionContext`` by hand there would shadow the real one.
+
+``litestar_queues.events`` works on its own. It needs only ``litestar`` and
+``typing_extensions``: no queue backend, no worker, and no queue record. A
+runtime that already has its own task runner can bind a task context and use
+the same event surface the package's own worker uses, rather than reimplementing
+the envelope, the sinks, and the chunking.
+
+Binding a task context
+======================
+
+``bind_task_context()`` binds a :class:`~litestar_queues.events.TaskExecutionContext`
+for the duration of a ``with`` block. While it is bound,
+``get_current_task_context()`` and the module-level publish helpers resolve to
+it. Setting a context variable is synchronous, so one plain ``with`` block works
+inside both sync and async task bodies:
+
+.. code-block:: python
+
+   import asyncio
+
+   from litestar_queues.events import (
+       InMemoryQueueEventSink,
+       QueueEventPublisher,
+       TaskExecutionContext,
+       bind_task_context,
+   )
+
+
+   async def main() -> None:
+       sink = InMemoryQueueEventSink()
+       publisher = QueueEventPublisher(sink)
+       context = TaskExecutionContext(
+           task_id="import-42",
+           task_name="catalog.import",
+           queue="default",
+           worker_id="runner-1",
+           execution_backend="external",
+           execution_profile=None,
+           attempt=1,
+           event_publisher=publisher,
+       )
+
+       with bind_task_context(context) as ctx:
+           await ctx.progress(current=12, total=400, message="loading")
+
+       print([event.type for event in sink.events])
+
+
+   asyncio.run(main())
+
+Receiving beats
+===============
+
+``bind_beat_sink()`` binds the receiver for ``ctx.beat(detail)``, the optional
+last-value-wins diagnostic detail. Implement
+:class:`~litestar_queues.events.TaskBeatSink` to receive it:
+
+.. code-block:: python
+
+   from litestar_queues.events import TaskBeatSink, bind_beat_sink
+
+
+   class LastBeat(TaskBeatSink):
+       def __init__(self) -> None:
+           self.detail: str | None = None
+
+       def record_beat(self, task_id: str, detail: str | None) -> None:
+           self.detail = detail
+
+
+   beats = LastBeat()
+   with bind_task_context(context), bind_beat_sink(beats):
+       context.beat("row 30000")
+
+Cancellation
+============
+
+Durable cancellation fan-in stays internal: the package's own worker binds it
+when it owns the queue record. An external runtime cancels through its own
+mechanism and can still surface that to task code by calling
+``context.mark_cancelled()``.
+
+For durable, queryable history — including extra scoping dimensions such as a
+tenant or project id — see :doc:`event-history`.

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -146,6 +146,85 @@ Code outside a worker should use this context manager:
 The context manager opens the resource, starts it, flushes pending events, and
 closes it. ``QueueEventProducer`` does not manage resources by itself.
 
+Standalone adoption
+===================
+
+``litestar_queues.events`` works on its own. It needs only ``litestar`` and
+``typing_extensions``: no queue backend, no worker, and no queue record. A
+runtime that already has its own task runner can bind a task context and use
+the same event surface the package's own worker uses.
+
+``bind_task_context()`` binds a :class:`~litestar_queues.events.TaskExecutionContext`
+for the duration of a ``with`` block. While it is bound,
+``get_current_task_context()`` and the module-level publish helpers resolve to
+it. Setting a context variable is synchronous, so one plain ``with`` block works
+inside both sync and async task bodies:
+
+.. code-block:: python
+
+   import asyncio
+
+   from litestar_queues.events import (
+       InMemoryQueueEventSink,
+       QueueEventPublisher,
+       TaskExecutionContext,
+       bind_task_context,
+       publish_task_progress,
+   )
+
+
+   async def main() -> None:
+       sink = InMemoryQueueEventSink()
+       publisher = QueueEventPublisher(sink)
+       context = TaskExecutionContext(
+           task_id="import-42",
+           task_name="catalog.import",
+           queue="default",
+           worker_id="runner-1",
+           execution_backend="external",
+           execution_profile=None,
+           attempt=1,
+           event_publisher=publisher,
+       )
+
+       with bind_task_context(context) as ctx:
+           await ctx.progress(current=12, total=400, message="loading")
+           await publish_task_progress(current=13, total=400)
+
+       print([event.type for event in sink.events])
+
+
+   asyncio.run(main())
+
+``bind_beat_sink()`` binds the receiver for ``ctx.beat(detail)``, the optional
+last-value-wins diagnostic detail. Implement
+:class:`~litestar_queues.events.TaskBeatSink` to receive it:
+
+.. code-block:: python
+
+   from litestar_queues.events import TaskBeatSink, bind_beat_sink
+
+
+   class LastBeat(TaskBeatSink):
+       def __init__(self) -> None:
+           self.detail: str | None = None
+
+       def record_beat(self, task_id: str, detail: str | None) -> None:
+           self.detail = detail
+
+
+   beats = LastBeat()
+   with bind_task_context(context), bind_beat_sink(beats):
+       context.beat("row 30000")
+
+Durable cancellation fan-in stays internal: the package's own worker binds it
+when it owns the queue record. An external runtime cancels through its own
+mechanism and can still surface that to task code by calling
+``context.mark_cancelled()``.
+
+For durable, queryable history — including extra scoping dimensions such as a
+tenant or project id — see :doc:`event-history`.
+
 Topology and security
 =====================
 
@@ -172,6 +251,7 @@ Next steps
 ==========
 
 * :doc:`event-streams` exposes SSE and WebSocket endpoints.
-* :doc:`event-history` retains backend-managed history.
+* :doc:`event-history` retains backend-managed history and adds extra scoping
+  dimensions such as a tenant id.
 * :doc:`event-testing` tests delivery without external infrastructure.
 * :doc:`../examples/index` runs the canonical visual examples.

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -103,9 +103,32 @@ optional, last-value-wins detail update for the next heartbeat write; it is not
 a liveness requirement and does not publish a task event by itself.
 
 The active task context adds the task ID, task name, queue, worker ID, attempt,
-execution backend, and sequence. Use ``publish_task_event()`` for a custom
-event type. Accept ``_task_context`` when you prefer to call the context
-methods directly.
+execution backend, and sequence.
+
+A running task never has to bind that context. The service binds it before it
+calls the task body, so the module-level helpers resolve it on their own:
+
+.. code-block:: python
+
+   from litestar_queues import task
+   from litestar_queues.events import publish_task_progress
+
+
+   @task("catalog.import")
+   async def import_catalog() -> None:
+       await publish_task_progress(current=13, total=400)
+
+Each helper is a pass-through to the context method of the same name, so
+``publish_task_progress(...)`` and ``ctx.progress(...)`` do the same work.
+Prefer the context method in a task body, where the context is already in hand.
+Reach for a helper in a function further down the call stack, so it can report
+progress without threading ``ctx`` through every signature in between. A helper
+raises :exc:`RuntimeError` when no context is bound.
+
+Context injection is keyed on the parameter **name** ``_task_context``, not on
+its type annotation: a parameter annotated ``TaskExecutionContext`` under any
+other name receives nothing. A task declaring ``**kwargs`` also receives the
+context under that key.
 
 Keep payloads small and JSON-serializable. Put large files, crawled documents,
 and model artifacts in external storage and send a stable reference in the
@@ -154,6 +177,13 @@ Standalone adoption
 runtime that already has its own task runner can bind a task context and use
 the same event surface the package's own worker uses.
 
+.. note::
+
+   This section is only for runtimes that never run this package's worker.
+   Inside a task, the service has already bound a context, and publishing is
+   the one-line call shown in `Publish from a task`_. Constructing a
+   ``TaskExecutionContext`` by hand there would replace the real one.
+
 ``bind_task_context()`` binds a :class:`~litestar_queues.events.TaskExecutionContext`
 for the duration of a ``with`` block. While it is bound,
 ``get_current_task_context()`` and the module-level publish helpers resolve to
@@ -169,7 +199,6 @@ inside both sync and async task bodies:
        QueueEventPublisher,
        TaskExecutionContext,
        bind_task_context,
-       publish_task_progress,
    )
 
 
@@ -189,7 +218,6 @@ inside both sync and async task bodies:
 
        with bind_task_context(context) as ctx:
            await ctx.progress(current=12, total=400, message="loading")
-           await publish_task_progress(current=13, total=400)
 
        print([event.type for event in sink.events])
 

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -169,86 +169,13 @@ Code outside a worker should use this context manager:
 The context manager opens the resource, starts it, flushes pending events, and
 closes it. ``QueueEventProducer`` does not manage resources by itself.
 
-Standalone adoption
-===================
+Using events without the queue
+==============================
 
-``litestar_queues.events`` works on its own. It needs only ``litestar`` and
-``typing_extensions``: no queue backend, no worker, and no queue record. A
-runtime that already has its own task runner can bind a task context and use
-the same event surface the package's own worker uses.
-
-.. note::
-
-   This section is only for runtimes that never run this package's worker.
-   Inside a task, the service has already bound a context, and publishing is
-   the one-line call shown in `Publish from a task`_. Constructing a
-   ``TaskExecutionContext`` by hand there would replace the real one.
-
-``bind_task_context()`` binds a :class:`~litestar_queues.events.TaskExecutionContext`
-for the duration of a ``with`` block. While it is bound,
-``get_current_task_context()`` and the module-level publish helpers resolve to
-it. Setting a context variable is synchronous, so one plain ``with`` block works
-inside both sync and async task bodies:
-
-.. code-block:: python
-
-   import asyncio
-
-   from litestar_queues.events import (
-       InMemoryQueueEventSink,
-       QueueEventPublisher,
-       TaskExecutionContext,
-       bind_task_context,
-   )
-
-
-   async def main() -> None:
-       sink = InMemoryQueueEventSink()
-       publisher = QueueEventPublisher(sink)
-       context = TaskExecutionContext(
-           task_id="import-42",
-           task_name="catalog.import",
-           queue="default",
-           worker_id="runner-1",
-           execution_backend="external",
-           execution_profile=None,
-           attempt=1,
-           event_publisher=publisher,
-       )
-
-       with bind_task_context(context) as ctx:
-           await ctx.progress(current=12, total=400, message="loading")
-
-       print([event.type for event in sink.events])
-
-
-   asyncio.run(main())
-
-``bind_beat_sink()`` binds the receiver for ``ctx.beat(detail)``, the optional
-last-value-wins diagnostic detail. Implement
-:class:`~litestar_queues.events.TaskBeatSink` to receive it:
-
-.. code-block:: python
-
-   from litestar_queues.events import TaskBeatSink, bind_beat_sink
-
-
-   class LastBeat(TaskBeatSink):
-       def __init__(self) -> None:
-           self.detail: str | None = None
-
-       def record_beat(self, task_id: str, detail: str | None) -> None:
-           self.detail = detail
-
-
-   beats = LastBeat()
-   with bind_task_context(context), bind_beat_sink(beats):
-       context.beat("row 30000")
-
-Durable cancellation fan-in stays internal: the package's own worker binds it
-when it owns the queue record. An external runtime cancels through its own
-mechanism and can still surface that to task code by calling
-``context.mark_cancelled()``.
+The ``litestar_queues.events`` subpackage also runs on its own, for a runtime
+that has its own task runner and never starts this package's worker. That is a
+separate integration path with its own setup — see
+:doc:`events-standalone`. Nothing on this page requires it.
 
 For durable, queryable history — including extra scoping dimensions such as a
 tenant or project id — see :doc:`event-history`.

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -158,6 +158,7 @@ Choose production options
    event-streams
    event-history
    event-testing
+   events-standalone
    observability
    dependency-resolver
    deployment/cloud-run

--- a/src/litestar_queues/backends/advanced_alchemy/event_log.py
+++ b/src/litestar_queues/backends/advanced_alchemy/event_log.py
@@ -76,12 +76,20 @@ class AdvancedAlchemyQueueEventLog:
             self._last_flush = time.monotonic()
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return durable event history records."""
         await self.flush_events()
         async with self._service_factory() as service:
-            return await service.list_events(task_id=task_id, task_name=task_name, limit=limit)
+            return await service.list_events(
+                task_id=task_id, task_name=task_name, actor_id=actor_id, actor_type=actor_type, limit=limit
+            )
 
     async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":
         """Return no aggregate summaries for the Advanced Alchemy event log."""

--- a/src/litestar_queues/backends/advanced_alchemy/mixins.py
+++ b/src/litestar_queues/backends/advanced_alchemy/mixins.py
@@ -147,6 +147,7 @@ class QueueEventHistoryModelMixin:
             Index(f"ix_{table}_task_id", "task_id", "sequence", "occurred_at"),
             Index(f"ix_{table}_task_name", "task_name", "occurred_at"),
             Index(f"ix_{table}_event_type", "event_type", "occurred_at"),
+            Index(f"ix_{table}_actor_id", "actor_id", "occurred_at"),
             Index(f"ix_{table}_occurred_at", "occurred_at"),
         )
 
@@ -180,6 +181,14 @@ class QueueEventHistoryModelMixin:
 
     @declared_attr
     def execution_profile(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=255), default=None)
+
+    @declared_attr
+    def actor_type(cls) -> "Mapped[str | None]":
+        return mapped_column(String(length=255), default=None)
+
+    @declared_attr
+    def actor_id(cls) -> "Mapped[str | None]":
         return mapped_column(String(length=255), default=None)
 
     @declared_attr

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -76,7 +76,13 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
         self.repository.session.add_all([self.model_from_record(record) for record in records])
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return matching event-history records in ascending event order."""
         model_type = self.model_type
@@ -85,6 +91,10 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
             criteria.append(model_type.task_id == task_id)
         if task_name is not None:
             criteria.append(model_type.task_name == task_name)
+        if actor_id is not None:
+            criteria.append(model_type.actor_id == actor_id)
+        if actor_type is not None:
+            criteria.append(model_type.actor_type == actor_type)
         statement = select(model_type)
         if criteria:
             statement = statement.where(*criteria)
@@ -136,6 +146,8 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
             worker_id=record.worker_id,
             execution_backend=record.execution_backend,
             execution_profile=record.execution_profile,
+            actor_type=record.actor_type,
+            actor_id=record.actor_id,
             level=record.level,
             message=record.message,
             detail_json=_serialize_json(record.detail),
@@ -166,6 +178,8 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
             worker_id=cast("str | None", model.worker_id),
             execution_backend=cast("str | None", model.execution_backend),
             execution_profile=cast("str | None", model.execution_profile),
+            actor_type=cast("str | None", model.actor_type),
+            actor_id=cast("str | None", model.actor_id),
             stage=optional_str(detail.get("stage")),
             level=cast("str | None", model.level),
             message=cast("str | None", model.message),

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -230,10 +230,11 @@ class BaseQueueBackend:
     async def notify_worker_control(self, worker_id: "str | None") -> "None":
         """Publish a best-effort worker-control hint.
 
-        ``worker_id`` is the record's persisted owner when the backend tracks
-        one, and ``None`` otherwise. It travels for observability only: the
-        control channel is shared and every subscribed worker reconciles its
-        own running tasks against durable status on receipt.
+        ``worker_id`` is the record's persisted owner, or ``None`` when the
+        record was cancelled before any worker claimed it. It travels for
+        observability only: the control channel is shared and every subscribed
+        worker reconciles its own running tasks against durable status on
+        receipt.
 
         Worker-control hints are lossy: durable status remains authoritative,
         and a dropped hint costs cancellation latency, never correctness.

--- a/src/litestar_queues/backends/ephemeral/codec.py
+++ b/src/litestar_queues/backends/ephemeral/codec.py
@@ -77,6 +77,8 @@ _EVENT_FIELDS = (
     "worker_id",
     "execution_backend",
     "execution_profile",
+    "actor_type",
+    "actor_id",
     "stage",
     "level",
     "message",

--- a/src/litestar_queues/backends/ephemeral/event_log.py
+++ b/src/litestar_queues/backends/ephemeral/event_log.py
@@ -65,7 +65,13 @@ class EphemeralQueueEventLog:
         """
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return matching event records in ascending event order.
 
@@ -86,6 +92,12 @@ class EphemeralQueueEventLog:
             return [event_from_payload(row["payload"]) for row in rows]
 
         records: "list[QueueEventLogRecord]" = await self._backend._run(operation)  # noqa: SLF001
+        # The actor lives in the encoded payload rather than its own indexed
+        # column, so it is matched after decoding. The table is capacity-bounded.
+        if actor_id is not None:
+            records = [record for record in records if record.actor_id == actor_id]
+        if actor_type is not None:
+            records = [record for record in records if record.actor_type == actor_type]
         records.sort(key=event_log_record_sort_key)
         return records[:limit] if limit is not None else records
 

--- a/src/litestar_queues/backends/memory/event_log.py
+++ b/src/litestar_queues/backends/memory/event_log.py
@@ -39,7 +39,13 @@ class InMemoryQueueEventLog:
         """
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return matching event history records in ascending event order."""
         async with self._lock:
@@ -48,6 +54,8 @@ class InMemoryQueueEventLog:
                 for record in self._records
                 if (task_id is None or record.task_id == task_id)
                 and (task_name is None or record.task_name == task_name)
+                and (actor_id is None or record.actor_id == actor_id)
+                and (actor_type is None or record.actor_type == actor_type)
             ]
         records.sort(key=event_log_record_sort_key)
         return records[:limit] if limit is not None else records

--- a/src/litestar_queues/backends/redis/event_log.py
+++ b/src/litestar_queues/backends/redis/event_log.py
@@ -71,7 +71,13 @@ class RedisQueueEventLog:
             self._last_flush = time.monotonic()
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return durable event history records."""
         await self.flush_events()
@@ -82,7 +88,10 @@ class RedisQueueEventLog:
         records = [
             record
             for record in records
-            if (task_id is None or record.task_id == task_id) and (task_name is None or record.task_name == task_name)
+            if (task_id is None or record.task_id == task_id)
+            and (task_name is None or record.task_name == task_name)
+            and (actor_id is None or record.actor_id == actor_id)
+            and (actor_type is None or record.actor_type == actor_type)
         ]
         records.sort(key=event_log_record_sort_key)
         return records[:limit] if limit is not None else records
@@ -178,6 +187,8 @@ class RedisQueueEventLog:
             "worker_id": record.worker_id or "",
             "execution_backend": record.execution_backend or "",
             "execution_profile": record.execution_profile or "",
+            "actor_type": record.actor_type or "",
+            "actor_id": record.actor_id or "",
             "level": record.level or "",
             "message": record.message or "",
             "detail": _json_dumps(record.detail),
@@ -230,6 +241,8 @@ def _record_from_mapping(mapping: "dict[str, Any]") -> "QueueEventLogRecord":
         worker_id=_optional_mapping_str(mapping.get("worker_id")),
         execution_backend=_optional_mapping_str(mapping.get("execution_backend")),
         execution_profile=_optional_mapping_str(mapping.get("execution_profile")),
+        actor_type=_optional_mapping_str(mapping.get("actor_type")),
+        actor_id=_optional_mapping_str(mapping.get("actor_id")),
         stage=optional_str(detail.get("stage")),
         level=_optional_mapping_str(mapping.get("level")),
         message=_optional_mapping_str(mapping.get("message")),

--- a/src/litestar_queues/backends/sqlspec/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/__init__.py
@@ -3,8 +3,10 @@
 from litestar_queues.backends.sqlspec.backend import SQLSpecQueueBackend
 from litestar_queues.backends.sqlspec.config import SQLSpecBackendConfig, SQLSpecWorkerWakeupConfig
 from litestar_queues.backends.sqlspec.extension import configure_queue_migration_extension
+from litestar_queues.backends.sqlspec.schema import EventHistoryExtraColumn
 
 __all__ = (
+    "EventHistoryExtraColumn",
     "SQLSpecBackendConfig",
     "SQLSpecQueueBackend",
     "SQLSpecWorkerWakeupConfig",

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -42,6 +42,7 @@ from litestar_queues.backends.sqlspec.reservation import create_task_reservation
 from litestar_queues.backends.sqlspec.schema import (
     DEFAULT_TABLE_NAME,
     resolve_column_map,
+    validate_event_history_extra_columns,
     validate_native_json_columns,
     validate_table_name,
 )
@@ -133,6 +134,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         "_control_pending_read",
         "_control_stream",
         "_event_channel",
+        "_event_history_extra_columns",
         "_event_history_table_name",
         "_event_log",
         "_event_log_store",
@@ -197,6 +199,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             validate_table_name(backend_config.event_history_table_name)
             if backend_config.event_history_table_name is not None
             else None
+        )
+        self._event_history_extra_columns = validate_event_history_extra_columns(
+            backend_config.event_history_extra_columns
         )
         self._maintenance_table_name = (
             validate_table_name(backend_config.maintenance_table_name)
@@ -2121,6 +2126,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 queue_table_name=self._resolve_queue_table_name(),
                 event_history_table_name=self._event_history_table_name,
                 manage_schema=self._manage_schema,
+                extra_columns=self._event_history_extra_columns,
             )
             self._event_history_table_name = store.table_name
             self._event_log_store = store

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from litestar_queues.backends.sqlspec.schema import (
+    EventHistoryExtraColumn,
     resolve_column_map,
+    validate_event_history_extra_columns,
     validate_native_json_columns,
     validate_table_name,
 )
@@ -99,6 +101,9 @@ class SQLSpecBackendConfig:
     event_history_table_name: "str | None" = None
     """Task-event history table name; ``None`` derives it from the queue-task table."""
 
+    event_history_extra_columns: "tuple[EventHistoryExtraColumn, ...]" = ()
+    """Adopter-declared extra scoping columns on the event-history table."""
+
     maintenance_table_name: "str | None" = None
     """Maintenance coordination table name; ``None`` derives the package default."""
 
@@ -124,6 +129,7 @@ class SQLSpecBackendConfig:
             self.maintenance_table_name = validate_table_name(self.maintenance_table_name)
         if self.task_reservation_table_name is not None:
             self.task_reservation_table_name = validate_table_name(self.task_reservation_table_name)
+        self.event_history_extra_columns = validate_event_history_extra_columns(self.event_history_extra_columns)
         self.column_map = resolve_column_map(self.column_map)
         self.native_json_columns = validate_native_json_columns(frozenset(self.native_json_columns))
 
@@ -169,6 +175,7 @@ class SQLSpecBackendConfig:
             queue_table_name=str(queue_table_name),
             event_history_enabled=event_log_config is not None,
             event_history_table_name=self.event_history_table_name,
+            event_history_extra_columns=self.event_history_extra_columns,
             maintenance_table_name=self.maintenance_table_name,
             task_reservation_table_name=self.task_reservation_table_name,
         )

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -87,6 +87,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 if column.indexed
             ),
             self._to_sql(sql.drop_index(self._index_name("occurred_at")).if_exists()),
+            self._to_sql(sql.drop_index(self._index_name("actor_id")).if_exists()),
             self._to_sql(sql.drop_index(self._index_name("task_name")).if_exists()),
             self._to_sql(sql.drop_index(self._index_name("task_id")).if_exists()),
             self._to_sql(sql.drop_table(self.table_name).if_exists()),
@@ -104,6 +105,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         *,
         task_id: "str | None" = None,
         task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
         limit: "int | None" = None,
         extra: "Mapping[str, str] | None" = None,
     ) -> "Select":
@@ -118,6 +121,10 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
             statement = statement.where_eq("task_id", task_id)
         if task_name is not None:
             statement = statement.where_eq("task_name", task_name)
+        if actor_id is not None:
+            statement = statement.where_eq("actor_id", actor_id)
+        if actor_type is not None:
+            statement = statement.where_eq("actor_type", actor_type)
         for name, value in filters:
             statement = statement.where_eq(name, value)
         statement = statement.order_by(
@@ -207,6 +214,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
             .column("worker_id", self._indexed_text_type())
             .column("execution_backend", self._indexed_text_type())
             .column("execution_profile", self._indexed_text_type())
+            .column("actor_type", self._indexed_text_type())
+            .column("actor_id", self._indexed_text_type())
             .column("stage", self._indexed_text_type())
             .column("level", self._indexed_text_type())
             .column("message", self._text_type())
@@ -246,6 +255,13 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 .if_not_exists()
                 .on_table(self.table_name)
                 .columns("task_name", "stage", "occurred_at")
+            ),
+            self._to_sql(
+                sql
+                .create_index(self._index_name("actor_id"))
+                .if_not_exists()
+                .on_table(self.table_name)
+                .columns("actor_id", "occurred_at")
             ),
             self._to_sql(
                 sql
@@ -295,6 +311,8 @@ class SpannerQueueEventLogStore(SQLSpecQueueEventLogStore, SpannerQueueStore):
             f"{self._quote_identifier('worker_id')} {self._indexed_text_type()}",
             f"{self._quote_identifier('execution_backend')} {self._indexed_text_type()}",
             f"{self._quote_identifier('execution_profile')} {self._indexed_text_type()}",
+            f"{self._quote_identifier('actor_type')} {self._indexed_text_type()}",
+            f"{self._quote_identifier('actor_id')} {self._indexed_text_type()}",
             f"{self._quote_identifier('stage')} {self._indexed_text_type()}",
             f"{self._quote_identifier('level')} {self._indexed_text_type()}",
             f"{self._quote_identifier('message')} {self._text_type()}",
@@ -325,6 +343,10 @@ class SpannerQueueEventLogStore(SQLSpecQueueEventLogStore, SpannerQueueStore):
                 f"{self._quote_identifier('occurred_at')})"
             ),
             (
+                f"CREATE INDEX {self._quoted_index_name('actor_id')} ON {self._quoted_table_name()} "
+                f"({self._quote_identifier('actor_id')}, {self._quote_identifier('occurred_at')})"
+            ),
+            (
                 f"CREATE INDEX {self._quoted_index_name('occurred_at')} ON {self._quoted_table_name()} "
                 f"({self._quote_identifier('occurred_at')})"
             ),
@@ -347,6 +369,7 @@ class SpannerQueueEventLogStore(SQLSpecQueueEventLogStore, SpannerQueueStore):
                 if column.indexed
             ),
             f"DROP INDEX {self._quoted_index_name('occurred_at')}",
+            f"DROP INDEX {self._quoted_index_name('actor_id')}",
             f"DROP INDEX {self._quoted_index_name('task_name')}",
             f"DROP INDEX {self._quoted_index_name('task_id')}",
             f"DROP TABLE {self._quoted_table_name()}",
@@ -423,15 +446,16 @@ class SQLSpecQueueEventLog:
         *,
         task_id: "str | None" = None,
         task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
         limit: "int | None" = None,
         extra: "Mapping[str, str] | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return durable event history records.
 
         ``extra`` filters on adopter-declared event-history columns with
-        equality, ANDed with ``task_id`` and ``task_name``. It is additive on
-        this concrete store; the ``QueueEventLog`` protocol signature is
-        unchanged.
+        equality, ANDed with the package-owned filters. It is additive on this
+        concrete store; the ``QueueEventLog`` protocol signature is unchanged.
 
         Raises:
             ValueError: If ``extra`` names a column that was not declared.
@@ -439,7 +463,14 @@ class SQLSpecQueueEventLog:
         await self.flush_events()
         async with self._session_factory() as driver:
             rows = await driver.select(
-                self._store.select_events(task_id=task_id, task_name=task_name, limit=limit, extra=extra)
+                self._store.select_events(
+                    task_id=task_id,
+                    task_name=task_name,
+                    actor_id=actor_id,
+                    actor_type=actor_type,
+                    limit=limit,
+                    extra=extra,
+                )
             )
         return [self._record_from_row(cast("dict[str, Any]", row)) for row in rows]
 
@@ -497,6 +528,8 @@ class SQLSpecQueueEventLog:
             "worker_id": event.worker_id,
             "execution_backend": event.execution_backend,
             "execution_profile": event.execution_profile,
+            "actor_type": event.actor.type if event.actor is not None else None,
+            "actor_id": event.actor.id if event.actor is not None else None,
             "stage": _optional_str(detail.get("stage")),
             "level": event.level,
             "message": event.message,
@@ -523,6 +556,8 @@ class SQLSpecQueueEventLog:
             worker_id=cast("str | None", row["worker_id"]),
             execution_backend=cast("str | None", row["execution_backend"]),
             execution_profile=cast("str | None", row["execution_profile"]),
+            actor_type=cast("str | None", row["actor_type"]),
+            actor_id=cast("str | None", row["actor_id"]),
             stage=cast("str | None", row["stage"]),
             level=cast("str | None", row["level"]),
             message=cast("str | None", row["message"]),

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -9,18 +9,24 @@ from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec import sql
 
-from litestar_queues.backends.sqlspec.schema import event_history_table_name_for, validate_table_name
+from litestar_queues.backends.sqlspec.schema import (
+    EVENT_HISTORY_COLUMNS,
+    event_history_table_name_for,
+    validate_event_history_extra_columns,
+    validate_table_name,
+)
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore, _adapter_name
 from litestar_queues.backends.sqlspec.stores.spanner import SpannerQueueStore
 from litestar_queues.events.history import EventHistoryConfig, QueueEventLogRecord, QueueEventStageSummary
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Mapping, Sequence
     from contextlib import AbstractAsyncContextManager
 
     from sqlspec.builder import CreateIndex, CreateTable, Delete, DropIndex, DropTable, Select
 
     from litestar_queues.backends.sqlspec._typing import DatetimeParam, SQLSpecDriver, SQLSpecStoreConfig
+    from litestar_queues.backends.sqlspec.schema import EventHistoryExtraColumn
     from litestar_queues.events.models import QueueEvent
 
 __all__ = (
@@ -33,37 +39,36 @@ __all__ = (
 
 logger = logging.getLogger(__name__)
 
-_EVENT_COLUMNS = (
-    "event_id",
-    "event_type",
-    "task_id",
-    "task_name",
-    "queue",
-    "worker_id",
-    "execution_backend",
-    "execution_profile",
-    "stage",
-    "level",
-    "message",
-    "detail",
-    "progress_current",
-    "progress_total",
-    "progress_percent",
-    "duration_ms",
-    "sequence",
-    "occurred_at",
-    "created_at",
-)
-
 
 class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
     """SQLSpec statement store for backend-managed queue event history."""
 
-    __slots__ = ()
+    __slots__ = ("_extra_columns",)
 
-    def __init__(self, *args: "Any", **kwargs: "Any") -> "None":
+    def __init__(
+        self, *args: "Any", extra_columns: "Sequence[EventHistoryExtraColumn] | None" = None, **kwargs: "Any"
+    ) -> "None":
         super().__init__(*args, **kwargs)
         self._column_map = {}
+        self._extra_columns = validate_event_history_extra_columns(extra_columns or ())
+
+    @property
+    def extra_columns(self) -> "tuple[EventHistoryExtraColumn, ...]":
+        """Adopter-declared extra scoping columns on this event-history table."""
+        return self._extra_columns
+
+    def _all_columns(self) -> "tuple[str, ...]":
+        return (*EVENT_HISTORY_COLUMNS, *(column.name for column in self._extra_columns))
+
+    def _validated_extra_filter(self, extra: "Mapping[str, str] | None") -> "tuple[tuple[str, str], ...]":
+        if not extra:
+            return ()
+        declared = {column.name for column in self._extra_columns}
+        unknown = sorted(set(extra) - declared)
+        if unknown:
+            msg = f"Unknown event-history filter column(s) {unknown!r}; declared extra columns are {sorted(declared)!r}"
+            raise ValueError(msg)
+        return tuple((name, extra[name]) for name in extra)
 
     def create_statements(self) -> "list[str]":
         """Return statements that create the event-log table and indexes."""
@@ -76,6 +81,11 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         if not self._manage_schema:
             return []
         return [
+            *(
+                self._to_sql(sql.drop_index(self._index_name(column.name)).if_exists())
+                for column in reversed(self._extra_columns)
+                if column.indexed
+            ),
             self._to_sql(sql.drop_index(self._index_name("occurred_at")).if_exists()),
             self._to_sql(sql.drop_index(self._index_name("task_name")).if_exists()),
             self._to_sql(sql.drop_index(self._index_name("task_id")).if_exists()),
@@ -84,19 +94,32 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
 
     def insert_events_template(self) -> "str":
         """Return a parametrized batch INSERT template for event rows."""
-        columns = ", ".join(self._quote_identifier(column) for column in _EVENT_COLUMNS)
-        placeholders = ", ".join(f":{column}" for column in _EVENT_COLUMNS)
+        names = self._all_columns()
+        columns = ", ".join(self._quote_identifier(column) for column in names)
+        placeholders = ", ".join(f":{column}" for column in names)
         return f"INSERT INTO {self._quoted_table_name()} ({columns}) VALUES ({placeholders})"  # noqa: S608
 
     def select_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        limit: "int | None" = None,
+        extra: "Mapping[str, str] | None" = None,
     ) -> "Select":
-        """Return a SELECT for event-log records."""
-        statement = sql.select(*_EVENT_COLUMNS).from_(self.table_name)
+        """Return a SELECT for event-log records.
+
+        Raises:
+            ValueError: If ``extra`` names a column that was not declared.
+        """
+        filters = self._validated_extra_filter(extra)
+        statement = sql.select(*EVENT_HISTORY_COLUMNS).from_(self.table_name)
         if task_id is not None:
             statement = statement.where_eq("task_id", task_id)
         if task_name is not None:
             statement = statement.where_eq("task_name", task_name)
+        for name, value in filters:
+            statement = statement.where_eq(name, value)
         statement = statement.order_by(
             _raw_order("occurred_at ASC"), _raw_order("sequence ASC"), _raw_order("event_id ASC")
         )
@@ -172,7 +195,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return detail if isinstance(detail, dict) else {}
 
     def _create_event_table_statement(self) -> "CreateTable":
-        return (
+        statement = (
             sql
             .create_table(self.table_name)
             .if_not_exists()
@@ -196,6 +219,9 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
             .column("occurred_at", self._timestamp_type(), not_null=True)
             .column("created_at", self._timestamp_type(), not_null=True)
         )
+        for column in self._extra_columns:
+            statement = statement.column(column.name, self._indexed_text_type())
+        return statement
 
     def _create_event_table_sql(self) -> "str":
         rendered = self._to_sql(self._create_event_table_statement())
@@ -227,6 +253,17 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 .if_not_exists()
                 .on_table(self.table_name)
                 .columns("occurred_at")
+            ),
+            *(
+                self._to_sql(
+                    sql
+                    .create_index(self._index_name(column.name))
+                    .if_not_exists()
+                    .on_table(self.table_name)
+                    .columns(column.name, "occurred_at")
+                )
+                for column in self._extra_columns
+                if column.indexed
             ),
         ]
 
@@ -269,6 +306,7 @@ class SpannerQueueEventLogStore(SQLSpecQueueEventLogStore, SpannerQueueStore):
             f"{self._quote_identifier('sequence')} {self._integer_type()}",
             f"{self._quote_identifier('occurred_at')} {self._timestamp_type()} NOT NULL",
             f"{self._quote_identifier('created_at')} {self._timestamp_type()} NOT NULL",
+            *(f"{self._quote_identifier(column.name)} {self._indexed_text_type()}" for column in self._extra_columns),
         )
         column_sql = ",\n  ".join(columns)
         return [
@@ -290,6 +328,12 @@ class SpannerQueueEventLogStore(SQLSpecQueueEventLogStore, SpannerQueueStore):
                 f"CREATE INDEX {self._quoted_index_name('occurred_at')} ON {self._quoted_table_name()} "
                 f"({self._quote_identifier('occurred_at')})"
             ),
+            *(
+                f"CREATE INDEX {self._quoted_index_name(column.name)} ON {self._quoted_table_name()} "
+                f"({self._quote_identifier(column.name)}, {self._quote_identifier('occurred_at')})"
+                for column in self._extra_columns
+                if column.indexed
+            ),
         ]
 
     def drop_statements(self) -> "list[str]":
@@ -297,6 +341,11 @@ class SpannerQueueEventLogStore(SQLSpecQueueEventLogStore, SpannerQueueStore):
         if not self._manage_schema:
             return []
         return [
+            *(
+                f"DROP INDEX {self._quoted_index_name(column.name)}"
+                for column in reversed(self._extra_columns)
+                if column.indexed
+            ),
             f"DROP INDEX {self._quoted_index_name('occurred_at')}",
             f"DROP INDEX {self._quoted_index_name('task_name')}",
             f"DROP INDEX {self._quoted_index_name('task_id')}",
@@ -370,12 +419,28 @@ class SQLSpecQueueEventLog:
             self._last_flush = time.monotonic()
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        limit: "int | None" = None,
+        extra: "Mapping[str, str] | None" = None,
     ) -> "list[QueueEventLogRecord]":
-        """Return durable event history records."""
+        """Return durable event history records.
+
+        ``extra`` filters on adopter-declared event-history columns with
+        equality, ANDed with ``task_id`` and ``task_name``. It is additive on
+        this concrete store; the ``QueueEventLog`` protocol signature is
+        unchanged.
+
+        Raises:
+            ValueError: If ``extra`` names a column that was not declared.
+        """
         await self.flush_events()
         async with self._session_factory() as driver:
-            rows = await driver.select(self._store.select_events(task_id=task_id, task_name=task_name, limit=limit))
+            rows = await driver.select(
+                self._store.select_events(task_id=task_id, task_name=task_name, limit=limit, extra=extra)
+            )
         return [self._record_from_row(cast("dict[str, Any]", row)) for row in rows]
 
     async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":
@@ -423,7 +488,7 @@ class SQLSpecQueueEventLog:
 
     def _params_from_event(self, event: "QueueEvent") -> "dict[str, Any]":
         detail = dict(event.payload)
-        return {
+        params: "dict[str, Any]" = {
             "event_id": event.id,
             "event_type": event.type,
             "task_id": event.task_id,
@@ -444,6 +509,9 @@ class SQLSpecQueueEventLog:
             "occurred_at": self._datetime_serializer(event.occurred_at),
             "created_at": self._datetime_serializer(datetime.now(timezone.utc)),
         }
+        for column in self._store.extra_columns:
+            params[column.name] = _optional_str(detail.get(column.source))
+        return params
 
     def _record_from_row(self, row: "dict[str, Any]") -> "QueueEventLogRecord":
         return QueueEventLogRecord(
@@ -484,6 +552,7 @@ def create_event_log_store(
     queue_table_name: "str",
     event_history_table_name: "str | None" = None,
     manage_schema: "bool" = True,
+    extra_columns: "Sequence[EventHistoryExtraColumn]" = (),
 ) -> "SQLSpecQueueEventLogStore":
     """Create an event-log store for a SQLSpec adapter configuration.
 
@@ -497,6 +566,7 @@ def create_event_log_store(
             queue_table_name, event_history_table_name=event_history_table_name
         ),
         manage_schema=manage_schema,
+        extra_columns=extra_columns,
     )
 
 

--- a/src/litestar_queues/backends/sqlspec/extension.py
+++ b/src/litestar_queues/backends/sqlspec/extension.py
@@ -8,13 +8,16 @@ from litestar_queues.backends.sqlspec.schema import (
     maintenance_table_name_for,
     migration_directory,
     task_reservation_table_name_for,
+    validate_event_history_extra_columns,
     validate_table_name,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
     from litestar_queues.backends.sqlspec._typing import SQLSpecConfig
+    from litestar_queues.backends.sqlspec.schema import EventHistoryExtraColumn
 
 __all__ = (
     "QUEUE_EXTENSION_NAME",
@@ -58,6 +61,7 @@ def configure_queue_migration_extension(
     queue_table_name: "str" = DEFAULT_TABLE_NAME,
     event_history_enabled: "bool" = False,
     event_history_table_name: "str | None" = None,
+    event_history_extra_columns: "Sequence[EventHistoryExtraColumn]" = (),
     maintenance_table_name: "str | None" = None,
     task_reservation_table_name: "str | None" = None,
 ) -> "None":
@@ -67,6 +71,7 @@ def configure_queue_migration_extension(
         queue_table_name=queue_table_name,
         event_history_enabled=event_history_enabled,
         event_history_table_name=event_history_table_name,
+        event_history_extra_columns=event_history_extra_columns,
         maintenance_table_name=maintenance_table_name,
         task_reservation_table_name=task_reservation_table_name,
     )
@@ -87,6 +92,7 @@ def _configure_extension_settings(
     queue_table_name: "str",
     event_history_enabled: "bool" = False,
     event_history_table_name: "str | None" = None,
+    event_history_extra_columns: "Sequence[EventHistoryExtraColumn]" = (),
     maintenance_table_name: "str | None" = None,
     task_reservation_table_name: "str | None" = None,
 ) -> "dict[str, Any]":
@@ -97,6 +103,10 @@ def _configure_extension_settings(
         queue_settings["event_history_enabled"] = True
         queue_settings["event_history_table_name"] = validate_table_name(
             event_history_table_name or event_history_table_name_for(queue_table_name)
+        )
+        queue_settings["event_history_extra_columns"] = tuple(
+            {"name": column.name, "source": column.source, "indexed": column.indexed}
+            for column in validate_event_history_extra_columns(event_history_extra_columns)
         )
     queue_settings["maintenance_table_name"] = validate_table_name(
         maintenance_table_name or maintenance_table_name_for(queue_table_name)

--- a/src/litestar_queues/backends/sqlspec/migrations/0001_create_queue_tasks.py
+++ b/src/litestar_queues/backends/sqlspec/migrations/0001_create_queue_tasks.py
@@ -8,10 +8,12 @@ from litestar_queues.backends.sqlspec.event_log import create_event_log_store
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.backends.sqlspec.maintenance import create_maintenance_store
 from litestar_queues.backends.sqlspec.reservation import create_task_reservation_store
-from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME, validate_table_name
+from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME, EventHistoryExtraColumn, validate_table_name
 from litestar_queues.backends.sqlspec.stores.factory import create_queue_store
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from sqlspec.migrations.context import MigrationContext
 
     from litestar_queues.backends.sqlspec.event_log import SQLSpecQueueEventLogStore
@@ -60,11 +62,19 @@ def _load_event_log_store(context: "MigrationContext | None") -> "SQLSpecQueueEv
         return None
     configured_event_table = queue_settings.get("event_history_table_name")
     event_history_table_name = str(configured_event_table) if configured_event_table is not None else None
+    declared = queue_settings.get("event_history_extra_columns") or ()
+    extra_columns = tuple(
+        EventHistoryExtraColumn(
+            name=str(entry["name"]), source=str(entry["source"]), indexed=bool(entry.get("indexed", False))
+        )
+        for entry in cast("Sequence[Mapping[str, Any]]", declared)
+    )
     return create_event_log_store(
         config,
         queue_table_name=queue_table_name,
         event_history_table_name=event_history_table_name,
         manage_schema=bool(getattr(config, "manage_schema", True)),
+        extra_columns=extra_columns,
     )
 
 

--- a/src/litestar_queues/backends/sqlspec/schema.py
+++ b/src/litestar_queues/backends/sqlspec/schema.py
@@ -81,6 +81,8 @@ EVENT_HISTORY_COLUMNS = (
     "worker_id",
     "execution_backend",
     "execution_profile",
+    "actor_type",
+    "actor_id",
     "stage",
     "level",
     "message",
@@ -97,7 +99,7 @@ EVENT_HISTORY_COLUMNS = (
 
 _EVENT_HISTORY_COLUMN_NAMES = frozenset(EVENT_HISTORY_COLUMNS)
 
-RESERVED_EVENT_HISTORY_COLUMNS = frozenset({"actor", "entity", "scope", "scope_key"})
+RESERVED_EVENT_HISTORY_COLUMNS = frozenset({"entity", "scope", "scope_key"})
 """Names held for built-in event-history scoping dimensions.
 
 These are not columns on the table yet. They are reserved so an adopter-declared

--- a/src/litestar_queues/backends/sqlspec/schema.py
+++ b/src/litestar_queues/backends/sqlspec/schema.py
@@ -95,6 +95,8 @@ EVENT_HISTORY_COLUMNS = (
 )
 """Physical columns the package owns on the SQLSpec event-history table."""
 
+_EVENT_HISTORY_COLUMN_NAMES = frozenset(EVENT_HISTORY_COLUMNS)
+
 RESERVED_EVENT_HISTORY_COLUMNS = frozenset({"actor", "entity", "scope", "scope_key"})
 """Names held for built-in event-history scoping dimensions.
 
@@ -137,23 +139,25 @@ def validate_event_history_extra_columns(
         if not _is_unquoted_identifier_part(column.name):
             msg = f"Invalid SQL identifier in event_history_extra_columns: {column.name!r}"
             raise QueueConfigurationError(msg)
-        if column.name in EVENT_HISTORY_COLUMNS:
+        # Unquoted SQL identifiers fold case, so every name comparison below does
+        # too: ``TASK_ID`` and ``task_id`` are one column to the database.
+        folded = column.name.lower()
+        if folded in _EVENT_HISTORY_COLUMN_NAMES:
             msg = f"event_history_extra_columns may not redeclare package-owned column {column.name!r}"
             raise QueueConfigurationError(msg)
-        # Unquoted SQL identifiers fold case, so the reservation must too.
-        if column.name.lower() in RESERVED_EVENT_HISTORY_COLUMNS:
+        if folded in RESERVED_EVENT_HISTORY_COLUMNS:
             msg = (
                 f"event_history_extra_columns may not use {column.name!r}: "
                 f"{sorted(RESERVED_EVENT_HISTORY_COLUMNS)!r} are reserved for built-in scoping dimensions"
             )
             raise QueueConfigurationError(msg)
-        if column.name in seen:
+        if folded in seen:
             msg = f"Duplicate column in event_history_extra_columns: {column.name!r}"
             raise QueueConfigurationError(msg)
         if not column.source:
             msg = f"event_history_extra_columns entry {column.name!r} requires a non-empty payload source key"
             raise QueueConfigurationError(msg)
-        seen.add(column.name)
+        seen.add(folded)
         validated.append(column)
     return tuple(validated)
 

--- a/src/litestar_queues/backends/sqlspec/schema.py
+++ b/src/litestar_queues/backends/sqlspec/schema.py
@@ -20,6 +20,7 @@ __all__ = (
     "DEFAULT_TABLE_NAME",
     "DEFAULT_TASK_RESERVATION_TABLE_SUFFIX",
     "EVENT_HISTORY_COLUMNS",
+    "RESERVED_EVENT_HISTORY_COLUMNS",
     "EventHistoryExtraColumn",
     "event_history_table_name_for",
     "maintenance_table_name_for",
@@ -94,6 +95,13 @@ EVENT_HISTORY_COLUMNS = (
 )
 """Physical columns the package owns on the SQLSpec event-history table."""
 
+RESERVED_EVENT_HISTORY_COLUMNS = frozenset({"actor", "entity", "scope", "scope_key"})
+"""Names held for built-in event-history scoping dimensions.
+
+These are not columns on the table yet. They are reserved so an adopter-declared
+extra column cannot claim a name the package intends to own.
+"""
+
 
 @dataclass(frozen=True, slots=True)
 class EventHistoryExtraColumn:
@@ -119,8 +127,9 @@ def validate_event_history_extra_columns(
 
     Raises:
         QueueConfigurationError: If a name is not a valid unquoted SQL
-            identifier, collides with a package-owned column, repeats another
-            declaration, or the payload source key is empty.
+            identifier, collides with a package-owned column, uses a reserved
+            scoping-dimension name, repeats another declaration, or the payload
+            source key is empty.
     """
     seen: "set[str]" = set()
     validated: "list[EventHistoryExtraColumn]" = []
@@ -130,6 +139,13 @@ def validate_event_history_extra_columns(
             raise QueueConfigurationError(msg)
         if column.name in EVENT_HISTORY_COLUMNS:
             msg = f"event_history_extra_columns may not redeclare package-owned column {column.name!r}"
+            raise QueueConfigurationError(msg)
+        # Unquoted SQL identifiers fold case, so the reservation must too.
+        if column.name.lower() in RESERVED_EVENT_HISTORY_COLUMNS:
+            msg = (
+                f"event_history_extra_columns may not use {column.name!r}: "
+                f"{sorted(RESERVED_EVENT_HISTORY_COLUMNS)!r} are reserved for built-in scoping dimensions"
+            )
             raise QueueConfigurationError(msg)
         if column.name in seen:
             msg = f"Duplicate column in event_history_extra_columns: {column.name!r}"

--- a/src/litestar_queues/backends/sqlspec/schema.py
+++ b/src/litestar_queues/backends/sqlspec/schema.py
@@ -1,5 +1,6 @@
 """Schema and migration helpers for the SQLSpec queue backend."""
 
+from dataclasses import dataclass
 from hashlib import sha1
 from importlib.resources import files
 from pathlib import Path
@@ -10,7 +11,7 @@ from sqlspec.utils.text import quote_identifier, split_qualified_identifier
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 __all__ = (
     "DEFAULT_COLUMN_MAP",
@@ -18,6 +19,8 @@ __all__ = (
     "DEFAULT_MAINTENANCE_TABLE_SUFFIX",
     "DEFAULT_TABLE_NAME",
     "DEFAULT_TASK_RESERVATION_TABLE_SUFFIX",
+    "EVENT_HISTORY_COLUMNS",
+    "EventHistoryExtraColumn",
     "event_history_table_name_for",
     "maintenance_table_name_for",
     "migration_directory",
@@ -25,6 +28,7 @@ __all__ = (
     "resolve_column_map",
     "task_reservation_table_name_for",
     "validate_column_map",
+    "validate_event_history_extra_columns",
     "validate_native_json_columns",
     "validate_table_name",
 )
@@ -66,6 +70,76 @@ _CANONICAL_COLUMNS = frozenset({
     "metadata_json",
 })
 _JSON_COLUMNS = frozenset({"args_json", "kwargs_json", "result_json", "metadata_json"})
+
+EVENT_HISTORY_COLUMNS = (
+    "event_id",
+    "event_type",
+    "task_id",
+    "task_name",
+    "queue",
+    "worker_id",
+    "execution_backend",
+    "execution_profile",
+    "stage",
+    "level",
+    "message",
+    "detail",
+    "progress_current",
+    "progress_total",
+    "progress_percent",
+    "duration_ms",
+    "sequence",
+    "occurred_at",
+    "created_at",
+)
+"""Physical columns the package owns on the SQLSpec event-history table."""
+
+
+@dataclass(frozen=True, slots=True)
+class EventHistoryExtraColumn:
+    """Adopter-declared scoping column on the SQLSpec event-history table."""
+
+    name: "str"
+    """Physical column name; must be a valid unquoted SQL identifier."""
+
+    source: "str"
+    """Key looked up in the event payload (``QueueEvent.payload``)."""
+
+    indexed: "bool" = False
+    """Whether a ``(name, occurred_at)`` index is created."""
+
+
+def validate_event_history_extra_columns(
+    columns: "Sequence[EventHistoryExtraColumn]",
+) -> "tuple[EventHistoryExtraColumn, ...]":
+    """Validate adopter-declared extra event-history columns.
+
+    Returns:
+        The validated declarations as a tuple.
+
+    Raises:
+        QueueConfigurationError: If a name is not a valid unquoted SQL
+            identifier, collides with a package-owned column, repeats another
+            declaration, or the payload source key is empty.
+    """
+    seen: "set[str]" = set()
+    validated: "list[EventHistoryExtraColumn]" = []
+    for column in columns:
+        if not _is_unquoted_identifier_part(column.name):
+            msg = f"Invalid SQL identifier in event_history_extra_columns: {column.name!r}"
+            raise QueueConfigurationError(msg)
+        if column.name in EVENT_HISTORY_COLUMNS:
+            msg = f"event_history_extra_columns may not redeclare package-owned column {column.name!r}"
+            raise QueueConfigurationError(msg)
+        if column.name in seen:
+            msg = f"Duplicate column in event_history_extra_columns: {column.name!r}"
+            raise QueueConfigurationError(msg)
+        if not column.source:
+            msg = f"event_history_extra_columns entry {column.name!r} requires a non-empty payload source key"
+            raise QueueConfigurationError(msg)
+        seen.add(column.name)
+        validated.append(column)
+    return tuple(validated)
 
 
 def validate_table_name(table_name: "str") -> "str":

--- a/src/litestar_queues/consumer.py
+++ b/src/litestar_queues/consumer.py
@@ -19,7 +19,7 @@ from uuid import UUID
 
 from litestar_queues._environment import CONFIG_FACTORY_ENV, TASK_ID_ENV
 from litestar_queues.config import QueueConfig
-from litestar_queues.events.context import _bind_beat_sink, _reset_beat_sink
+from litestar_queues.events import bind_beat_sink
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import HeartbeatTouch
 from litestar_queues.service import QueueService
@@ -192,36 +192,35 @@ async def _resolve_and_consume(
 async def _execute_claimed_record(queue: "QueueService", claimed: "QueuedTaskRecord") -> "TaskExitCode":
     expected_retry_count = claimed.retry_count
     beat_sink = SingleTaskBeatSink(claimed.id)
-    beat_token = _bind_beat_sink(beat_sink)
-    heartbeat_task = asyncio.create_task(
-        _heartbeat_loop(queue, claimed.id, expected_retry_count=expected_retry_count, beat_sink=beat_sink)
-    )
-    execution_task = asyncio.create_task(queue.execute_record(claimed))
-    try:
-        done, _pending = await asyncio.wait({heartbeat_task, execution_task}, return_when=asyncio.FIRST_COMPLETED)
-        if heartbeat_task in done and not heartbeat_task.result():
+    with bind_beat_sink(beat_sink):
+        heartbeat_task = asyncio.create_task(
+            _heartbeat_loop(queue, claimed.id, expected_retry_count=expected_retry_count, beat_sink=beat_sink)
+        )
+        execution_task = asyncio.create_task(queue.execute_record(claimed))
+        try:
+            done, _pending = await asyncio.wait({heartbeat_task, execution_task}, return_when=asyncio.FIRST_COMPLETED)
+            if heartbeat_task in done and not heartbeat_task.result():
+                execution_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await execution_task
+                await queue.publish_claim_lost(claimed, phase="heartbeat", expected_retry_count=expected_retry_count)
+                return TaskExitCode.CLAIM_LOST
+            updated = await execution_task
+        except asyncio.CancelledError:
+            # The caller going away is not the queue deciding anything. The record
+            # is still running and still owned, so stop the body, let the ``finally``
+            # clear the heartbeat that stale recovery reads, and let the
+            # cancellation reach the caller rather than reporting an outcome it
+            # could mistake for a settled one.
             execution_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await execution_task
-            await queue.publish_claim_lost(claimed, phase="heartbeat", expected_retry_count=expected_retry_count)
-            return TaskExitCode.CLAIM_LOST
-        updated = await execution_task
-    except asyncio.CancelledError:
-        # The caller going away is not the queue deciding anything. The record
-        # is still running and still owned, so stop the body, let the ``finally``
-        # clear the heartbeat that stale recovery reads, and let the
-        # cancellation reach the caller rather than reporting an outcome it
-        # could mistake for a settled one.
-        execution_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await execution_task
-        raise
-    finally:
-        heartbeat_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await heartbeat_task
-        _reset_beat_sink(beat_token)
-        await queue.get_queue_backend().null_heartbeats([claimed.id], expected_retry_count=expected_retry_count)
+            raise
+        finally:
+            heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat_task
+            await queue.get_queue_backend().null_heartbeats([claimed.id], expected_retry_count=expected_retry_count)
 
     if updated.status == "completed":
         return TaskExitCode.SUCCESS

--- a/src/litestar_queues/events/__init__.py
+++ b/src/litestar_queues/events/__init__.py
@@ -5,8 +5,11 @@ from typing import TYPE_CHECKING, Any
 from litestar_queues.events.channels import QueueChannels
 from litestar_queues.events.config import EventDeliveryConfig, QueueEventsConfig
 from litestar_queues.events.context import (
+    TaskBeatSink,
     TaskExecutionContext,
     beat,
+    bind_beat_sink,
+    bind_task_context,
     get_current_task_context,
     publish_task_event,
     publish_task_log,
@@ -70,9 +73,12 @@ __all__ = (
     "QueueEventStageSummary",
     "QueueEventType",
     "QueueEventsConfig",
+    "TaskBeatSink",
     "TaskExecutionContext",
     "UnauthenticatedAccess",
     "beat",
+    "bind_beat_sink",
+    "bind_task_context",
     "create_event_producer",
     "get_current_task_context",
     "publish_task_event",

--- a/src/litestar_queues/events/_log_records.py
+++ b/src/litestar_queues/events/_log_records.py
@@ -35,6 +35,8 @@ def event_log_record_from_event(event: "QueueEvent", *, created_at: "datetime | 
         worker_id=event.worker_id,
         execution_backend=event.execution_backend,
         execution_profile=event.execution_profile,
+        actor_type=event.actor.type if event.actor is not None else None,
+        actor_id=event.actor.id if event.actor is not None else None,
         stage=optional_str(detail.get("stage")),
         level=event.level,
         message=event.message,

--- a/src/litestar_queues/events/context.py
+++ b/src/litestar_queues/events/context.py
@@ -1,32 +1,41 @@
 """Task execution context and helper APIs for queue event publishing."""
 
 import asyncio
-from contextvars import ContextVar, Token
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from litestar_queues.events.models import QueueEvent
 from litestar_queues.exceptions import JobCancelledError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Protocol
+    from collections.abc import Iterator, Sequence
 
     from litestar_queues.events.publisher import QueueEventPublisher
 
-    class TaskBeatSink(Protocol):
-        def record_beat(self, task_id: "str", detail: "str | None") -> "None": ...
-
 
 __all__ = (
+    "TaskBeatSink",
     "TaskExecutionContext",
     "beat",
+    "bind_beat_sink",
+    "bind_task_context",
     "get_current_task_context",
     "publish_task_event",
     "publish_task_log",
     "publish_task_progress",
     "require_current_task_context",
 )
+
+
+class TaskBeatSink(Protocol):
+    """Receives last-value-wins beat progress for a running task."""
+
+    def record_beat(self, task_id: "str", detail: "str | None") -> "None":
+        """Record the latest beat detail reported by ``task_id``."""
+        ...
+
 
 _current_task_context: 'ContextVar["TaskExecutionContext | None"]' = ContextVar(
     "litestar_queues_task_context", default=None
@@ -251,27 +260,41 @@ def beat(detail: "str | None" = None) -> "None":
         context.beat(detail)
 
 
-def _bind_task_context(context: "TaskExecutionContext") -> "Token[TaskExecutionContext | None]":
+@contextmanager
+def bind_task_context(context: "TaskExecutionContext") -> "Iterator[TaskExecutionContext]":
+    """Bind ``context`` as the current task execution context.
+
+    This is the supported entry point for external runtimes adopting the events
+    subpackage standalone. While bound, :func:`require_current_task_context` and
+    the module-level publish helpers resolve to ``context``.
+
+    Yields:
+        The bound task execution context.
+    """
     _active_task_contexts[context.task_id] = context
-    return _current_task_context.set(context)
-
-
-def _reset_task_context(token: "Token[TaskExecutionContext | None]") -> "None":
-    context = _current_task_context.get()
-    if context is not None:
+    token = _current_task_context.set(context)
+    try:
+        yield context
+    finally:
         _active_task_contexts.pop(context.task_id, None)
-    _current_task_context.reset(token)
+        _current_task_context.reset(token)
+
+
+@contextmanager
+def bind_beat_sink(sink: "TaskBeatSink") -> "Iterator[TaskBeatSink]":
+    """Bind ``sink`` to receive :meth:`TaskExecutionContext.beat` calls.
+
+    Yields:
+        The bound beat sink.
+    """
+    token = _current_beat_sink.set(sink)
+    try:
+        yield sink
+    finally:
+        _current_beat_sink.reset(token)
 
 
 def _cancel_task_context(task_id: "str") -> "None":
     context = _active_task_contexts.get(task_id)
     if context is not None:
         context.mark_cancelled()
-
-
-def _bind_beat_sink(sink: "TaskBeatSink") -> "Token[TaskBeatSink | None]":
-    return _current_beat_sink.set(sink)
-
-
-def _reset_beat_sink(token: "Token[TaskBeatSink | None]") -> "None":
-    _current_beat_sink.reset(token)

--- a/src/litestar_queues/events/history.py
+++ b/src/litestar_queues/events/history.py
@@ -54,6 +54,8 @@ class QueueEventLogRecord:
     worker_id: "str | None"
     execution_backend: "str | None"
     execution_profile: "str | None"
+    actor_type: "str | None"
+    actor_id: "str | None"
     stage: "str | None"
     level: "str | None"
     message: "str | None"
@@ -90,9 +92,18 @@ class QueueEventLog(Protocol):
         ...
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
-        """Return durable event history records."""
+        """Return durable event history records.
+
+        Every filter uses equality and is ANDed with the others.
+        """
         ...
 
     async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -4,6 +4,7 @@ import logging
 import math
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable, iscoroutinefunction
@@ -21,7 +22,7 @@ from litestar_queues._correlation import (
 from litestar_queues._identity import IDENTITY_VERSION, arguments_identity, task_identity
 from litestar_queues.backends.base import interruption_count
 from litestar_queues.config import execution_backend_name, queue_backend_name
-from litestar_queues.events.context import TaskExecutionContext, _bind_task_context, _reset_task_context
+from litestar_queues.events.context import TaskExecutionContext, bind_task_context
 from litestar_queues.events.models import QueueEvent
 from litestar_queues.events.producer import QueueEventProducer
 from litestar_queues.events.sinks import _call_optional_lifecycle, _select_lifecycle_error
@@ -1466,19 +1467,21 @@ def _capture_enqueue_context(runtime: "QueueObservabilityRuntimeProtocol", metad
 
 def _bind_execution_context(
     task_context: "TaskExecutionContext", metadata: "Mapping[str, Any]"
-) -> "tuple[Any, tuple[Any, bool]]":
+) -> "tuple[ExitStack, tuple[Any, bool]]":
     """Bind the ambient context a task body runs under.
 
     Returns:
         Scope state for :func:`_reset_execution_context`.
     """
-    return _bind_task_context(task_context), bind_correlation_id(metadata)
+    stack = ExitStack()
+    stack.enter_context(bind_task_context(task_context))
+    return stack, bind_correlation_id(metadata)
 
 
-def _reset_execution_context(scope: "tuple[Any, tuple[Any, bool]]") -> "None":
+def _reset_execution_context(scope: "tuple[ExitStack, tuple[Any, bool]]") -> "None":
     """Restore the context that was active before the task body ran."""
-    context_token, correlation_state = scope
-    _reset_task_context(context_token)
+    stack, correlation_state = scope
+    stack.close()
     reset_correlation_id(correlation_state)
 
 

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -653,8 +653,9 @@ class QueueService:
         await task_context.lifecycle("task.cancelled", message=message, payload=payload)
         self._log_task_event("Queue task cancelled", record, level=logging.INFO, payload=payload)
         if include_running:
-            # Not gated on a persisted owner: backends that do not track one
-            # would otherwise never emit the hint their workers listen for.
+            # Not gated on a persisted owner: an unclaimed record has no owner
+            # to name, and every subscribed worker reconciles the shared
+            # control channel against durable status regardless.
             await backend.notify_worker_control(record.worker_id)
         return True
 

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -502,8 +502,7 @@ class Worker:
                             )
                         except Exception:
                             self._record_counter(
-                                "litestar_queues.worker.interrupt.error",
-                                {"messaging.destination.name": record.queue},
+                                "litestar_queues.worker.interrupt.error", {"messaging.destination.name": record.queue}
                             )
                             self._logger.exception(
                                 "Queue task shutdown requeue failed; record remains running",

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -8,7 +8,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from litestar_queues.config import WorkerConfig, execution_backend_name, queue_backend_name
-from litestar_queues.events.context import _bind_beat_sink, _cancel_task_context, _reset_beat_sink
+from litestar_queues.events import bind_beat_sink
+from litestar_queues.events.context import _cancel_task_context
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.worker.heartbeat import WorkerHeartbeatManager
 
@@ -482,37 +483,40 @@ class Worker:
     async def _execute_claimed(self, record: "QueuedTaskRecord") -> "None":
         await self._heartbeat_manager.start()
         self._heartbeat_manager.register(record.id, expected_retry_count=record.retry_count)
-        beat_token = _bind_beat_sink(self._heartbeat_manager)
         try:
-            await self._service.get_execution_backend().execute(self._service, record, worker_id=self._worker_id)
-        except asyncio.CancelledError:
-            task_setting = record.metadata.get("requeue_on_shutdown")
-            should_requeue = self._requeue_on_shutdown if task_setting is None else task_setting is True
-            if self._stop_event.is_set() and should_requeue:
-                # A backend failure here must never replace the cancellation:
-                # the exception would be swallowed whole by the drain/cancel
-                # wait and the record would silently stay `running`.
+            with bind_beat_sink(self._heartbeat_manager):
                 try:
-                    updated = await self._service.interrupt_task(
-                        record, worker_id=self._worker_id, max_interruptions=self._max_interruptions
+                    await self._service.get_execution_backend().execute(
+                        self._service, record, worker_id=self._worker_id
                     )
-                except Exception:
-                    self._record_counter(
-                        "litestar_queues.worker.interrupt.error", {"messaging.destination.name": record.queue}
-                    )
-                    self._logger.exception(
-                        "Queue task shutdown requeue failed; record remains running",
-                        extra={"worker_id": self._worker_id, "task_id": str(record.id)},
-                    )
-                else:
-                    if updated is None:
-                        self._logger.warning(
-                            "Queue task shutdown requeue lost its fence",
-                            extra={"worker_id": self._worker_id, "task_id": str(record.id)},
-                        )
-            raise
+                except asyncio.CancelledError:
+                    task_setting = record.metadata.get("requeue_on_shutdown")
+                    should_requeue = self._requeue_on_shutdown if task_setting is None else task_setting is True
+                    if self._stop_event.is_set() and should_requeue:
+                        # A backend failure here must never replace the cancellation:
+                        # the exception would be swallowed whole by the drain/cancel
+                        # wait and the record would silently stay `running`.
+                        try:
+                            updated = await self._service.interrupt_task(
+                                record, worker_id=self._worker_id, max_interruptions=self._max_interruptions
+                            )
+                        except Exception:
+                            self._record_counter(
+                                "litestar_queues.worker.interrupt.error",
+                                {"messaging.destination.name": record.queue},
+                            )
+                            self._logger.exception(
+                                "Queue task shutdown requeue failed; record remains running",
+                                extra={"worker_id": self._worker_id, "task_id": str(record.id)},
+                            )
+                        else:
+                            if updated is None:
+                                self._logger.warning(
+                                    "Queue task shutdown requeue lost its fence",
+                                    extra={"worker_id": self._worker_id, "task_id": str(record.id)},
+                                )
+                    raise
         finally:
-            _reset_beat_sink(beat_token)
             try:
                 try:
                     self._heartbeat_manager.unregister(record.id)

--- a/src/tests/integration/backends/advanced_alchemy/test_model_class.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_model_class.py
@@ -97,6 +97,8 @@ def test_queue_event_history_model_mixin_adds_generic_event_history_schema() -> 
         "worker_id",
         "execution_backend",
         "execution_profile",
+        "actor_type",
+        "actor_id",
         "level",
         "message",
         "detail_json",
@@ -106,11 +108,12 @@ def test_queue_event_history_model_mixin_adds_generic_event_history_schema() -> 
         "sequence",
         "occurred_at",
     } <= _column_names(CustomQueueEventHistoryModel)
-    assert {"stage", "duration_ms"}.isdisjoint(_column_names(CustomQueueEventHistoryModel))
+    assert {"stage", "duration_ms", "actor_name"}.isdisjoint(_column_names(CustomQueueEventHistoryModel))
     assert {
         "ix_custom_queue_task_event_log_task_id",
         "ix_custom_queue_task_event_log_task_name",
         "ix_custom_queue_task_event_log_event_type",
+        "ix_custom_queue_task_event_log_actor_id",
         "ix_custom_queue_task_event_log_occurred_at",
     } <= _index_names(CustomQueueEventHistoryModel)
 

--- a/src/tests/integration/backends/sqlspec/test_event_log.py
+++ b/src/tests/integration/backends/sqlspec/test_event_log.py
@@ -22,7 +22,13 @@ from litestar_queues import (
 )
 from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
-from litestar_queues.events import QueueEventsConfig, publish_task_log, publish_task_progress
+from litestar_queues.events import (
+    QueueEvent,
+    QueueEventActor,
+    QueueEventsConfig,
+    publish_task_log,
+    publish_task_progress,
+)
 from litestar_queues.task import clear_task_registry
 from tests.integration.backends.sqlspec._schema import bootstrap_queue_schema
 
@@ -113,6 +119,55 @@ async def test_sqlspec_event_log_records_and_queries_task_history(
     assert third_deleted == 1
     assert after_third == []
     assert (final_deleted, after_final) == (0, [])
+
+
+async def test_sqlspec_event_log_persists_and_filters_the_actor(
+    tmp_path: "Path", sqlite_config_factory: "SqliteConfigFactory"
+) -> "None":
+    """The actor type and id are stored columns, so history can be filtered by who acted."""
+    db_path = tmp_path / "event-actor.db"
+    event_log_config = EventHistoryConfig(batch_size=100, flush_interval=60)
+    backend_config = SQLSpecBackendConfig(sqlspec_config=sqlite_config_factory(db_path))
+    await bootstrap_queue_schema(backend_config, event_history_enabled=True)
+    config = QueueConfig(
+        worker=WorkerConfig(placement="external"),
+        queue_backend=backend_config,
+        events=QueueEventsConfig(history=event_log_config),
+    )
+
+    async with QueueService(config) as service:
+        event_log = service.get_queue_backend().get_event_log(event_log_config)
+        assert event_log is not None
+        for index, actor in enumerate((
+            QueueEventActor(type="user", id="u-1", name="Alice"),
+            QueueEventActor(type="service", id="svc-1"),
+            None,
+        )):
+            await event_log.publish_event(
+                QueueEvent(
+                    type="task.log",
+                    scope="task",
+                    task_id=f"task-{index}",
+                    task_name="tasks.actor",
+                    sequence=index,
+                    actor=actor,
+                    payload={"index": index},
+                )
+            )
+
+        recorded = await event_log.list_events(task_name="tasks.actor")
+        by_actor_id = await event_log.list_events(actor_id="u-1")
+        by_actor_type = await event_log.list_events(actor_type="service")
+        by_both = await event_log.list_events(actor_id="u-1", actor_type="service")
+
+    assert [(record.actor_type, record.actor_id) for record in recorded] == [
+        ("user", "u-1"),
+        ("service", "svc-1"),
+        (None, None),
+    ]
+    assert [record.detail["index"] for record in by_actor_id] == [0]
+    assert [record.detail["index"] for record in by_actor_type] == [1]
+    assert by_both == []
 
 
 async def test_sqlspec_event_history_table_follows_event_history_enabled_lifecycle(

--- a/src/tests/integration/backends/sqlspec/test_event_log_extra_columns.py
+++ b/src/tests/integration/backends/sqlspec/test_event_log_extra_columns.py
@@ -1,0 +1,141 @@
+"""Adopter-declared scoping columns on the SQLSpec event-history table."""
+
+import importlib
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+pytest.importorskip("sqlspec")
+
+from litestar_queues import QueueConfig, QueueService, WorkerConfig, task
+from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig
+from litestar_queues.backends.sqlspec.event_log import create_event_log_store
+from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME, configure_queue_migration_extension
+from litestar_queues.events import EventHistoryConfig, QueueEventsConfig, publish_task_log
+from litestar_queues.task import clear_task_registry
+from tests.integration._names import table_name_for_test
+from tests.integration.backends.sqlspec._schema import bootstrap_queue_schema
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_databases.docker.postgres import PostgresService
+
+    from litestar_queues.backends.sqlspec.event_log import SQLSpecQueueEventLog
+
+pytestmark = pytest.mark.anyio
+
+_TENANT_COLUMN = EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True)
+
+
+@pytest.fixture
+def aiosqlite_history_config(tmp_path: "Path") -> "Any":
+    """Return a name-binding SQLSpec adapter config."""
+    pytest.importorskip("aiosqlite")
+    from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+    return AiosqliteConfig(connection_config={"database": str(tmp_path / "extra-columns.db")})
+
+
+@pytest.fixture
+def psycopg_history_config(postgres_service: "PostgresService", request: "pytest.FixtureRequest") -> "Any":
+    """Return a positional-binding SQLSpec adapter config backed by a real PostgreSQL service."""
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg import PsycopgAsyncConfig
+
+    return PsycopgAsyncConfig(
+        connection_config={
+            "host": postgres_service.host,
+            "port": postgres_service.port,
+            "user": postgres_service.user,
+            "password": postgres_service.password,
+            "dbname": postgres_service.database,
+        },
+        extension_config={
+            QUEUE_EXTENSION_NAME: {"table_name": table_name_for_test("lq_extra_cols", "psycopg", request.node.nodeid)}
+        },
+    )
+
+
+@pytest.fixture(params=["aiosqlite", "psycopg"])
+def event_history_config(request: "pytest.FixtureRequest") -> "Any":
+    """Return a SQLSpec adapter config for a name-binding and a positional-binding engine."""
+    return request.getfixturevalue(f"{request.param}_history_config")
+
+
+async def _run_scoped_task(config: "Any", *, tenants: "tuple[str, ...]") -> "list[Any]":
+    clear_task_registry()
+
+    @task("tasks.tenant_scoped")
+    async def tenant_scoped(*, tenant: "str") -> "str":
+        await publish_task_log("scoped", payload={"tenant_id": tenant, "stage": "load", "note": "kept"})
+        return tenant
+
+    history = EventHistoryConfig(batch_size=1, flush_interval=60)
+    backend_config = SQLSpecBackendConfig(sqlspec_config=config, event_history_extra_columns=(_TENANT_COLUMN,))
+    await bootstrap_queue_schema(backend_config, event_history_enabled=True)
+    queue_config = QueueConfig(
+        worker=WorkerConfig(placement="external"),
+        queue_backend=backend_config,
+        execution_backend="immediate",
+        events=QueueEventsConfig(history=history),
+    )
+
+    async with QueueService(queue_config) as service:
+        for tenant in tenants:
+            await service.enqueue(tenant_scoped, tenant=tenant)
+
+        event_log = cast("SQLSpecQueueEventLog", service.get_queue_backend().get_event_log(history))
+        await event_log.flush_events()
+
+        scoped = await event_log.list_events(extra={"tenant_id": tenants[0]})
+        everything = await event_log.list_events()
+
+        with pytest.raises(ValueError, match="tenant_id"):
+            await event_log.list_events(extra={"unknown": "x"})
+
+    assert len(everything) > len(scoped)
+    return scoped
+
+
+async def test_extra_column_is_created_written_and_filterable(event_history_config: "Any") -> "None":
+    """A declared extra column is provisioned, populated from the payload, and filterable."""
+    scoped = await _run_scoped_task(event_history_config, tenants=("t-1", "t-2"))
+
+    assert scoped, "expected at least one event for tenant t-1"
+    assert {record.detail["tenant_id"] for record in scoped} == {"t-1"}
+    # ``detail`` remains the complete payload; the column is an indexing/filtering copy.
+    assert all(record.detail["note"] == "kept" for record in scoped)
+
+
+@pytest.mark.parametrize("adapter", ["aiosqlite", "duckdb", "psycopg"])
+async def test_packaged_migration_ddl_matches_managed_schema(
+    adapter: "str", request: "pytest.FixtureRequest", tmp_path: "Path"
+) -> "None":
+    """The packaged migration emits the same event-history DDL as the managed store."""
+    if adapter == "duckdb":
+        pytest.importorskip("duckdb")
+        from sqlspec.adapters.duckdb import DuckDBConfig
+
+        config: "Any" = DuckDBConfig(connection_config={"database": str(tmp_path / "extra.duckdb")})
+    else:
+        config = request.getfixturevalue(f"{adapter}_history_config")
+
+    configure_queue_migration_extension(
+        config, queue_table_name="queue_task", event_history_enabled=True, event_history_extra_columns=(_TENANT_COLUMN,)
+    )
+    settings = config.get_migration_commands().extension_configs[QUEUE_EXTENSION_NAME]
+    config.extension_config = {QUEUE_EXTENSION_NAME: settings}
+
+    migration = importlib.import_module("litestar_queues.backends.sqlspec.migrations.0001_create_queue_tasks")
+    statements = await migration.up(SimpleNamespace(config=config))
+
+    expected = create_event_log_store(
+        config, queue_table_name="queue_task", extra_columns=(_TENANT_COLUMN,)
+    ).create_statements()
+
+    assert settings["event_history_extra_columns"] == ({"name": "tenant_id", "source": "tenant_id", "indexed": True},)
+    assert any("tenant_id" in statement for statement in expected)
+    for statement in expected:
+        assert statement in statements

--- a/src/tests/unit/backends/test_ephemeral.py
+++ b/src/tests/unit/backends/test_ephemeral.py
@@ -18,7 +18,7 @@ from litestar_queues.backends.ephemeral import backend as ephemeral_backend_modu
 from litestar_queues.backends.ephemeral.codec import MAGIC, encode_payload, record_from_payload, record_to_payload
 from litestar_queues.backends.ephemeral.schema import EphemeralDatabaseError
 from litestar_queues.backends.ephemeral.server import EphemeralServerContext
-from litestar_queues.events import EventHistoryConfig, QueueEvent
+from litestar_queues.events import EventHistoryConfig, QueueEvent, QueueEventActor
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import HeartbeatTouch, QueuedTaskRecord, TaskRequest
 from tests.helpers._timing import MutableClock
@@ -627,6 +627,39 @@ async def test_event_log_round_trips_every_history_field(backend: "EphemeralQueu
     assert record.duration_ms == 11.0
     assert record.sequence == 7
     assert record.occurred_at == occurred
+
+
+async def test_event_log_filters_by_actor(backend: "EphemeralQueueBackend") -> "None":
+    log = _event_log(backend, EventHistoryConfig())
+    for index, actor in enumerate((
+        QueueEventActor(type="user", id="u-1", name="Alice"),
+        QueueEventActor(type="service", id="svc-1"),
+        None,
+    )):
+        await log.publish_event(
+            QueueEvent(
+                type="task.log",
+                scope="task",
+                task_id=f"task-{index}",
+                task_name="tasks.actor",
+                sequence=index,
+                actor=actor,
+                payload={"index": index},
+                occurred_at=datetime(2026, 1, 1, 0, 0, index, tzinfo=timezone.utc),
+            )
+        )
+
+    recorded = await log.list_events(task_name="tasks.actor")
+    by_actor_id = await log.list_events(actor_id="u-1")
+    by_actor_type = await log.list_events(actor_type="service")
+
+    assert [(record.actor_type, record.actor_id) for record in recorded] == [
+        ("user", "u-1"),
+        ("service", "svc-1"),
+        (None, None),
+    ]
+    assert [record.detail["index"] for record in by_actor_id] == [0]
+    assert [record.detail["index"] for record in by_actor_type] == [1]
 
 
 async def test_event_log_summarize_stages_returns_no_aggregates(backend: "EphemeralQueueBackend") -> "None":

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -16,6 +16,7 @@ from litestar_queues import (
 from litestar_queues.backends import InMemoryQueueBackend
 from litestar_queues.events import (
     QueueEvent,
+    QueueEventActor,
     QueueEventsConfig,
     publish_task_event,
     publish_task_log,
@@ -124,6 +125,55 @@ async def test_memory_backend_event_log_is_bounded_and_cleanup_is_queryable() ->
     assert [record.detail["index"] for record in after_second] == [4]
     assert final_deleted == 0
     assert [record.detail["index"] for record in after_final] == [4]
+
+
+async def test_memory_backend_event_log_records_and_filters_the_actor() -> "None":
+    event_log_config = EventHistoryConfig()
+    backend = InMemoryQueueBackend(
+        QueueConfig(
+            worker=WorkerConfig(placement="external"),
+            queue_backend="memory",
+            events=QueueEventsConfig(history=event_log_config),
+        )
+    )
+    event_log = backend.get_event_log(event_log_config)
+    assert event_log is not None
+
+    await event_log.publish_event(
+        QueueEvent(
+            type="task.log",
+            scope="task",
+            task_name="tasks.actor",
+            actor=QueueEventActor(type="user", id="u-1", name="Alice"),
+            payload={"index": 0},
+        )
+    )
+    await event_log.publish_event(
+        QueueEvent(
+            type="task.log",
+            scope="task",
+            task_name="tasks.actor",
+            actor=QueueEventActor(type="service", id="svc-1"),
+            payload={"index": 1},
+        )
+    )
+    await event_log.publish_event(
+        QueueEvent(type="task.log", scope="task", task_name="tasks.actor", payload={"index": 2})
+    )
+
+    recorded = await event_log.list_events(task_name="tasks.actor")
+    by_actor_id = await event_log.list_events(actor_id="u-1")
+    by_actor_type = await event_log.list_events(actor_type="service")
+    by_both = await event_log.list_events(actor_id="u-1", actor_type="service")
+
+    assert [(record.actor_type, record.actor_id) for record in recorded] == [
+        ("user", "u-1"),
+        ("service", "svc-1"),
+        (None, None),
+    ]
+    assert [record.detail["index"] for record in by_actor_id] == [0]
+    assert [record.detail["index"] for record in by_actor_type] == [1]
+    assert by_both == []
 
 
 async def test_memory_backend_clear_clears_event_log() -> "None":

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -1,0 +1,142 @@
+"""Unit tests for adopter-declared extra columns on the SQLSpec event-history table."""
+
+import pytest
+
+pytest.importorskip("sqlspec")
+pytest.importorskip("aiosqlite")
+
+from typing import TYPE_CHECKING
+
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig
+from litestar_queues.backends.sqlspec.event_log import create_event_log_store
+from litestar_queues.backends.sqlspec.schema import EVENT_HISTORY_COLUMNS, validate_event_history_extra_columns
+from litestar_queues.exceptions import QueueConfigurationError
+
+if TYPE_CHECKING:
+    from litestar_queues.events import QueueEventLog
+
+_TENANT = EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True)
+
+
+def _store(*extra: "EventHistoryExtraColumn") -> "object":
+    return create_event_log_store(
+        AiosqliteConfig(connection_config={"database": ":memory:"}), queue_table_name="queue_task", extra_columns=extra
+    )
+
+
+def test_extra_column_declaration_validates() -> "None":
+    columns = (EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),)
+
+    assert validate_event_history_extra_columns(columns) == columns
+
+
+def test_extra_column_source_defaults_are_explicit() -> "None":
+    column = EventHistoryExtraColumn(name="project_id", source="project")
+
+    assert column.indexed is False
+    assert validate_event_history_extra_columns([column]) == (column,)
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        pytest.param(EventHistoryExtraColumn(name="task_id", source="x"), id="reserved-name"),
+        pytest.param(EventHistoryExtraColumn(name="drop table", source="x"), id="invalid-identifier"),
+        pytest.param(EventHistoryExtraColumn(name="tenant_id", source=""), id="empty-source"),
+        pytest.param(EventHistoryExtraColumn(name="", source="tenant_id"), id="empty-name"),
+    ],
+)
+def test_extra_column_declaration_rejects(column: "EventHistoryExtraColumn") -> "None":
+    with pytest.raises(QueueConfigurationError):
+        validate_event_history_extra_columns((column,))
+
+
+def test_extra_column_duplicate_names_rejected() -> "None":
+    columns = (
+        EventHistoryExtraColumn(name="tenant_id", source="tenant_id"),
+        EventHistoryExtraColumn(name="tenant_id", source="account_id"),
+    )
+
+    with pytest.raises(QueueConfigurationError, match="tenant_id"):
+        validate_event_history_extra_columns(columns)
+
+
+def test_event_history_columns_are_shared_with_the_event_log_module() -> "None":
+    from litestar_queues.backends.sqlspec.event_log import SQLSpecQueueEventLogStore
+
+    assert "task_id" in EVENT_HISTORY_COLUMNS
+    assert "detail" in EVENT_HISTORY_COLUMNS
+    assert SQLSpecQueueEventLogStore is not None
+
+
+def test_backend_config_validates_extra_columns() -> "None":
+    config = SQLSpecBackendConfig(
+        event_history_extra_columns=(EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),)
+    )
+
+    assert config.event_history_extra_columns == (
+        EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),
+    )
+
+    with pytest.raises(QueueConfigurationError):
+        SQLSpecBackendConfig(event_history_extra_columns=(EventHistoryExtraColumn(name="detail", source="x"),))
+
+
+def test_store_without_extras_emits_unchanged_statements() -> "None":
+    baseline = _store()
+
+    statements = baseline.create_statements()  # type: ignore[attr-defined]
+    template = baseline.insert_events_template()  # type: ignore[attr-defined]
+
+    assert not any("tenant_id" in statement for statement in statements)
+    assert "tenant_id" not in template
+    assert template.count(":") == len(EVENT_HISTORY_COLUMNS)
+
+
+def test_extra_columns_appear_in_ddl_and_insert_template() -> "None":
+    store = _store(_TENANT)
+
+    statements = store.create_statements()  # type: ignore[attr-defined]
+    template = store.insert_events_template()  # type: ignore[attr-defined]
+
+    assert any("tenant_id" in statement and statement.startswith("CREATE TABLE") for statement in statements)
+    assert any("tenant_id" in statement and statement.startswith("CREATE INDEX") for statement in statements)
+    assert ":tenant_id" in template
+    assert any("tenant_id" in statement for statement in store.drop_statements())  # type: ignore[attr-defined]
+
+
+def test_unindexed_extra_column_has_no_index_statement() -> "None":
+    store = _store(EventHistoryExtraColumn(name="project_id", source="project_id"))
+
+    statements = store.create_statements()  # type: ignore[attr-defined]
+
+    assert any("project_id" in statement and statement.startswith("CREATE TABLE") for statement in statements)
+    assert not any("project_id" in statement and statement.startswith("CREATE INDEX") for statement in statements)
+
+
+def test_select_events_rejects_undeclared_extra_filter() -> "None":
+    store = _store(_TENANT)
+
+    with pytest.raises(ValueError, match="tenant_id"):
+        store.select_events(extra={"unknown": "x"})  # type: ignore[attr-defined]
+
+
+def test_select_events_accepts_declared_extra_filter() -> "None":
+    store = _store(_TENANT)
+
+    statement = store.select_events(extra={"tenant_id": "t-1"})  # type: ignore[attr-defined]
+
+    assert "tenant_id" in statement.build(dialect="sqlite").sql
+
+
+def test_sqlspec_event_log_still_satisfies_the_frozen_protocol() -> "None":
+    """The extra filter is additive: the concrete store still matches ``QueueEventLog``."""
+    from litestar_queues.backends.sqlspec.event_log import SQLSpecQueueEventLog
+
+    def accepts_protocol(log: "QueueEventLog") -> "QueueEventLog":
+        return log
+
+    event_log = SQLSpecQueueEventLog.__new__(SQLSpecQueueEventLog)
+    assert accepts_protocol(event_log) is event_log

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -84,7 +84,7 @@ def test_extra_column_duplicate_names_are_case_insensitive() -> "None":
         validate_event_history_extra_columns(columns)
 
 
-@pytest.mark.parametrize("reserved", ["scope", "scope_key", "actor", "entity"])
+@pytest.mark.parametrize("reserved", ["scope", "scope_key", "entity"])
 def test_extra_column_reserved_dimension_names_rejected(reserved: "str") -> "None":
     """Names held for the built-in scoping dimensions cannot be claimed by adopters."""
     column = EventHistoryExtraColumn(name=reserved, source="x")
@@ -93,7 +93,7 @@ def test_extra_column_reserved_dimension_names_rejected(reserved: "str") -> "Non
         validate_event_history_extra_columns((column,))
 
 
-@pytest.mark.parametrize("reserved", ["Scope", "SCOPE_KEY", "Actor", "ENTITY"])
+@pytest.mark.parametrize("reserved", ["Scope", "SCOPE_KEY", "ENTITY"])
 def test_extra_column_reserved_names_are_case_insensitive(reserved: "str") -> "None":
     """Unquoted SQL identifiers are case-insensitive, so the reservation is too."""
     column = EventHistoryExtraColumn(name=reserved, source="x")
@@ -111,6 +111,15 @@ def test_extra_column_names_near_reserved_words_are_allowed() -> "None":
     )
 
     assert validate_event_history_extra_columns(columns) == columns
+
+
+@pytest.mark.parametrize("name", ["actor_type", "actor_id", "ACTOR_ID", "Actor_Type"])
+def test_actor_columns_are_package_owned(name: "str") -> "None":
+    """The actor columns are real columns now, so they collide as package-owned names."""
+    column = EventHistoryExtraColumn(name=name, source="x")
+
+    with pytest.raises(QueueConfigurationError, match="package-owned"):
+        validate_event_history_extra_columns((column,))
 
 
 def test_extra_column_duplicate_names_rejected() -> "None":
@@ -174,6 +183,42 @@ def test_unindexed_extra_column_has_no_index_statement() -> "None":
 
     assert any("project_id" in statement and statement.startswith("CREATE TABLE") for statement in statements)
     assert not any("project_id" in statement and statement.startswith("CREATE INDEX") for statement in statements)
+
+
+def test_actor_columns_are_created_and_indexed() -> "None":
+    store = _store()
+
+    statements = store.create_statements()  # type: ignore[attr-defined]
+    template = store.insert_events_template()  # type: ignore[attr-defined]
+
+    create_table = next(statement for statement in statements if statement.startswith("CREATE TABLE"))
+    assert "actor_type" in create_table
+    assert "actor_id" in create_table
+    assert any(
+        statement.startswith("CREATE INDEX") and "actor_id" in statement and "occurred_at" in statement
+        for statement in statements
+    )
+    assert ":actor_type" in template
+    assert ":actor_id" in template
+    assert any("actor_id" in statement for statement in store.drop_statements())  # type: ignore[attr-defined]
+
+
+def test_actor_name_is_not_persisted() -> "None":
+    """Display names go stale against the event they are stamped on, so only type and id persist."""
+    store = _store()
+
+    statements = store.create_statements()  # type: ignore[attr-defined]
+
+    assert "actor_name" not in next(statement for statement in statements if statement.startswith("CREATE TABLE"))
+
+
+def test_select_events_filters_on_actor() -> "None":
+    store = _store()
+
+    rendered = store.select_events(actor_id="u-1", actor_type="user").build(dialect="sqlite").sql  # type: ignore[attr-defined]
+
+    assert "actor_id" in rendered
+    assert "actor_type" in rendered
 
 
 def test_select_events_rejects_undeclared_extra_filter() -> "None":

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -53,6 +53,35 @@ def test_extra_column_declaration_rejects(column: "EventHistoryExtraColumn") -> 
         validate_event_history_extra_columns((column,))
 
 
+@pytest.mark.parametrize("reserved", ["scope", "scope_key", "actor", "entity"])
+def test_extra_column_reserved_dimension_names_rejected(reserved: "str") -> "None":
+    """Names held for the built-in scoping dimensions cannot be claimed by adopters."""
+    column = EventHistoryExtraColumn(name=reserved, source="x")
+
+    with pytest.raises(QueueConfigurationError, match="reserved"):
+        validate_event_history_extra_columns((column,))
+
+
+@pytest.mark.parametrize("reserved", ["Scope", "SCOPE_KEY", "Actor", "ENTITY"])
+def test_extra_column_reserved_names_are_case_insensitive(reserved: "str") -> "None":
+    """Unquoted SQL identifiers are case-insensitive, so the reservation is too."""
+    column = EventHistoryExtraColumn(name=reserved, source="x")
+
+    with pytest.raises(QueueConfigurationError, match="reserved"):
+        validate_event_history_extra_columns((column,))
+
+
+def test_extra_column_names_near_reserved_words_are_allowed() -> "None":
+    """Only the exact reserved names are held back."""
+    columns = (
+        EventHistoryExtraColumn(name="scope_id", source="scope_id"),
+        EventHistoryExtraColumn(name="entity_id", source="entity_id"),
+        EventHistoryExtraColumn(name="actor_name", source="actor_name"),
+    )
+
+    assert validate_event_history_extra_columns(columns) == columns
+
+
 def test_extra_column_duplicate_names_rejected() -> "None":
     columns = (
         EventHistoryExtraColumn(name="tenant_id", source="tenant_id"),

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -53,6 +53,37 @@ def test_extra_column_declaration_rejects(column: "EventHistoryExtraColumn") -> 
         validate_event_history_extra_columns((column,))
 
 
+@pytest.mark.parametrize("name", ["TASK_ID", "Detail", "Occurred_At"])
+def test_extra_column_package_owned_names_are_case_insensitive(name: "str") -> "None":
+    """Unquoted SQL identifiers fold case, so the collision check must too."""
+    column = EventHistoryExtraColumn(name=name, source="x")
+
+    with pytest.raises(QueueConfigurationError, match="package-owned"):
+        validate_event_history_extra_columns((column,))
+
+
+def test_extra_column_names_near_package_owned_names_are_allowed() -> "None":
+    """Only exact package-owned names collide, not names that merely contain them."""
+    columns = (
+        EventHistoryExtraColumn(name="task_id_hash", source="a"),
+        EventHistoryExtraColumn(name="detail_url", source="b"),
+        EventHistoryExtraColumn(name="sub_queue", source="c"),
+    )
+
+    assert validate_event_history_extra_columns(columns) == columns
+
+
+def test_extra_column_duplicate_names_are_case_insensitive() -> "None":
+    """Two declarations differing only in case are the same physical column."""
+    columns = (
+        EventHistoryExtraColumn(name="tenant_id", source="tenant_id"),
+        EventHistoryExtraColumn(name="TENANT_ID", source="account_id"),
+    )
+
+    with pytest.raises(QueueConfigurationError, match="Duplicate"):
+        validate_event_history_extra_columns(columns)
+
+
 @pytest.mark.parametrize("reserved", ["scope", "scope_key", "actor", "entity"])
 def test_extra_column_reserved_dimension_names_rejected(reserved: "str") -> "None":
     """Names held for the built-in scoping dimensions cannot be claimed by adopters."""

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -1221,9 +1221,15 @@ class _RecordingEventLog:
         self.flushed = True
 
     async def list_events(
-        self, *, task_id: "str | None" = None, task_name: "str | None" = None, limit: "int | None" = None
+        self,
+        *,
+        task_id: "str | None" = None,
+        task_name: "str | None" = None,
+        actor_id: "str | None" = None,
+        actor_type: "str | None" = None,
+        limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
-        del task_id, task_name, limit
+        del task_id, task_name, actor_id, actor_type, limit
         return []
 
     async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":

--- a/src/tests/unit/test_task_context.py
+++ b/src/tests/unit/test_task_context.py
@@ -9,15 +9,17 @@ from litestar_queues.events import (
     InMemoryQueueEventSink,
     QueueEventPublisher,
     QueueEventsConfig,
+    TaskBeatSink,
     TaskExecutionContext,
     beat,
+    bind_beat_sink,
+    bind_task_context,
     get_current_task_context,
     publish_task_event,
     publish_task_log,
     publish_task_progress,
     require_current_task_context,
 )
-from litestar_queues.events.context import _bind_beat_sink, _bind_task_context, _reset_beat_sink, _reset_task_context
 
 pytestmark = pytest.mark.anyio
 
@@ -34,15 +36,12 @@ async def test_task_context_cooperative_cancellation_helpers() -> "None":
     assert context.is_cancelled is False
     from litestar_queues.events.context import _cancel_task_context
 
-    token = _bind_task_context(context)
-    try:
+    with bind_task_context(context):
         _cancel_task_context(context.task_id)
         await context.wait_cancelled()
         with pytest.raises(JobCancelledError):
             context.raise_if_cancelled()
         assert context.is_cancelled is True
-    finally:
-        _reset_task_context(token)
 
 
 async def test_task_context_is_bound_and_helpers_publish_task_events() -> "None":
@@ -136,11 +135,8 @@ async def test_module_helper_immediate_flushes_prior() -> "None":
 
     await context.log("buffered")
 
-    token = _bind_task_context(context)
-    try:
+    with bind_task_context(context):
         await publish_task_progress(current=1, total=2, immediate=True)
-    finally:
-        _reset_task_context(token)
 
     assert [event.type for event in sink.events] == ["task.log", "task.progress"]
 
@@ -153,11 +149,8 @@ def test_ctx_beat_forwards_to_bound_sink() -> "None":
     sink = _RecordingBeatSink()
     context = _build_context()
 
-    token = _bind_beat_sink(sink)
-    try:
+    with bind_beat_sink(sink):
         context.beat("row 30000")
-    finally:
-        _reset_beat_sink(token)
 
     assert sink.records == [("task-1", "row 30000")]
 
@@ -166,13 +159,8 @@ def test_module_beat_forwards_current_context_to_bound_sink() -> "None":
     sink = _RecordingBeatSink()
     context = _build_context()
 
-    context_token = _bind_task_context(context)
-    sink_token = _bind_beat_sink(sink)
-    try:
+    with bind_task_context(context), bind_beat_sink(sink):
         beat("row 30000")
-    finally:
-        _reset_beat_sink(sink_token)
-        _reset_task_context(context_token)
 
     assert sink.records == [("task-1", "row 30000")]
 
@@ -181,13 +169,46 @@ def test_beat_performs_no_await_and_no_backend_call() -> "None":
     sink = _RecordingBeatSink()
     context = _build_context(event_publisher=_FailingPublisher())
 
-    token = _bind_beat_sink(sink)
-    try:
+    with bind_beat_sink(sink):
         context.beat("sync progress")
-    finally:
-        _reset_beat_sink(token)
 
     assert sink.records == [("task-1", "sync progress")]
+
+
+def test_bind_task_context_public_contextmanager() -> "None":
+    context = _build_context()
+    with bind_task_context(context) as bound:
+        assert bound is context
+        assert get_current_task_context() is context
+    assert get_current_task_context() is None
+
+
+def test_bind_beat_sink_public_contextmanager() -> "None":
+    sink = _RecordingBeatSink()
+    context = _build_context()
+    with bind_task_context(context), bind_beat_sink(sink):
+        context.beat("halfway")
+    assert sink.records == [(context.task_id, "halfway")]
+
+
+def test_public_beat_sink_protocol_is_importable_at_runtime() -> "None":
+    sink: "TaskBeatSink" = _RecordingBeatSink()
+    sink.record_beat("task-1", "detail")
+    assert TaskBeatSink.__name__ == "TaskBeatSink"
+
+
+async def test_bind_task_context_supports_cancellation_fanin() -> "None":
+    from litestar_queues.events.context import _cancel_task_context
+
+    context = _build_context()
+    with bind_task_context(context):
+        _cancel_task_context(context.task_id)
+        assert context.is_cancelled is True
+
+    # Once unbound the context leaves the registry, so cancellation is a no-op.
+    unbound = _build_context()
+    _cancel_task_context(unbound.task_id)
+    assert unbound.is_cancelled is False
 
 
 def _build_context(*, event_publisher: "object | None" = None) -> "TaskExecutionContext":


### PR DESCRIPTION
Makes the `litestar_queues.events` subpackage usable on its own, lets SQLSpec-backed event history carry an adopter-owned scoping dimension such as a tenant id, and records the event actor so history can be queried by who caused it. Addresses #98 and #99.

- **Bind a task context from your own runtime.** `bind_task_context()` and `bind_beat_sink()` are now public context managers exported from `litestar_queues.events`, so a runtime with its own task loop can publish progress, log, and custom events with no queue backend and no worker. `TaskBeatSink` is a public protocol you can implement.
- **The private binders are gone.** The service, worker, and consumer now use the public context managers; the underscore-prefixed token binders they replaced were deleted.
- **Scope event history by an extra column.** `SQLSpecBackendConfig(event_history_extra_columns=...)` adds indexed, filterable text columns to the event-history table, populated from a key in the event payload. The managed schema and the packaged migration emit identical DDL.
- **Query history by actor.** Event history now stores the actor's type and id and can be filtered on either, across every shipped event log. The actor's display name stays on the live envelope: it is mutable text that would go stale against the event it was stamped on.
- **Docs cover both scoping routes.** Implementing `QueueEventLog` yourself remains the path for arbitrary dimensions, custom indexes, or scoped aggregates; the columns are the narrower option for keeping the built-in store.

**Breaking:** `actor_type` and `actor_id` are now package-owned event-history column names, and `actor` is no longer reserved.

## How you use it

Inside a task, nothing needs binding. The service binds the context before it calls the task body:

```python
from litestar_queues import task
from litestar_queues.events import publish_task_progress


@task("catalog.import")
async def import_catalog() -> None:
    await publish_task_progress(current=13, total=400)
```

Take the context directly when you want to call its methods. Injection is keyed on the parameter name `_task_context`:

```python
@task("crawl.run")
async def crawl(*, _task_context: TaskExecutionContext) -> None:
    await _task_context.progress(current=3, total=6, message="3/6 pages")
```

From a runtime that never runs this package's worker, build a context and bind it yourself:

```python
with bind_task_context(TaskExecutionContext(task_id="import-42", event_publisher=publisher, ...)):
    await publish_task_progress(current=13, total=400)
```

Scope durable history by tenant, and query it by actor:

```python
from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig

backend_config = SQLSpecBackendConfig(
    sqlspec_config=sqlspec_config,
    event_history_extra_columns=(
        EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),
    ),
)

records = await event_log.list_events(extra={"tenant_id": "acme"})
by_actor = await event_log.list_events(actor_id="user-42")
```
