### PR TITLE
fix: align claim ordering and keep native batch claim under queue caps

### DIFF
--- a/docs/usage/workers.rst
+++ b/docs/usage/workers.rst
@@ -169,7 +169,9 @@ queue/execution filters.
 
 ``max_concurrency`` remains the worker-wide ceiling. Use
 ``queue_concurrency={"email": 1, "reports": 2}`` for per-worker queue caps.
-These are local limits, not distributed fleet semaphores.
+These are local limits, not distributed fleet semaphores. Backends with a
+native batch claim keep it when caps are set: PostgreSQL applies them inside
+the same claim statement and Redis/Valkey inside the same claim script.
 
 Shutdown
 ========

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -111,9 +111,16 @@ local eb_filter = ARGV[5]
 local window = tonumber(ARGV[6])
 
 local reservation_prefix = ARGV[7]
+local ncaps = tonumber(ARGV[8])
+local caps = {}
+local idx = 9
+for _ = 1, ncaps do
+    caps[ARGV[idx]] = tonumber(ARGV[idx + 1])
+    idx = idx + 2
+end
 local queue_filter = {}
 local has_queue_filter = false
-for i = 8, #ARGV do
+for i = idx, #ARGV do
     queue_filter[ARGV[i]] = true
     has_queue_filter = true
 end
@@ -200,17 +207,21 @@ while #claimed < limit do
                     redis.call('PUBLISH', prefix .. ':completions', id)
                     expired[#expired + 1] = id
                 else
-                    redis.call('HSET', hkey, 'status', 'running', 'started_at', now_iso, 'heartbeat_at', now_iso,
-                        'started_score', now_ms, 'heartbeat_score', now_ms)
-                    redis.call('SREM', prefix .. ':status:pending', id)
-                    redis.call('SADD', prefix .. ':status:running', id)
-                    redis.call('ZREM', ready, id)
-                    removed = removed + 1
-                    redis.call('ZADD', prefix .. ':maintenance:running', now_ms, id)
-                    redis.call('ZREM', prefix .. ':maintenance:terminal', id)
-                    redis.call('ZREM', prefix .. ':maintenance:expiry', id)
-                    redis.call('ZREM', prefix .. ':maintenance:external', id)
-                    claimed[#claimed + 1] = id
+                    local cap = caps[q]
+                    if cap == nil or cap > 0 then
+                        redis.call('HSET', hkey, 'status', 'running', 'started_at', now_iso, 'heartbeat_at', now_iso,
+                            'started_score', now_ms, 'heartbeat_score', now_ms)
+                        redis.call('SREM', prefix .. ':status:pending', id)
+                        redis.call('SADD', prefix .. ':status:running', id)
+                        redis.call('ZREM', ready, id)
+                        removed = removed + 1
+                        redis.call('ZADD', prefix .. ':maintenance:running', now_ms, id)
+                        redis.call('ZREM', prefix .. ':maintenance:terminal', id)
+                        redis.call('ZREM', prefix .. ':maintenance:expiry', id)
+                        redis.call('ZREM', prefix .. ':maintenance:external', id)
+                        claimed[#claimed + 1] = id
+                        if cap ~= nil then caps[q] = cap - 1 end
+                    end
                 end
             end
         end
@@ -986,9 +997,7 @@ class RedisQueueBackend(BaseQueueBackend):
             and (queue is None or record.queue == queue)
             and (execution_backend is None or record.execution_backend == execution_backend)
         ]
-        due_records.sort(
-            key=lambda record: (-record.priority, record.queued_at, record.created_at, record.id.int)
-        )
+        due_records.sort(key=lambda record: (-record.priority, record.queued_at, record.created_at, record.id.int))
         return due_records[:limit]
 
     async def claim_task(
@@ -1059,15 +1068,12 @@ class RedisQueueBackend(BaseQueueBackend):
         queue_limits: "Mapping[str, int] | None" = None,
     ) -> "tuple[list[QueuedTaskRecord], list[QueuedTaskRecord]]":
         """Claim records and report expirations owned by the same Lua script."""
-        if queue_limits is not None:
-            return await super().claim_many_with_expired(
-                limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
-            )
         if limit <= 0:
             return [], []
         client = await self._get_client()
         now = _utc_now()
         window = max(limit * 2, limit + 10)
+        caps = sorted((queue_limits or {}).items())
         args = [
             self._key_prefix,
             repr(now.timestamp() * 1000.0),
@@ -1076,6 +1082,8 @@ class RedisQueueBackend(BaseQueueBackend):
             execution_backend or "",
             str(window),
             EXTERNAL_DISPATCH_RESERVATION_PREFIX,
+            str(len(caps)),
+            *(value for queue, cap in caps for value in (queue, str(cap))),
             *queues,
         ]
         outcome = await _eval_script(client, _CLAIM_SCRIPT, [self._ready_key, self._scheduled_key], args)

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -162,50 +162,60 @@ for _, id in ipairs(due) do
 end
 
 local claimed = {}
-local candidates = redis.call('ZRANGE', ready, 0, window)
-for _, id in ipairs(candidates) do
-    if #claimed >= limit then break end
-    local hkey = prefix .. ':task:' .. id
-    local status = redis.call('HGET', hkey, 'status')
-    if status ~= 'pending' then
-        redis.call('ZREM', ready, id)
-    else
-        local eb = redis.call('HGET', hkey, 'execution_backend')
-        local q = redis.call('HGET', hkey, 'queue')
-        local execution_ref = redis.call('HGET', hkey, 'execution_ref')
-        local eb_ok = (eb_filter == '' or eb == eb_filter)
-        local q_ok = (not has_queue_filter or queue_filter[q] == true)
-        local reservation_active = execution_ref and string.sub(execution_ref, 1, string.len(reservation_prefix)) == reservation_prefix
-        local unreserved = not reservation_active
-        if eb_ok and q_ok and unreserved then
-            local expires_score = tonumber(redis.call('HGET', hkey, 'expires_score')) or 0
-            if expires_score > 0 and expires_score <= now_ms then
-                redis.call('HSET', hkey, 'status', 'expired', 'completed_at', now_iso,
-                    'completed_score', now_ms, 'heartbeat_at', '', 'heartbeat_score', '0')
-                redis.call('SREM', prefix .. ':status:pending', id)
-                redis.call('SADD', prefix .. ':status:expired', id)
-                redis.call('ZREM', ready, id)
-                redis.call('ZREM', scheduled, id)
-                redis.call('ZREM', prefix .. ':maintenance:running', id)
-                redis.call('ZREM', prefix .. ':maintenance:external', id)
-                redis.call('ZREM', prefix .. ':maintenance:expiry', id)
-                redis.call('ZADD', prefix .. ':maintenance:terminal', now_ms, id)
-                redis.call('PUBLISH', prefix .. ':completions', id)
-                expired[#expired + 1] = id
-            else
-                redis.call('HSET', hkey, 'status', 'running', 'started_at', now_iso, 'heartbeat_at', now_iso,
-                    'started_score', now_ms, 'heartbeat_score', now_ms)
-                redis.call('SREM', prefix .. ':status:pending', id)
-                redis.call('SADD', prefix .. ':status:running', id)
-                redis.call('ZREM', ready, id)
-                redis.call('ZADD', prefix .. ':maintenance:running', now_ms, id)
-                redis.call('ZREM', prefix .. ':maintenance:terminal', id)
-                redis.call('ZREM', prefix .. ':maintenance:expiry', id)
-                redis.call('ZREM', prefix .. ':maintenance:external', id)
-                claimed[#claimed + 1] = id
+local start = 0
+while #claimed < limit do
+    local candidates = redis.call('ZRANGE', ready, start, start + window - 1)
+    if #candidates == 0 then break end
+    local scanned = #candidates
+    local removed = 0
+    for _, id in ipairs(candidates) do
+        if #claimed >= limit then break end
+        local hkey = prefix .. ':task:' .. id
+        local status = redis.call('HGET', hkey, 'status')
+        if status ~= 'pending' then
+            redis.call('ZREM', ready, id)
+            removed = removed + 1
+        else
+            local eb = redis.call('HGET', hkey, 'execution_backend')
+            local q = redis.call('HGET', hkey, 'queue')
+            local execution_ref = redis.call('HGET', hkey, 'execution_ref')
+            local eb_ok = (eb_filter == '' or eb == eb_filter)
+            local q_ok = (not has_queue_filter or queue_filter[q] == true)
+            local reservation_active = execution_ref and string.sub(execution_ref, 1, string.len(reservation_prefix)) == reservation_prefix
+            local unreserved = not reservation_active
+            if eb_ok and q_ok and unreserved then
+                local expires_score = tonumber(redis.call('HGET', hkey, 'expires_score')) or 0
+                if expires_score > 0 and expires_score <= now_ms then
+                    redis.call('HSET', hkey, 'status', 'expired', 'completed_at', now_iso,
+                        'completed_score', now_ms, 'heartbeat_at', '', 'heartbeat_score', '0')
+                    redis.call('SREM', prefix .. ':status:pending', id)
+                    redis.call('SADD', prefix .. ':status:expired', id)
+                    redis.call('ZREM', ready, id)
+                    removed = removed + 1
+                    redis.call('ZREM', scheduled, id)
+                    redis.call('ZREM', prefix .. ':maintenance:running', id)
+                    redis.call('ZREM', prefix .. ':maintenance:external', id)
+                    redis.call('ZREM', prefix .. ':maintenance:expiry', id)
+                    redis.call('ZADD', prefix .. ':maintenance:terminal', now_ms, id)
+                    redis.call('PUBLISH', prefix .. ':completions', id)
+                    expired[#expired + 1] = id
+                else
+                    redis.call('HSET', hkey, 'status', 'running', 'started_at', now_iso, 'heartbeat_at', now_iso,
+                        'started_score', now_ms, 'heartbeat_score', now_ms)
+                    redis.call('SREM', prefix .. ':status:pending', id)
+                    redis.call('SADD', prefix .. ':status:running', id)
+                    redis.call('ZREM', ready, id)
+                    removed = removed + 1
+                    redis.call('ZADD', prefix .. ':maintenance:running', now_ms, id)
+                    redis.call('ZREM', prefix .. ':maintenance:terminal', id)
+                    redis.call('ZREM', prefix .. ':maintenance:expiry', id)
+                    redis.call('ZREM', prefix .. ':maintenance:external', id)
+                    claimed[#claimed + 1] = id
+                end
             end
         end
     end
+    start = start + scanned - removed
 end
 local outcome = {}
 for _, id in ipairs(claimed) do
@@ -976,7 +986,9 @@ class RedisQueueBackend(BaseQueueBackend):
             and (queue is None or record.queue == queue)
             and (execution_backend is None or record.execution_backend == execution_backend)
         ]
-        due_records.sort(key=lambda record: (-record.priority, record.created_at))
+        due_records.sort(
+            key=lambda record: (-record.priority, record.queued_at, record.created_at, record.id.int)
+        )
         return due_records[:limit]
 
     async def claim_task(

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -736,15 +736,13 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         Returns:
             Claimed task records.
         """
-        if queue_limits is not None:
-            return await super().claim_many(
-                limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
-            )
         if limit <= 0:
             return []
         store = self._get_store()
         if not type(store).supports_returning_claim:
-            return await super().claim_many(limit=limit, queues=queues, execution_backend=execution_backend)
+            return await super().claim_many(
+                limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
+            )
         now = _utc_now()
         parameters: "dict[str, Any]" = {
             "now": self._serialize_datetime(now),
@@ -758,8 +756,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             parameters[f"queue_{index}"] = queue
         if execution_backend is not None:
             parameters["execution_backend"] = execution_backend
+        cap_count = self._bind_queue_limits(parameters, queue_limits)
         sql_text = store.claim_batch_returning_sql(
-            queue_count=len(queues), filter_execution_backend=execution_backend is not None
+            queue_count=len(queues), filter_execution_backend=execution_backend is not None, cap_count=cap_count
         )
         with self._observe_queue_operation("claim", execution_backend=execution_backend):
             async with self._session() as driver:
@@ -778,16 +777,16 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         queue_limits: "Mapping[str, int] | None" = None,
     ) -> "tuple[list[QueuedTaskRecord], list[QueuedTaskRecord]]":
         """Claim records and report every expiry transition owned by this call."""
-        if queue_limits is not None:
-            return await super().claim_many_with_expired(
-                limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
-            )
         if limit <= 0:
             return [], []
         store = self._get_store()
         if type(store).supports_combined_expiry_claim:
             return await self._claim_many_postgres_with_expired(
-                store, limit=limit, queues=queues, execution_backend=execution_backend
+                store, limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
+            )
+        if queue_limits is not None:
+            return await super().claim_many_with_expired(
+                limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
             )
 
         expired = await self.expire_overdue()
@@ -816,8 +815,28 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         unique_expired = {record.id: record for record in expired}
         return claimed, list(unique_expired.values())
 
+    @staticmethod
+    def _bind_queue_limits(parameters: "dict[str, Any]", queue_limits: "Mapping[str, int] | None") -> "int":
+        """Bind per-queue caps as ``qc_*`` parameters.
+
+        Returns:
+            The number of bound caps, which selects the capped statement variant.
+        """
+        if not queue_limits:
+            return 0
+        for index, (queue, cap) in enumerate(sorted(queue_limits.items())):
+            parameters[f"qc_queue_{index}"] = queue
+            parameters[f"qc_cap_{index}"] = cap
+        return len(queue_limits)
+
     async def _claim_many_postgres_with_expired(
-        self, store: "SQLSpecQueueStore", *, limit: "int", queues: "tuple[str, ...]", execution_backend: "str | None"
+        self,
+        store: "SQLSpecQueueStore",
+        *,
+        limit: "int",
+        queues: "tuple[str, ...]",
+        execution_backend: "str | None",
+        queue_limits: "Mapping[str, int] | None" = None,
     ) -> "tuple[list[QueuedTaskRecord], list[QueuedTaskRecord]]":
         now = _utc_now()
         parameters: "dict[str, Any]" = {
@@ -833,8 +852,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             parameters[f"queue_{index}"] = queue
         if execution_backend is not None:
             parameters["execution_backend"] = execution_backend
+        cap_count = self._bind_queue_limits(parameters, queue_limits)
         sql_text = store.claim_batch_with_expired_returning_sql(
-            queue_count=len(queues), filter_execution_backend=execution_backend is not None
+            queue_count=len(queues), filter_execution_backend=execution_backend is not None, cap_count=cap_count
         )
         with self._observe_queue_operation("claim", execution_backend=execution_backend):
             async with self._session() as driver:

--- a/src/litestar_queues/backends/sqlspec/stores/_dialects.py
+++ b/src/litestar_queues/backends/sqlspec/stores/_dialects.py
@@ -182,6 +182,7 @@ class PostgresQueueStore(SQLSpecQueueStore):
             queue_col = self._quoted_col("queue")
             eb_col = self._quoted_col("execution_backend")
             priority_col = self._quoted_col("priority")
+            queued_col = self._quoted_col("queued_at")
             created_col = self._quoted_col("created_at")
             claim_conditions = [
                 f"{status_col} IN ('pending', 'scheduled')",
@@ -206,7 +207,7 @@ class PostgresQueueStore(SQLSpecQueueStore):
                 f"{self._quoted_col('completed_at')} = :completed_at, {self._quoted_col('heartbeat_at')} = NULL "
                 f"FROM expired_candidates AS e WHERE t.{id_col} = e.{id_col} RETURNING {returned}), "
                 f"claim_candidates AS (SELECT {id_col} FROM {table} WHERE {claim_where} "
-                f"ORDER BY {priority_col} DESC, {created_col} ASC "
+                f"ORDER BY {priority_col} DESC, {queued_col} ASC, {created_col} ASC, {id_col} ASC "
                 f"FOR UPDATE SKIP LOCKED LIMIT :limit), "
                 f"claimed AS (UPDATE {table} AS t SET {status_col} = 'running', "
                 f"{self._quoted_col('started_at')} = :started_at, {self._quoted_col('heartbeat_at')} = :heartbeat_at "
@@ -253,7 +254,8 @@ class PostgresQueueStore(SQLSpecQueueStore):
             (
                 f"CREATE INDEX IF NOT EXISTS {self._quoted_index_name('pending')} "
                 f"ON {table_name} ({self._quoted_col('queue')}, {self._quoted_col('execution_backend')}, "
-                f"{self._quoted_col('priority')} DESC, {self._quoted_col('created_at')}) "
+                f"{self._quoted_col('priority')} DESC, {self._quoted_col('queued_at')}, "
+                f"{self._quoted_col('created_at')}) "
                 f"WHERE {self._quoted_col('status')} IN ('pending', 'scheduled')"
             ),
             (

--- a/src/litestar_queues/backends/sqlspec/stores/_dialects.py
+++ b/src/litestar_queues/backends/sqlspec/stores/_dialects.py
@@ -168,9 +168,11 @@ class PostgresQueueStore(SQLSpecQueueStore):
     supports_returning_claim: "ClassVar[bool]" = True
     supports_combined_expiry_claim: "ClassVar[bool]" = True
 
-    def claim_batch_with_expired_returning_sql(self, *, queue_count: "int", filter_execution_backend: "bool") -> "str":
+    def claim_batch_with_expired_returning_sql(
+        self, *, queue_count: "int", filter_execution_backend: "bool", cap_count: "int" = 0
+    ) -> "str":
         """Return one PostgreSQL statement that expires and claims due records."""
-        cache_key = f"claim_batch_with_expired:{queue_count}:{int(filter_execution_backend)}"
+        cache_key = f"claim_batch_with_expired:{queue_count}:{int(filter_execution_backend)}:{cap_count}"
 
         def build() -> "str":
             table = self._quoted_table_name()
@@ -198,6 +200,19 @@ class PostgresQueueStore(SQLSpecQueueStore):
                 claim_conditions.append(f"{eb_col} = :execution_backend")
             claim_where = " AND ".join(claim_conditions)
             returned = self._prefixed_returning_columns_sql("t")
+            if cap_count:
+                candidates_sql = (
+                    f"{self._capped_candidate_ctes_sql(cap_count=cap_count, where=claim_where)}"  # noqa: S608
+                    f"claim_candidates AS (SELECT {id_col} FROM {table} "
+                    f"WHERE {id_col} IN (SELECT {id_col} FROM picked) AND {claim_where} "
+                    f"FOR UPDATE SKIP LOCKED), "
+                )
+            else:
+                candidates_sql = (
+                    f"claim_candidates AS (SELECT {id_col} FROM {table} WHERE {claim_where} "  # noqa: S608
+                    f"ORDER BY {priority_col} DESC, {queued_col} ASC, {created_col} ASC, {id_col} ASC "
+                    f"FOR UPDATE SKIP LOCKED LIMIT :limit), "
+                )
             return (
                 f"WITH expired_candidates AS (SELECT {id_col} FROM {table} "  # noqa: S608
                 f"WHERE {status_col} IN ('pending', 'scheduled') AND {execution_ref_col} IS NULL "
@@ -206,9 +221,7 @@ class PostgresQueueStore(SQLSpecQueueStore):
                 f"expired AS (UPDATE {table} AS t SET {status_col} = 'expired', "
                 f"{self._quoted_col('completed_at')} = :completed_at, {self._quoted_col('heartbeat_at')} = NULL "
                 f"FROM expired_candidates AS e WHERE t.{id_col} = e.{id_col} RETURNING {returned}), "
-                f"claim_candidates AS (SELECT {id_col} FROM {table} WHERE {claim_where} "
-                f"ORDER BY {priority_col} DESC, {queued_col} ASC, {created_col} ASC, {id_col} ASC "
-                f"FOR UPDATE SKIP LOCKED LIMIT :limit), "
+                f"{candidates_sql}"
                 f"claimed AS (UPDATE {table} AS t SET {status_col} = 'running', "
                 f"{self._quoted_col('started_at')} = :started_at, {self._quoted_col('heartbeat_at')} = :heartbeat_at "
                 f"FROM claim_candidates AS c WHERE t.{id_col} = c.{id_col} RETURNING {returned}) "

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -249,13 +249,54 @@ class SQLSpecQueueStore:
 
         return self._cached("insert_returning", build)
 
-    def claim_batch_returning_sql(self, *, queue_count: "int", filter_execution_backend: "bool") -> "str":
+    def _claim_order_sql(self, *, alias: "str" = "") -> "str":
+        """Return the canonical claim ordering, optionally prefixed with a table alias."""
+        prefix = f"{alias}." if alias else ""
+        return (
+            f"{prefix}{self._quoted_col('priority')} DESC, {prefix}{self._quoted_col('queued_at')} ASC, "
+            f"{prefix}{self._quoted_col('created_at')} ASC, {prefix}{self._quoted_col('id')} ASC"
+        )
+
+    def _capped_candidate_ctes_sql(self, *, cap_count: "int", where: "str") -> "str":
+        """Return ``caps``/``ranked``/``picked`` CTE text applying per-queue claim caps.
+
+        PostgreSQL rejects ``FOR UPDATE`` in a query level that contains a window
+        function, so ranking happens here and the caller locks the picked ids in a
+        separate stage.
+
+        Returns:
+            Comma-terminated CTE definitions ending with the ``picked`` CTE.
+        """
+        table = self._quoted_table_name()
+        id_col = self._quoted_col("id")
+        queue_col = self._quoted_col("queue")
+        cap_rows = ", ".join(
+            f"(CAST(:qc_queue_{index} AS {self._indexed_text_type()}), CAST(:qc_cap_{index} AS INTEGER))"
+            for index in range(cap_count)
+        )
+        ranked_columns = ", ".join(
+            self._quoted_col(canonical) for canonical in ("id", "queue", "priority", "queued_at", "created_at")
+        )
+        return (
+            f'caps("queue", "cap") AS (VALUES {cap_rows}), '  # noqa: S608
+            f"ranked AS (SELECT {ranked_columns}, row_number() OVER ("
+            f"PARTITION BY {queue_col} ORDER BY {self._claim_order_sql()}"
+            f') AS "qrank" FROM {table} WHERE {where}), '
+            f"picked AS (SELECT r.{id_col} FROM ranked AS r "
+            f'LEFT JOIN caps AS c ON c."queue" = r.{queue_col} '
+            f'WHERE c."cap" IS NULL OR r."qrank" <= c."cap" '
+            f"ORDER BY {self._claim_order_sql(alias='r')} LIMIT :limit), "
+        )
+
+    def claim_batch_returning_sql(
+        self, *, queue_count: "int", filter_execution_backend: "bool", cap_count: "int" = 0
+    ) -> "str":
         """Return a cached batched claim statement locking rows with SKIP LOCKED.
 
         Returns:
             An ``UPDATE ... FROM (SELECT ... FOR UPDATE SKIP LOCKED LIMIT :limit) ... RETURNING`` statement.
         """
-        cache_key = f"claim_batch:{queue_count}:{int(filter_execution_backend)}"
+        cache_key = f"claim_batch:{queue_count}:{int(filter_execution_backend)}:{cap_count}"
 
         def build() -> "str":
             table = self._quoted_table_name()
@@ -281,10 +322,23 @@ class SQLSpecQueueStore:
             if filter_execution_backend:
                 conditions.append(f"{eb_col} = :execution_backend")
             where = " AND ".join(conditions)
-            return (
+            update_sql = (
                 f"UPDATE {table} AS t "  # noqa: S608
                 f"SET {status_col} = 'running', {self._quoted_col('started_at')} = :started_at, "
                 f"{self._quoted_col('heartbeat_at')} = :heartbeat_at "
+            )
+            if cap_count:
+                return (
+                    f"WITH {self._capped_candidate_ctes_sql(cap_count=cap_count, where=where)}"  # noqa: S608
+                    f"claim_candidates AS (SELECT {id_col} FROM {table} "
+                    f"WHERE {id_col} IN (SELECT {id_col} FROM picked) AND {where} "
+                    f"FOR UPDATE SKIP LOCKED) "
+                    f"{update_sql}"
+                    f"FROM claim_candidates AS c WHERE t.{id_col} = c.{id_col} "
+                    f"RETURNING {self._prefixed_returning_columns_sql('t')}"
+                )
+            return (
+                f"{update_sql}"  # noqa: S608
                 f"FROM (SELECT {id_col} FROM {table} WHERE {where} "
                 f"ORDER BY {priority_col} DESC, {queued_col} ASC, {created_col} ASC, {id_col} ASC "
                 f"FOR UPDATE SKIP LOCKED LIMIT :limit) AS sub "
@@ -294,7 +348,9 @@ class SQLSpecQueueStore:
 
         return self._cached(cache_key, build)
 
-    def claim_batch_with_expired_returning_sql(self, *, queue_count: "int", filter_execution_backend: "bool") -> "str":
+    def claim_batch_with_expired_returning_sql(
+        self, *, queue_count: "int", filter_execution_backend: "bool", cap_count: "int" = 0
+    ) -> "str":
         """Return a tagged expiry-and-claim statement for capable stores."""
         raise NotImplementedError
 

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -985,18 +985,9 @@ class QueueService:
             Records successfully transitioned to ``running``.
         """
         backend = self.get_queue_backend()
-        if queue_limits is None:
-            claimed, expired = await backend.claim_many_with_expired(
-                limit=limit, queues=queues, execution_backend=execution_backend
-            )
-        else:
-            from litestar_queues.backends.base import BaseQueueBackend
-
-            expired = await backend.expire_overdue()
-            claimed = await BaseQueueBackend.claim_many(
-                backend, limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
-            )
-            expired.extend(await backend.expire_overdue())
+        claimed, expired = await backend.claim_many_with_expired(
+            limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
+        )
         self.observability_runtime.record_histogram(
             "litestar_queues.claim.batch.size",
             len(claimed),

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -364,9 +364,37 @@ async def test_redis_backend_claim_many_orders_by_priority_then_created(redis_ba
     assert all(record.status == "running" for record in claimed)
 
 
-async def test_redis_queue_filtered_claim_reaches_beyond_ready_window(
-    redis_backend: "RedisQueueBackend",
+async def test_redis_claim_many_enforces_queue_limits_in_script(
+    redis_backend: "RedisQueueBackend", monkeypatch: "pytest.MonkeyPatch"
 ) -> "None":
+    """Per-queue caps are applied inside the claim script, not by a generic fallback loop."""
+    from litestar_queues.backends.base import BaseQueueBackend
+
+    email_first = await redis_backend.enqueue("tasks.caps.email1", queue="email", priority=100)
+    email_second = await redis_backend.enqueue("tasks.caps.email2", queue="email", priority=90)
+    bulk = await redis_backend.enqueue("tasks.caps.bulk", queue="bulk", priority=50)
+    reports = await redis_backend.enqueue("tasks.caps.reports", queue="reports", priority=1)
+
+    def _fail(*args: "Any", **kwargs: "Any") -> "Any":
+        del args, kwargs
+        msg = "fell back to generic claim loop"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(BaseQueueBackend, "claim_many", _fail)
+    monkeypatch.setattr(BaseQueueBackend, "claim_next", _fail)
+
+    claimed = await redis_backend.claim_many(limit=4, queue_limits={"email": 1, "reports": 2})
+
+    assert [record.id for record in claimed] == [email_first.id, bulk.id, reports.id]
+    stored = await redis_backend.get_task(email_second.id)
+    assert stored is not None
+    assert stored.status == "pending"
+
+    later = await redis_backend.claim_many(limit=4)
+    assert [record.id for record in later] == [email_second.id]
+
+
+async def test_redis_queue_filtered_claim_reaches_beyond_ready_window(redis_backend: "RedisQueueBackend") -> "None":
     """A queue-filtered claim finds records sitting far behind other queues' head-of-set traffic."""
     noise = [await redis_backend.enqueue(f"tasks.noise.{index}", queue="noise", priority=10) for index in range(40)]
     wanted = [await redis_backend.enqueue(f"tasks.wanted.{index}", queue="wanted", priority=1) for index in range(3)]

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -364,6 +364,40 @@ async def test_redis_backend_claim_many_orders_by_priority_then_created(redis_ba
     assert all(record.status == "running" for record in claimed)
 
 
+async def test_redis_queue_filtered_claim_reaches_beyond_ready_window(
+    redis_backend: "RedisQueueBackend",
+) -> "None":
+    """A queue-filtered claim finds records sitting far behind other queues' head-of-set traffic."""
+    noise = [await redis_backend.enqueue(f"tasks.noise.{index}", queue="noise", priority=10) for index in range(40)]
+    wanted = [await redis_backend.enqueue(f"tasks.wanted.{index}", queue="wanted", priority=1) for index in range(3)]
+
+    claimed = await redis_backend.claim_many(limit=3, queues=("wanted",))
+
+    assert {record.id for record in claimed} == {record.id for record in wanted}
+    assert all(record.queue == "wanted" for record in claimed)
+    assert all(record.status == "running" for record in claimed)
+    for record in noise:
+        stored = await redis_backend.get_task(record.id)
+        assert stored is not None
+        assert stored.status == "pending"
+
+
+async def test_redis_list_pending_orders_retries_behind_newer_work(redis_backend: "RedisQueueBackend") -> "None":
+    """``list_pending`` ranks a retried record behind newer same-priority work."""
+    old = await redis_backend.enqueue("tasks.fairness.old", priority=5, max_retries=3)
+    await asyncio.sleep(0.005)
+    newer = await redis_backend.enqueue("tasks.fairness.newer", priority=5, max_retries=3)
+
+    assert await redis_backend.claim_task(old.id) is not None
+    retried = await redis_backend.fail_task(old.id, "boom", retry=True, expected_retry_count=0)
+    assert retried is not None
+    assert retried.status == "pending"
+
+    pending = await redis_backend.list_pending(limit=2)
+
+    assert [record.id for record in pending] == [newer.id, old.id]
+
+
 async def test_redis_backend_claim_many_filters_queue_and_execution_backend(
     redis_backend: "RedisQueueBackend",
 ) -> "None":

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -577,6 +577,27 @@ def test_postgres_claim_with_expired_sql_is_one_tagged_statement() -> "None":
     assert '"execution_backend" = :execution_backend' in sql
 
 
+def test_postgres_claim_with_expired_sql_orders_by_queued_at() -> "None":
+    """The combined expiry/claim statement uses the canonical fairness ordering."""
+    store = AsyncpgQueueStore(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
+
+    sql = store.claim_batch_with_expired_returning_sql(queue_count=0, filter_execution_backend=False)
+
+    assert 'ORDER BY "priority" DESC, "queued_at" ASC, "created_at" ASC, "id" ASC' in sql
+    assert 'ORDER BY "priority" DESC, "created_at" ASC ' not in sql
+
+
+def test_postgres_pending_index_covers_queued_at() -> "None":
+    """The Postgres partial pending index matches the canonical claim ordering."""
+    store = AsyncpgQueueStore(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
+
+    pending_index = next(
+        statement for statement in store.create_statements() if store._quoted_index_name("pending") in statement
+    )
+
+    assert '"priority" DESC, "queued_at", "created_at"' in pending_index
+
+
 def test_sqlspec_complete_returning_sql_clears_heartbeat_and_fences() -> "None":
     """The completion statement clears the heartbeat and fences on running status."""
     store = AsyncpgQueueStore(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
@@ -1763,6 +1784,28 @@ async def test_sqlspec_postgres_claim_many_single_statement_orders_and_fences(
             claimed_ids.extend(record.id for record in straggler)
         assert len(claimed_ids) == len(set(claimed_ids))
         assert set(claimed_ids) == concurrent_ids
+
+
+async def test_sqlspec_postgres_combined_claim_retries_behind_newer_work(
+    postgres_service: "PostgresService", request: "FixtureRequest"
+) -> "None":
+    """A retried record re-enters behind newer same-priority work on the combined hot path."""
+    async with _postgres_asyncpg_backend(postgres_service, request, "lq_claim_fair") as backend:
+        assert type(backend._get_store()).supports_combined_expiry_claim is True
+
+        old = await backend.enqueue("tasks.fairness.old", queue="q1", priority=5, max_retries=3)
+        newer = await backend.enqueue("tasks.fairness.newer", queue="q1", priority=5, max_retries=3)
+
+        first, _ = await backend.claim_many_with_expired(limit=1, queues=("q1",))
+        assert [record.id for record in first] == [old.id]
+
+        retried = await backend.fail_task(old.id, "boom", retry=True, expected_retry_count=0)
+        assert retried is not None
+        assert retried.status == "pending"
+
+        second, _ = await backend.claim_many_with_expired(limit=1, queues=("q1",))
+
+        assert [record.id for record in second] == [newer.id]
 
 
 async def test_sqlspec_postgres_claim_many_returns_owned_expirations(

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -528,7 +528,7 @@ def test_sqlspec_claim_batch_sql_is_cached() -> "None":
     claim_second = store.claim_batch_returning_sql(queue_count=1, filter_execution_backend=True)
 
     assert claim_first is claim_second
-    assert store._cached_sql["claim_batch:1:1"] is claim_first
+    assert store._cached_sql["claim_batch:1:1:0"] is claim_first
     assert store.complete_returning_sql(fence_retry_count=True) is store.complete_returning_sql(fence_retry_count=True)
     assert store.fail_returning_sql(fence_retry_count=True) is store.fail_returning_sql(fence_retry_count=True)
     assert store.insert_returning_sql() is store.insert_returning_sql()
@@ -559,6 +559,40 @@ def test_sqlspec_claim_batch_returning_sql_shape() -> "None":
     unfiltered = store.claim_batch_returning_sql(queue_count=0, filter_execution_backend=False)
     assert '"queue" IN' not in unfiltered
     assert '"execution_backend" = :execution_backend' not in unfiltered
+
+
+def test_sqlspec_claim_batch_sql_with_caps_shape() -> "None":
+    """Per-queue caps rank inside a CTE so the locking stage stays window-function free."""
+    store = AsyncpgQueueStore(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
+
+    capped = store.claim_batch_returning_sql(queue_count=0, filter_execution_backend=False, cap_count=2)
+
+    assert 'PARTITION BY "queue"' in capped
+    assert '"qrank" <= c."cap"' in capped
+    assert "FOR UPDATE SKIP LOCKED" in capped
+    assert ":qc_queue_0" in capped
+    assert ":qc_cap_1" in capped
+    ranked_select = capped.split("picked AS")[0]
+    assert "row_number()" in ranked_select
+    assert "FOR UPDATE" not in ranked_select
+
+    assert store.claim_batch_returning_sql(
+        queue_count=0, filter_execution_backend=False, cap_count=0
+    ) == store.claim_batch_returning_sql(queue_count=0, filter_execution_backend=False)
+
+
+def test_postgres_claim_with_expired_sql_with_caps_shape() -> "None":
+    """The combined Postgres statement applies caps in a ranking CTE too."""
+    store = AsyncpgQueueStore(_fake_adapter_config("asyncpg", dialect="postgres"), table_name="queue_tasks")
+
+    capped = store.claim_batch_with_expired_returning_sql(queue_count=0, filter_execution_backend=False, cap_count=1)
+
+    assert 'PARTITION BY "queue"' in capped
+    assert '"qrank" <= c."cap"' in capped
+    assert capped.count("FOR UPDATE SKIP LOCKED") == 2
+    assert store.claim_batch_with_expired_returning_sql(
+        queue_count=0, filter_execution_backend=False, cap_count=0
+    ) == store.claim_batch_with_expired_returning_sql(queue_count=0, filter_execution_backend=False)
 
 
 def test_postgres_claim_with_expired_sql_is_one_tagged_statement() -> "None":
@@ -1784,6 +1818,64 @@ async def test_sqlspec_postgres_claim_many_single_statement_orders_and_fences(
             claimed_ids.extend(record.id for record in straggler)
         assert len(claimed_ids) == len(set(claimed_ids))
         assert set(claimed_ids) == concurrent_ids
+
+
+def _forbid_generic_claim_loop(monkeypatch: "pytest.MonkeyPatch") -> "None":
+    """Make any fall back to the generic per-record claim loop fail loudly."""
+    from litestar_queues.backends.base import BaseQueueBackend
+
+    def _fail(*args: "Any", **kwargs: "Any") -> "Any":
+        del args, kwargs
+        msg = "fell back to generic claim loop"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(BaseQueueBackend, "claim_many", _fail)
+    monkeypatch.setattr(BaseQueueBackend, "claim_next", _fail)
+
+
+async def test_sqlspec_postgres_claim_many_enforces_queue_limits_natively(
+    postgres_service: "PostgresService", request: "FixtureRequest", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    """Per-queue caps ride the single-statement claim instead of the generic loop."""
+    async with _postgres_asyncpg_backend(postgres_service, request, "lq_caps_claim") as backend:
+        email_first = await backend.enqueue("tasks.caps.email1", queue="email", priority=100)
+        email_second = await backend.enqueue("tasks.caps.email2", queue="email", priority=90)
+        reports = await backend.enqueue("tasks.caps.reports", queue="reports", priority=1)
+        bulk = await backend.enqueue("tasks.caps.bulk", queue="bulk", priority=50)
+
+        _forbid_generic_claim_loop(monkeypatch)
+        claimed = await backend.claim_many(limit=4, queue_limits={"email": 1, "reports": 2})
+
+        assert {record.id for record in claimed} == {email_first.id, bulk.id, reports.id}
+        stored = await backend.get_task(email_second.id)
+        assert stored is not None
+        assert stored.status == "pending"
+
+
+async def test_sqlspec_postgres_claim_many_with_expired_enforces_queue_limits_natively(
+    postgres_service: "PostgresService", request: "FixtureRequest", monkeypatch: "pytest.MonkeyPatch"
+) -> "None":
+    """The combined statement honours per-queue caps and still reports expirations."""
+    async with _postgres_asyncpg_backend(postgres_service, request, "lq_caps_combined") as backend:
+        email_first = await backend.enqueue("tasks.caps.email1", queue="email", priority=100)
+        email_second = await backend.enqueue("tasks.caps.email2", queue="email", priority=90)
+        reports = await backend.enqueue("tasks.caps.reports", queue="reports", priority=1)
+        bulk = await backend.enqueue("tasks.caps.bulk", queue="bulk", priority=50)
+        overdue = await backend.enqueue(
+            "tasks.caps.overdue",
+            queue="email",
+            priority=200,
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+
+        _forbid_generic_claim_loop(monkeypatch)
+        claimed, expired = await backend.claim_many_with_expired(limit=4, queue_limits={"email": 1, "reports": 2})
+
+        assert {record.id for record in claimed} == {email_first.id, bulk.id, reports.id}
+        assert [record.id for record in expired] == [overdue.id]
+        stored = await backend.get_task(email_second.id)
+        assert stored is not None
+        assert stored.status == "pending"
 
 
 async def test_sqlspec_postgres_combined_claim_retries_behind_newer_work(

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -12,7 +12,7 @@ from litestar_queues.execution import BaseExecutionBackend
 from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
     from uuid import UUID
 
     from litestar_queues.events import QueueEvent, QueueEventLog, QueueEventLogRecord, QueueEventStageSummary
@@ -1309,3 +1309,53 @@ async def test_interrupt_task_under_the_cap_requeues() -> "None":
         assert stored.status == "pending"
         assert stored.metadata.get("interruptions") == 1
         assert stored.error is None
+
+
+class _RecordingClaimBackend(InMemoryQueueBackend):
+    """Records the kwargs every native batch-claim call receives."""
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.claim_calls: "list[Mapping[str, int] | None]" = []
+        self.base_loop_calls = 0
+
+    async def claim_many_with_expired(
+        self,
+        *,
+        limit: "int",
+        queues: "tuple[str, ...]" = (),
+        execution_backend: "str | None" = None,
+        queue_limits: "Mapping[str, int] | None" = None,
+    ) -> "tuple[list[QueuedTaskRecord], list[QueuedTaskRecord]]":
+        self.claim_calls.append(queue_limits)
+        return await super().claim_many_with_expired(
+            limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
+        )
+
+    async def claim_many(
+        self,
+        *,
+        limit: "int",
+        queues: "tuple[str, ...]" = (),
+        execution_backend: "str | None" = None,
+        queue_limits: "Mapping[str, int] | None" = None,
+    ) -> "list[QueuedTaskRecord]":
+        self.base_loop_calls += 1
+        return await super().claim_many(
+            limit=limit, queues=queues, execution_backend=execution_backend, queue_limits=queue_limits
+        )
+
+
+async def test_claim_tasks_forwards_queue_limits_to_backend() -> "None":
+    """Per-queue caps reach the backend through one batch-claim call."""
+    backend = _RecordingClaimBackend()
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=backend
+    ) as service:
+        await backend.enqueue("tasks.email.first", queue="email")
+        await backend.enqueue("tasks.email.second", queue="email")
+
+        claimed = await service.claim_tasks(limit=2, queue_limits={"email": 1})
+
+    assert len(claimed) == 1
+    assert backend.claim_calls == [{"email": 1}]


### PR DESCRIPTION
Claiming work is supposed to follow one order everywhere — highest priority first, then oldest queued, then oldest created. Three claim paths disagreed with that, so this aligns them and keeps every backend on its single-round-trip claim.

- **A retried task no longer hot-loops ahead of newer work on PostgreSQL.** The combined expire-and-claim statement ordered candidates by priority and creation time only. A retry resets the queued time precisely so the task re-enters behind newer same-priority work, but that statement ignored it, so a fast-failing task could starve everything else at its priority (#114). The partial pending index now covers the same columns.
- **A queue-filtered Redis worker no longer sits idle in front of its own work.** The claim script only looked at the first window of the shared ready set, so records parked behind another queue's traffic were invisible and the worker claimed nothing. It now pages through the set until it fills its batch or runs out (#118). Candidate listing sorts by the same keys the claim uses.
- **Per-queue concurrency caps keep the fast claim path.** Setting `queue_concurrency` used to disable native batch claim entirely and fall back to a sequential per-record loop. Caps now ride the native paths: PostgreSQL ranks candidates per queue inside the same statement and still locks with `FOR UPDATE SKIP LOCKED`, and Redis and Valkey carry the remaining caps into the same script (#121). Backends without a native batch claim, such as memory, keep using the shared loop.

## How you use it

Nothing changes in configuration. `WorkerConfig(queue_concurrency={"email": 1, "reports": 2})` behaves the same from the outside but now costs one statement or one script call per poll instead of up to one round trip per record. Freshly created PostgreSQL schemas pick up the wider pending index; existing deployments keep their current index until the schema is recreated.
