### PR TITLE
feat: cut running-cancellation delivery latency

### DIFF
--- a/docs/usage/failures-and-cancellation.rst
+++ b/docs/usage/failures-and-cancellation.rst
@@ -45,6 +45,40 @@ record. The default remains ``False`` so an ordinary cancellation call cannot
 silently overwrite active work. Running cancellation is cooperative: the task
 must check for cancellation and release its resources safely.
 
+How a running cancellation reaches the worker
+=============================================
+
+The durable status write is authoritative. Every worker reconciles its running
+tasks against stored status on a fixed cadence
+(``WorkerConfig.cancellation_poll_interval``, one second by default), so a
+cancellation always lands even if nothing else works.
+
+On top of that, cancelling a running record publishes a worker-control hint so
+the owning worker stops waiting and reconciles immediately. This matters most
+when a worker is at ``max_concurrency``: it has nothing to claim, so it sits in
+an adaptive polling wait that can grow to ``poll_backoff_max`` (thirty seconds
+by default). The hint interrupts that wait.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Backend
+     - Hint transport
+   * - Redis, Valkey
+     - a dedicated pub/sub control channel
+   * - SQLSpec on PostgreSQL
+     - the events channel, ``LISTEN``/``NOTIFY``-backed
+   * - memory
+     - an in-process event
+   * - everything else
+     - none; the durable poll is the only path
+
+Hints are lossy by contract. A dropped hint costs latency, never correctness,
+so a backend that cannot deliver one simply keeps polling. Backends adding a
+transport implement ``notify_worker_control`` and ``wait_for_worker_control``
+and must preserve that contract: no cancellation outcome may depend on a hint
+arriving.
+
 Inside a task, ``current_task_context().is_cancelled`` exposes the cooperative
 token; ``wait_cancelled()`` waits for it and ``raise_if_cancelled()`` raises
 ``JobCancelledError``. Threaded synchronous work must use these checkpoints.

--- a/docs/usage/workers.rst
+++ b/docs/usage/workers.rst
@@ -101,6 +101,26 @@ consecutive misses are tolerated. ``heartbeat_jitter_fraction`` adds up to that
 fraction of positive random delay to each interval so a fleet does not write in
 lockstep. It defaults to ``0.1``; set it to ``0.0`` for an exact fixed interval.
 
+Losing a claim
+==============
+
+When ``heartbeat_miss_threshold`` consecutive heartbeat writes are rejected, the
+worker no longer owns the record: another worker has taken it over. The queue
+already fences writes on the claim, so the losing attempt cannot record a
+result — but its side effects keep going while the replacement re-runs the same
+task.
+
+``WorkerConfig.cancel_on_claim_loss`` (default ``True``) closes that window by
+cancelling the local coroutine as soon as claim loss is detected. The body sees
+``asyncio.CancelledError``, the attempt is recorded as interrupted, and no
+terminal write is attempted, so exactly one ownership-loss event is published
+for the attempt. The record itself is left alone; it belongs to whichever worker
+holds the claim now.
+
+Set it to ``False`` to let a lost attempt run to completion instead. Its
+terminal write is then rejected on the claim fence, which publishes a second
+ownership-loss event for the same attempt.
+
 Choosing a placement
 ====================
 

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -227,8 +227,31 @@ class BaseQueueBackend:
         records = await asyncio.gather(*(self.get_task(task_id) for task_id in task_ids))
         return [record for record in records if record is not None]
 
-    async def notify_worker_control(self, worker_id: "str") -> "None":
-        """Publish a best-effort worker-control hint."""
+    async def notify_worker_control(self, worker_id: "str | None") -> "None":
+        """Publish a best-effort worker-control hint.
+
+        ``worker_id`` is the record's persisted owner when the backend tracks
+        one, and ``None`` otherwise. It travels for observability only: the
+        control channel is shared and every subscribed worker reconciles its
+        own running tasks against durable status on receipt.
+
+        Worker-control hints are lossy: durable status remains authoritative,
+        and a dropped hint costs cancellation latency, never correctness.
+        """
+
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        """Wait for a best-effort worker-control hint.
+
+        Mirrors :meth:`wait_for_wakeups`: polling-only backends inherit this
+        sleep-and-report-nothing default and stay pure-poll.
+
+        Returns:
+            True when a control hint was observed.
+        """
+        del worker_id
+        if timeout is not None:
+            await asyncio.sleep(timeout)
+        return False
 
     async def assign_worker(
         self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -375,8 +375,20 @@ class EphemeralQueueBackend(BaseQueueBackend):
         records = await asyncio.gather(*(self.get_task(task_id) for task_id in task_ids))
         return [record for record in records if record is not None]
 
-    async def notify_worker_control(self, worker_id: "str") -> "None":
-        """Rely on durable polling for cross-process cancellation."""
+    async def notify_worker_control(self, worker_id: "str | None") -> "None":
+        """Rely on durable polling for cross-process cancellation.
+
+        A process-local signal would only ever reach the emitting process, and
+        the owning worker usually runs in another one.
+        """
+
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        """Rely on durable polling for cross-process cancellation.
+
+        Returns:
+            Always False: this backend has no cross-process control transport.
+        """
+        return await super().wait_for_worker_control(worker_id=worker_id, timeout=timeout)
 
     async def assign_worker(
         self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -39,6 +39,8 @@ class InMemoryQueueBackend(BaseQueueBackend):
     """In-process queue backend for tests, local development, and examples."""
 
     __slots__ = (
+        "_control_event",
+        "_control_pending_read",
         "_event_log",
         "_keys",
         "_lock",
@@ -57,6 +59,8 @@ class InMemoryQueueBackend(BaseQueueBackend):
         self._lock = asyncio.Lock()
         self._notification_event = asyncio.Event()
         self._pending_read = PendingNativeRead()
+        self._control_event = asyncio.Event()
+        self._control_pending_read = PendingNativeRead()
         self._event_log: "QueueEventLog | None" = None
         self._maintenances: "dict[str, tuple[str, datetime]]" = {}
 
@@ -189,9 +193,9 @@ class InMemoryQueueBackend(BaseQueueBackend):
     async def get_tasks(self, task_ids: "Sequence[UUID]") -> "list[QueuedTaskRecord]":
         return [record for task_id in task_ids if (record := self._records.get(task_id)) is not None]
 
-    async def notify_worker_control(self, worker_id: "str") -> "None":
+    async def notify_worker_control(self, worker_id: "str | None") -> "None":
         del worker_id
-        self._notification_event.set()
+        self._control_event.set()
 
     async def assign_worker(
         self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
@@ -774,6 +778,18 @@ class InMemoryQueueBackend(BaseQueueBackend):
         self._notification_event.clear()
         return True
 
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        del worker_id
+        if not self._control_pending_read.has_pending and self._control_event.is_set():
+            self._control_event.clear()
+            return True
+        task = await self._control_pending_read.race(self._control_event.wait, timeout)
+        if task is None:
+            return False
+        task.result()
+        self._control_event.clear()
+        return True
+
     async def time_until_next_due(self, *, queues: "tuple[str, ...]" = ()) -> "float | None":
         """Return seconds until the earliest not-yet-due pending/scheduled record.
 
@@ -796,8 +812,9 @@ class InMemoryQueueBackend(BaseQueueBackend):
         return max((min(upcoming) - _utc_now()).total_seconds(), 0.0)
 
     async def close(self) -> "None":
-        """Cancel any retained notification wait."""
+        """Cancel any retained notification and worker-control waits."""
         await self._pending_read.aclose()
+        await self._control_pending_read.aclose()
 
     async def clear(self) -> "None":
         """Clear all in-memory records."""
@@ -807,7 +824,9 @@ class InMemoryQueueBackend(BaseQueueBackend):
             self._maintenances.clear()
             self._reservations.clear()
             self._notification_event.clear()
+            self._control_event.clear()
         await self._pending_read.aclose()
+        await self._control_pending_read.aclose()
         if self._event_log is not None:
             clear = getattr(self._event_log, "clear", None)
             if clear is not None:

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -747,6 +747,9 @@ class RedisQueueBackend(BaseQueueBackend):
         "_completion_pubsub",
         "_completion_reader_task",
         "_completion_waiters",
+        "_control_channel",
+        "_control_pending_read",
+        "_control_pubsub",
         "_event_log",
         "_key_prefix",
         "_notifications",
@@ -781,8 +784,13 @@ class RedisQueueBackend(BaseQueueBackend):
             if config is not None
             else "litestar_queues:worker_wakeups"
         )
+        self._control_channel = (
+            config.names.channel("worker_control") if config is not None else "litestar_queues:worker_control"
+        )
         self._pubsub: "PubSubLike | None" = None
         self._pending_read = PendingNativeRead()
+        self._control_pubsub: "PubSubLike | None" = None
+        self._control_pending_read = PendingNativeRead()
         self._completion_lock = asyncio.Lock()
         self._completion_pubsub: "PubSubLike | None" = None
         self._completion_reader_task: "asyncio.Task[None] | None" = None
@@ -817,10 +825,14 @@ class RedisQueueBackend(BaseQueueBackend):
         if self._event_log is not None:
             await self._event_log.flush_events()
         await self._pending_read.aclose()
+        await self._control_pending_read.aclose()
         await self._close_completion_subscriber()
         if self._pubsub is not None:
             await _close_pubsub(self._pubsub, self._wakeup_channel)
             self._pubsub = None
+        if self._control_pubsub is not None:
+            await _close_pubsub(self._control_pubsub, self._control_channel)
+            self._control_pubsub = None
         if self._owns_client and self._client is not None:
             close = getattr(self._client, "aclose", None) or getattr(self._client, "close", None)
             if close is not None:
@@ -1844,6 +1856,43 @@ class RedisQueueBackend(BaseQueueBackend):
             raise exc
         return bool(task.result())
 
+    async def notify_worker_control(self, worker_id: "str | None") -> "None":
+        """Publish a worker-control hint on the Redis-protocol control channel.
+
+        The hint is lossy by contract: it only shortens the wait before the
+        owning worker reconciles durable status.
+        """
+        if not self._notifications:
+            return
+        client = await self._get_client()
+        await client.publish(self._control_channel, _json_dumps({"event": "worker_control", "worker_id": worker_id}))
+
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        """Wait for a Redis-protocol worker-control hint.
+
+        The control subscription and its pending receive are retained across
+        worker poll timeouts, exactly like the wakeup subscription, and are
+        never shared with it: one in-flight read per subscription.
+
+        Returns:
+            True when a control hint was observed.
+
+        Raises:
+            Exception: Whatever the pub/sub receive raised, after the
+                subscription is reset so the next wait reconnects.
+        """
+        if not self._notifications:
+            return await super().wait_for_worker_control(worker_id=worker_id, timeout=timeout)
+        pubsub = await self._get_control_pubsub()
+        task = await self._control_pending_read.race(lambda: _receive_pubsub_message(pubsub), timeout)
+        if task is None:
+            return False
+        exc = task.exception()
+        if exc is not None:
+            await self._reset_control_pubsub()
+            raise exc
+        return bool(task.result())
+
     async def time_until_next_due(self, *, queues: "tuple[str, ...]" = ()) -> "float | None":
         """Return seconds until the earliest not-yet-due scheduled record.
 
@@ -1874,6 +1923,14 @@ class RedisQueueBackend(BaseQueueBackend):
         self._pubsub = None
         if pubsub is not None:
             await _close_pubsub(pubsub, self._wakeup_channel)
+
+    async def _reset_control_pubsub(self) -> "None":
+        """Drop the control subscription so the next wait re-establishes it."""
+        await self._control_pending_read.aclose()
+        pubsub = self._control_pubsub
+        self._control_pubsub = None
+        if pubsub is not None:
+            await _close_pubsub(pubsub, self._control_channel)
 
     async def wait_for_completion(self, task_id: "UUID", *, timeout: "float | None" = None) -> "bool":
         """Wait for a terminal completion message naming ``task_id``.
@@ -1971,6 +2028,15 @@ class RedisQueueBackend(BaseQueueBackend):
             if inspect.isawaitable(subscribe):
                 await subscribe
         return self._pubsub
+
+    async def _get_control_pubsub(self) -> "PubSubLike":
+        if self._control_pubsub is None:
+            client = await self._get_client()
+            self._control_pubsub = client.pubsub()
+            subscribe = self._control_pubsub.subscribe(self._control_channel)
+            if inspect.isawaitable(subscribe):
+                await subscribe
+        return self._control_pubsub
 
     async def _commit_transition(
         self,

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -26,7 +26,11 @@ from litestar_queues.backends.base import (
     stale_requeue_error,
     stale_requeue_priority,
 )
-from litestar_queues.backends.sqlspec.config import DEFAULT_WAKEUP_CHANNEL, SQLSpecBackendConfig
+from litestar_queues.backends.sqlspec.config import (
+    DEFAULT_CONTROL_CHANNEL,
+    DEFAULT_WAKEUP_CHANNEL,
+    SQLSpecBackendConfig,
+)
 from litestar_queues.backends.sqlspec.event_log import (
     SQLSpecQueueEventLog,
     create_event_log_store,
@@ -125,6 +129,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
     __slots__ = (
         "_column_map",
+        "_control_channel",
+        "_control_pending_read",
+        "_control_stream",
         "_event_channel",
         "_event_history_table_name",
         "_event_log",
@@ -215,6 +222,11 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         )
         self._event_stream: "Any | None" = None
         self._pending_read = PendingNativeRead()
+        self._control_stream: "Any | None" = None
+        self._control_pending_read = PendingNativeRead()
+        self._control_channel = (
+            config.names.database_channel("worker_control") if config is not None else DEFAULT_CONTROL_CHANNEL
+        )
         self._opened = False
 
     async def open(self) -> "bool":
@@ -239,6 +251,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         if self._event_log is not None:
             await self._event_log.flush_events()
         await self._close_notification_stream()
+        await self._close_control_stream()
         await self._close_heartbeat_pool()
         if self._owns_event_channel and self._event_channel is not None:
             await _invoke_event_channel_method(self._event_channel, "shutdown")
@@ -1837,6 +1850,56 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         await _invoke_event_channel_method(self._event_channel, "ack", event.event_id)
         return True
 
+    async def notify_worker_control(self, worker_id: "str | None") -> "None":
+        """Publish a worker-control hint on the SQLSpec events channel.
+
+        On the Postgres drivers this is a LISTEN/NOTIFY message. The hint is
+        lossy by contract: it only shortens the wait before the owning worker
+        reconciles durable status.
+        """
+        if not self._worker_wakeups_enabled or self._event_channel is None:
+            return
+        await _invoke_event_channel_method(
+            self._event_channel,
+            "publish",
+            self._resolve_control_channel(),
+            {"event": "worker_control", "worker_id": worker_id},
+            {"event_type": "litestar_queues.worker_control"},
+        )
+
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        """Wait for a SQLSpec worker-control hint.
+
+        One ``iter_events`` stream and its pending read are retained across
+        worker poll timeouts, exactly like the wakeup stream, and are never
+        shared with it.
+
+        Returns:
+            True when a control hint was observed.
+
+        Raises:
+            Exception: Whatever the event read raised, after the stream is
+                closed so the next wait re-establishes it.
+        """
+        if not self._worker_wakeups_enabled or self._event_channel is None:
+            return await super().wait_for_worker_control(worker_id=worker_id, timeout=timeout)
+
+        stream = self._control_stream
+        if stream is None:
+            stream = self._event_channel.iter_events(
+                self._resolve_control_channel(), poll_interval=self._wakeup_poll_interval
+            )
+            self._control_stream = stream
+        task = await self._control_pending_read.race(lambda: _next_event(stream), timeout)
+        if task is None:
+            return False
+        exc = task.exception()
+        if exc is not None:
+            await self._close_control_stream()
+            raise exc
+        await _invoke_event_channel_method(self._event_channel, "ack", task.result().event_id)
+        return True
+
     async def time_until_next_due(self, *, queues: "tuple[str, ...]" = ()) -> "float | None":
         """Return seconds until the earliest not-yet-due pending/scheduled record.
 
@@ -1869,6 +1932,19 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                     if isawaitable(result):
                         await result
 
+    async def _close_control_stream(self) -> "None":
+        """Cancel the retained control read and close its iterator."""
+        await self._control_pending_read.aclose()
+        stream = self._control_stream
+        self._control_stream = None
+        if stream is not None:
+            with suppress(Exception):
+                close = getattr(stream, "aclose", None) or getattr(stream, "close", None)
+                if close is not None:
+                    result = close()
+                    if isawaitable(result):
+                        await result
+
     @staticmethod
     def _default_sqlspec_config() -> "SQLSpecConfig":
         from sqlspec.adapters.aiosqlite import AiosqliteConfig
@@ -1888,6 +1964,10 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         else:
             self._wakeup_channel = DEFAULT_WAKEUP_CHANNEL
         return self._wakeup_channel
+
+    def _resolve_control_channel(self) -> "str":
+        self._control_channel = _normalize_wakeup_channel(str(self._control_channel))
+        return self._control_channel
 
     def _configure_worker_wakeups(self) -> "None":
         sqlspec_config = self._get_sqlspec_config()

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -19,9 +19,17 @@ if TYPE_CHECKING:
     from litestar_queues.backends.sqlspec._typing import SQLSpecConfig, SQLSpecStoreConfig
     from litestar_queues.config import QueueConfig
 
-__all__ = ("DEFAULT_WAKEUP_CHANNEL", "WAKEUP_TRANSPORTS", "SQLSpecBackendConfig", "SQLSpecWorkerWakeupConfig")
+__all__ = (
+    "DEFAULT_CONTROL_CHANNEL",
+    "DEFAULT_WAKEUP_CHANNEL",
+    "WAKEUP_TRANSPORTS",
+    "SQLSpecBackendConfig",
+    "SQLSpecWorkerWakeupConfig",
+)
 
 DEFAULT_WAKEUP_CHANNEL = "litestar_queues_tasks"
+
+DEFAULT_CONTROL_CHANNEL = "litestar_queues_worker_control"
 
 WAKEUP_TRANSPORTS: "frozenset[str]" = frozenset({"aq", "notify", "notify_queue", "poll_queue", "polling", "txeventq"})
 """Valid worker-wakeup transports for :attr:`SQLSpecWorkerWakeupConfig.transport`.

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -220,6 +220,15 @@ class WorkerConfig:
     heartbeat_miss_threshold: "int" = 2
     """Consecutive heartbeat misses tolerated before claim loss."""
 
+    cancel_on_claim_loss: "bool" = True
+    """Whether heartbeat claim loss cancels the locally running coroutine.
+
+    Writes are already fenced on the claim, but side effects are not: while a
+    lost claim keeps running, a replacement worker executes the same record.
+    Cancelling closes that duplicate-execution window. Set to ``False`` to let
+    a lost attempt run to completion and have its terminal write rejected.
+    """
+
     cancellation_poll_interval: "float" = 1.0
     """Interval between durable running-cancellation reconciliation passes."""
 

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -651,7 +651,9 @@ class QueueService:
         task_context = _task_execution_context(record, worker_id=None, event_publisher=self.get_event_publisher())
         await task_context.lifecycle("task.cancelled", message=message, payload=payload)
         self._log_task_event("Queue task cancelled", record, level=logging.INFO, payload=payload)
-        if include_running and record.worker_id is not None:
+        if include_running:
+            # Not gated on a persisted owner: backends that do not track one
+            # would otherwise never emit the hint their workers listen for.
             await backend.notify_worker_control(record.worker_id)
         return True
 

--- a/src/litestar_queues/worker/heartbeat.py
+++ b/src/litestar_queues/worker/heartbeat.py
@@ -11,7 +11,7 @@ from litestar_queues.models import HeartbeatTouch
 from litestar_queues.namespace import QueueNamespace
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
     from typing import Protocol
 
     from litestar_queues.models import HeartbeatTouchResult, QueuedTaskRecord
@@ -90,6 +90,7 @@ class WorkerHeartbeatManager:
         "_jitter_fraction",
         "_logger",
         "_miss_threshold",
+        "_on_claim_lost",
         "_registrations",
         "_service",
         "_stop_event",
@@ -105,8 +106,10 @@ class WorkerHeartbeatManager:
         miss_threshold: "int" = 2,
         worker_id: "str",
         jitter_fraction: "float" = 0.1,
+        on_claim_lost: "Callable[[UUID], None] | None" = None,
     ) -> "None":
         self._service = service
+        self._on_claim_lost = on_claim_lost
         config = getattr(service, "config", None)
         names = getattr(config, "names", QueueNamespace())
         self._logger = logging.getLogger(names.logger("worker", "heartbeat"))
@@ -231,6 +234,12 @@ class WorkerHeartbeatManager:
             self.record_failure(exc)
             return
         self.unregister(task_id)
+        if self._on_claim_lost is None:
+            return
+        try:
+            self._on_claim_lost(task_id)
+        except Exception as exc:  # noqa: BLE001 - a cancel hiccup must not kill the heartbeat loop.
+            self.record_failure(exc, "Queue worker claim-loss cancellation failed")
 
     async def _safe_tick(self) -> "None":
         try:

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -141,6 +141,7 @@ class Worker:
             miss_threshold=worker_config.heartbeat_miss_threshold,
             worker_id=self._worker_id,
             jitter_fraction=worker_config.heartbeat_jitter_fraction,
+            on_claim_lost=self._cancel_claim_lost_task if worker_config.cancel_on_claim_loss else None,
         )
         self._queues = worker_config.queues
         self._running_tasks: "dict[asyncio.Task[None], QueuedTaskRecord]" = {}
@@ -430,6 +431,23 @@ class Worker:
                     extra={"worker_id": self._worker_id},
                 )
         self._completion_event.set()
+
+    def _cancel_claim_lost_task(self, task_id: "UUID") -> "None":
+        """Cancel the local coroutine whose claim the heartbeat manager just lost.
+
+        Deliberately a plain ``cancel()`` rather than the durable-cancel pair:
+        claim loss is an ownership interruption, not a user cancel, so the
+        attempt records ``interrupted`` telemetry and attempts no terminal
+        write. The record already belongs to whichever worker took the claim.
+        """
+        for task, record in self._running_tasks.items():
+            if record.id != task_id or task.done():
+                continue
+            task.cancel()
+            self._record_counter(
+                "litestar_queues.worker.claim_lost_cancel", {"messaging.destination.name": record.queue}
+            )
+            return
 
     async def _maybe_cancel_running(self) -> "None":
         if not self._running_tasks:

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -679,16 +679,24 @@ class Worker:
             )
             self._listener_reconnect_pending = False
         notification_task = asyncio.create_task(queue_backend.wait_for_wakeups(timeout=timeout))
+        control_task = asyncio.create_task(
+            queue_backend.wait_for_worker_control(worker_id=self._worker_id, timeout=timeout)
+        )
         stop_task = asyncio.create_task(self._stop_event.wait())
         completion_task = asyncio.create_task(self._completion_event.wait())
         done, pending = await asyncio.wait(
-            {notification_task, stop_task, completion_task}, return_when=asyncio.FIRST_COMPLETED
+            {notification_task, control_task, stop_task, completion_task}, return_when=asyncio.FIRST_COMPLETED
         )
         self._completion_event.clear()
         for task in pending:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+        if control_task in done and await self._consume_control_task(control_task):
+            # A saturated worker never reaches run_once's cadence check quickly
+            # enough for the hint to matter, so the gate is reset before the pass.
+            self._last_cancellation_check_at = -float("inf")
+            await self._maybe_cancel_running()
         outcome: "bool | None" = None
         if notification_task in done:
             outcome = await self._consume_wait_task(notification_task)
@@ -728,6 +736,31 @@ class Worker:
             await self._backoff_after_loop_error()
             return None
         return result
+
+    async def _consume_control_task(self, task: "asyncio.Task[bool]") -> "bool":
+        """Return whether a worker-control hint arrived, containing read failures.
+
+        Returns:
+            True when a hint was observed and an immediate cancellation pass
+            should run.
+        """
+        try:
+            return task.result()
+        except asyncio.TimeoutError:
+            return False
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Control hints are lossy by contract: a failed read costs latency,
+            # never correctness, because run_once still polls durable status.
+            self._record_counter("litestar_queues.worker.loop.error", {"worker.error.type": type(exc).__name__})
+            self._service.observability_runtime.record_counter(
+                "litestar_queues.listener.error",
+                attributes={**self._transport_metric_attributes(), "queue.outcome": "control_read_failed"},
+            )
+            self._listener_reconnect_pending = True
+            self._logger.exception("Queue worker loop iteration failed", extra={"worker_id": self._worker_id})
+            return False
 
     async def _backoff_after_loop_error(self) -> "None":
         timeout = min(max(self._poll_interval, 0.01), 1.0)

--- a/src/tests/integration/_worker_control_contract.py
+++ b/src/tests/integration/_worker_control_contract.py
@@ -1,0 +1,142 @@
+"""Backend-agnostic proof that a control hint cancels a saturated worker.
+
+The scenario pins both durable slow paths (adaptive-poll ceiling and the
+cancellation poll cadence) far beyond the assertion window, so a prompt cancel
+can only come from the backend's push worker-control transport. The companion
+helper pins them short and disables the transport, proving the durable poll
+remains the correctness fallback.
+"""
+
+import asyncio
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+from litestar_queues import QueueConfig, QueueService, Worker, WorkerConfig, task
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from litestar_queues.backends import BaseQueueBackend
+
+__all__ = ("assert_control_hint_cancels_saturated_worker", "assert_durable_poll_cancels_without_control_hint")
+
+_PINNED_FAR = 30.0
+"""Poll and cancellation-poll interval used to rule out durable discovery."""
+
+
+async def _run_saturated_cancel(
+    *,
+    worker_backend: "BaseQueueBackend",
+    control_backend: "BaseQueueBackend",
+    backend_name: "str",
+    cancellation_poll_interval: "float",
+    poll_interval: "float",
+    wait_for_listener: "Callable[[], Awaitable[None]] | None",
+    timeout: "float",
+) -> "None":
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    @task("tasks.worker_control_hint")
+    async def hung() -> "None":
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    config = QueueConfig(
+        worker=WorkerConfig(placement="external"),
+        queue_backend=backend_name,
+        execution_backend="local",
+        initialize_schedules=False,
+    )
+    service = await QueueService(config, queue_backend=worker_backend).open()
+    controller = await QueueService(config, queue_backend=control_backend).open()
+    worker = Worker(
+        service,
+        WorkerConfig(
+            max_concurrency=1,
+            poll_interval=poll_interval,
+            poll_backoff_max=None,
+            cancellation_poll_interval=cancellation_poll_interval,
+            reconcile_interval=3600,
+            heartbeat_interval=60,
+        ),
+    )
+
+    record = await service.enqueue(hung)
+    worker_task = asyncio.create_task(worker.start())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=timeout)
+        if wait_for_listener is not None:
+            await wait_for_listener()
+
+        assert await controller.cancel_task(record.id, include_running=True) is True
+        await asyncio.wait_for(cancelled.wait(), timeout=timeout)
+    finally:
+        await worker.stop()
+        try:
+            await asyncio.wait_for(asyncio.shield(worker_task), timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            worker_task.cancel()
+            with suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await worker_task
+
+    stored = await worker_backend.get_task(record.id)
+    assert stored is not None
+    assert stored.status == "cancelled"
+
+
+async def assert_control_hint_cancels_saturated_worker(
+    *,
+    worker_backend: "BaseQueueBackend",
+    control_backend: "BaseQueueBackend",
+    backend_name: "str",
+    wait_for_listener: "Callable[[], Awaitable[None]] | None" = None,
+    timeout: "float" = 10.0,
+) -> "None":
+    """Assert a cross-instance cancel reaches a saturated worker within ``timeout``."""
+    await _run_saturated_cancel(
+        worker_backend=worker_backend,
+        control_backend=control_backend,
+        backend_name=backend_name,
+        cancellation_poll_interval=_PINNED_FAR,
+        poll_interval=_PINNED_FAR,
+        wait_for_listener=wait_for_listener,
+        timeout=timeout,
+    )
+
+
+async def assert_durable_poll_cancels_without_control_hint(
+    *,
+    worker_backend: "BaseQueueBackend",
+    control_backend: "BaseQueueBackend",
+    backend_name: "str",
+    timeout: "float" = 10.0,
+) -> "None":
+    """Assert the durable status poll still cancels when every hint is dropped."""
+    backend_type = type(worker_backend)
+    original = backend_type.wait_for_worker_control
+
+    async def never_delivers(self: "BaseQueueBackend", *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        del self, worker_id
+        if timeout is not None:
+            await asyncio.sleep(timeout)
+        return False
+
+    # Slot classes reject instance-level method assignment, so patch the class.
+    backend_type.wait_for_worker_control = never_delivers  # type: ignore[method-assign]
+    try:
+        await _run_saturated_cancel(
+            worker_backend=worker_backend,
+            control_backend=control_backend,
+            backend_name=backend_name,
+            cancellation_poll_interval=0.1,
+            poll_interval=0.1,
+            wait_for_listener=None,
+            timeout=timeout,
+        )
+    finally:
+        backend_type.wait_for_worker_control = original  # type: ignore[method-assign]

--- a/src/tests/integration/backends/redis/test_worker_control.py
+++ b/src/tests/integration/backends/redis/test_worker_control.py
@@ -1,0 +1,78 @@
+"""Real-Redis proof that a worker-control hint cancels a saturated worker."""
+
+import uuid
+from typing import TYPE_CHECKING, Protocol
+
+import pytest
+
+pytest.importorskip("redis")
+
+from litestar_queues import QueueConfig, WorkerConfig
+from litestar_queues.backends.redis import RedisBackendConfig, RedisQueueBackend
+from tests.helpers.redis_protocol import wait_for_channel_subscribers
+from tests.integration._worker_control_contract import (
+    assert_control_hint_cancels_saturated_worker,
+    assert_durable_poll_cancels_without_control_hint,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class RedisService(Protocol):
+    """pytest-databases Redis service attributes used here."""
+
+    host: "str"
+    port: "int"
+    db: "int"
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def redis_control_pair(redis_service: "RedisService") -> "AsyncIterator[tuple[RedisQueueBackend, ...]]":
+    """Yield two independently connected backends sharing one private namespace."""
+    config = QueueConfig(
+        namespace=f"lq_ctl_{uuid.uuid4().hex[:12]}",
+        queue_backend="redis",
+        worker=WorkerConfig(placement="external"),
+        initialize_schedules=False,
+    )
+    url = f"redis://{redis_service.host}:{redis_service.port}/{redis_service.db}"
+    backends = tuple(
+        RedisQueueBackend(config, backend_config=RedisBackendConfig(url=url, worker_wakeups=True)) for _ in range(2)
+    )
+    for backend in backends:
+        await backend.open()
+    try:
+        yield backends
+    finally:
+        for backend in backends:
+            await backend.close()
+
+
+async def test_redis_control_hint_cancels_saturated_worker(
+    redis_control_pair: "tuple[RedisQueueBackend, ...]",
+) -> "None":
+    worker_backend, control_backend = redis_control_pair
+
+    async def listener_ready() -> "None":
+        await wait_for_channel_subscribers(worker_backend, worker_backend._control_channel, timeout=5.0)
+
+    await assert_control_hint_cancels_saturated_worker(
+        worker_backend=worker_backend,
+        control_backend=control_backend,
+        backend_name="redis",
+        wait_for_listener=listener_ready,
+    )
+
+
+async def test_redis_dropped_control_hint_still_cancels_via_durable_poll(
+    redis_control_pair: "tuple[RedisQueueBackend, ...]",
+) -> "None":
+    worker_backend, control_backend = redis_control_pair
+
+    await assert_durable_poll_cancels_without_control_hint(
+        worker_backend=worker_backend, control_backend=control_backend, backend_name="redis"
+    )

--- a/src/tests/integration/backends/sqlspec/test_worker_control.py
+++ b/src/tests/integration/backends/sqlspec/test_worker_control.py
@@ -1,0 +1,114 @@
+"""Postgres LISTEN/NOTIFY proof that a control hint cancels a saturated worker."""
+
+import uuid
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+pytest.importorskip("sqlspec")
+
+from litestar_queues import QueueConfig, WorkerConfig
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig, SQLSpecQueueBackend
+from tests.helpers._timing import wait_until
+from tests.integration._worker_control_contract import (
+    assert_control_hint_cancels_saturated_worker,
+    assert_durable_poll_cancels_without_control_hint,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from litestar_queues.backends.sqlspec.typing import SQLSpecManager, SQLSpecSessionConfig
+    from tests.integration._backends import PostgresService
+
+pytestmark = pytest.mark.anyio
+
+_QUEUE_TABLE = "lq_worker_control"
+
+
+@pytest.fixture
+async def postgres_control_pair(
+    postgres_service: "PostgresService",
+) -> "AsyncIterator[tuple[SQLSpecQueueBackend, ...]]":
+    """Yield two asyncpg-backed backends sharing one private namespace."""
+    pytest.importorskip("asyncpg")
+    from sqlspec.adapters.asyncpg import AsyncpgConfig
+
+    config = QueueConfig(
+        namespace=f"lq_ctl_{uuid.uuid4().hex[:12]}",
+        queue_backend="sqlspec",
+        worker=WorkerConfig(placement="external"),
+        initialize_schedules=False,
+    )
+
+    def sqlspec_config() -> "AsyncpgConfig":
+        return AsyncpgConfig(
+            connection_config={
+                "host": postgres_service.host,
+                "port": postgres_service.port,
+                "user": postgres_service.user,
+                "password": postgres_service.password,
+                "database": postgres_service.database,
+            }
+        )
+
+    backends = tuple(
+        SQLSpecQueueBackend(
+            config, backend_config=SQLSpecBackendConfig(sqlspec_config=sqlspec_config(), queue_table_name=_QUEUE_TABLE)
+        )
+        for _ in range(2)
+    )
+    for backend in backends:
+        await backend.open()
+    await backends[0].create_schema()
+    try:
+        yield backends
+    finally:
+        with suppress(Exception):
+            await _drop_tables(backends[0])
+        for backend in backends:
+            await backend.close()
+
+
+async def _drop_tables(backend: "SQLSpecQueueBackend") -> "None":
+    from litestar_queues.backends.sqlspec.backend import _bridge_session
+
+    assert backend._sqlspec is not None
+    assert backend._sqlspec_config is not None
+    async with _bridge_session(
+        cast("SQLSpecManager", backend._sqlspec), cast("SQLSpecSessionConfig", backend._sqlspec_config)
+    ) as driver:
+        await driver.execute_script(f'DROP TABLE IF EXISTS "{_QUEUE_TABLE}"')
+
+
+async def test_sqlspec_postgres_control_hint_cancels_saturated_worker(
+    postgres_control_pair: "tuple[SQLSpecQueueBackend, ...]",
+) -> "None":
+    worker_backend, control_backend = postgres_control_pair
+    assert worker_backend.capabilities.supports_worker_wakeups is True
+
+    async def listener_ready() -> "None":
+        await wait_until(
+            lambda: cast("Any", worker_backend)._control_stream is not None,
+            timeout=5.0,
+            message="worker did not open its LISTEN/NOTIFY control stream",
+        )
+
+    await assert_control_hint_cancels_saturated_worker(
+        worker_backend=worker_backend,
+        control_backend=control_backend,
+        backend_name="sqlspec",
+        wait_for_listener=listener_ready,
+    )
+
+
+async def test_sqlspec_postgres_dropped_control_hint_still_cancels_via_durable_poll(
+    postgres_control_pair: "tuple[SQLSpecQueueBackend, ...]",
+) -> "None":
+    worker_backend, control_backend = postgres_control_pair
+
+    await assert_durable_poll_cancels_without_control_hint(
+        worker_backend=worker_backend, control_backend=control_backend, backend_name="sqlspec"
+    )

--- a/src/tests/integration/backends/valkey/test_worker_control.py
+++ b/src/tests/integration/backends/valkey/test_worker_control.py
@@ -1,0 +1,78 @@
+"""Real-Valkey proof that a worker-control hint cancels a saturated worker."""
+
+import uuid
+from typing import TYPE_CHECKING, Protocol
+
+import pytest
+
+pytest.importorskip("valkey")
+
+from litestar_queues import QueueConfig, WorkerConfig
+from litestar_queues.backends.valkey import ValkeyBackendConfig, ValkeyQueueBackend
+from tests.helpers.redis_protocol import wait_for_channel_subscribers
+from tests.integration._worker_control_contract import (
+    assert_control_hint_cancels_saturated_worker,
+    assert_durable_poll_cancels_without_control_hint,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class ValkeyService(Protocol):
+    """pytest-databases Valkey service attributes used here."""
+
+    host: "str"
+    port: "int"
+    db: "int"
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def valkey_control_pair(valkey_service: "ValkeyService") -> "AsyncIterator[tuple[ValkeyQueueBackend, ...]]":
+    """Yield two independently connected backends sharing one private namespace."""
+    config = QueueConfig(
+        namespace=f"lq_ctl_{uuid.uuid4().hex[:12]}",
+        queue_backend="valkey",
+        worker=WorkerConfig(placement="external"),
+        initialize_schedules=False,
+    )
+    url = f"redis://{valkey_service.host}:{valkey_service.port}/{valkey_service.db}"
+    backends = tuple(
+        ValkeyQueueBackend(config, backend_config=ValkeyBackendConfig(url=url, worker_wakeups=True)) for _ in range(2)
+    )
+    for backend in backends:
+        await backend.open()
+    try:
+        yield backends
+    finally:
+        for backend in backends:
+            await backend.close()
+
+
+async def test_valkey_control_hint_cancels_saturated_worker(
+    valkey_control_pair: "tuple[ValkeyQueueBackend, ...]",
+) -> "None":
+    worker_backend, control_backend = valkey_control_pair
+
+    async def listener_ready() -> "None":
+        await wait_for_channel_subscribers(worker_backend, worker_backend._control_channel, timeout=5.0)
+
+    await assert_control_hint_cancels_saturated_worker(
+        worker_backend=worker_backend,
+        control_backend=control_backend,
+        backend_name="valkey",
+        wait_for_listener=listener_ready,
+    )
+
+
+async def test_valkey_dropped_control_hint_still_cancels_via_durable_poll(
+    valkey_control_pair: "tuple[ValkeyQueueBackend, ...]",
+) -> "None":
+    worker_backend, control_backend = valkey_control_pair
+
+    await assert_durable_poll_cancels_without_control_hint(
+        worker_backend=worker_backend, control_backend=control_backend, backend_name="valkey"
+    )

--- a/src/tests/unit/backends/test_base_backend.py
+++ b/src/tests/unit/backends/test_base_backend.py
@@ -57,6 +57,14 @@ async def test_worker_lock_uses_a_distinct_token_per_acquisition() -> "None":
     assert len(set(tokens)) == 2
 
 
+async def test_worker_control_wait_defaults_to_sleep_and_report_nothing() -> "None":
+    """Polling-only backends inherit a wait that never claims a hint arrived."""
+    backend = _MaintenanceOnlyBackend()
+
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0) is False
+    assert await backend.wait_for_worker_control(worker_id="worker-a") is False
+
+
 _REQUIRED_CONTRACT_CALLS = {
     "cleanup_terminal": lambda b: b.cleanup_terminal(datetime.now(timezone.utc)),
     "expire_overdue": lambda b: b.expire_overdue(),

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -704,3 +704,15 @@ class _CountingEvent:
     async def wait(self) -> "bool":
         self.waits += 1
         return await self._event.wait()
+
+
+async def test_memory_worker_control_uses_its_own_primitive() -> "None":
+    backend = InMemoryQueueBackend()
+
+    await backend.notify_worker_control("worker-a")
+
+    # The control hint must not masquerade as new-work availability.
+    assert await backend.wait_for_wakeups(timeout=0) is False
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0) is True
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0) is False
+    await backend.close()

--- a/src/tests/unit/backends/test_redis_backend.py
+++ b/src/tests/unit/backends/test_redis_backend.py
@@ -83,6 +83,52 @@ async def test_redis_wait_for_wakeups_wakes_after_prior_timeout() -> "None":
     await backend.close()
 
 
+async def test_redis_notify_worker_control_publishes_to_control_channel() -> "None":
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), worker_wakeups=True))
+
+    await backend.notify_worker_control("worker-a")
+
+    assert len(client.published) == 1
+    channel, payload = client.published[0]
+    assert channel == "litestar_queues:worker_control"
+    assert json.loads(payload) == {"event": "worker_control", "worker_id": "worker-a"}
+
+
+async def test_redis_worker_control_wait_retains_one_read_across_timeouts() -> "None":
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), worker_wakeups=True))
+
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0.001) is False
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0.001) is False
+    control_pubsub = client.pubsubs[0]
+    control_pubsub.deliver()
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=1.0) is True
+
+    # The control subscription is its own, never shared with the wakeup read.
+    assert control_pubsub.channels == ["litestar_queues:worker_control"]
+    assert control_pubsub.subscribe_calls == 1
+    assert control_pubsub.get_message_calls == 1
+
+    assert await backend.wait_for_wakeups(timeout=0.001) is False
+    assert client.pubsubs[1].channels == ["litestar_queues:worker_wakeups"]
+
+    await backend.close()
+    assert control_pubsub.unsubscribe_calls == 1
+    assert control_pubsub.close_calls == 1
+
+
+async def test_redis_worker_control_falls_back_to_polling_without_notifications() -> "None":
+    client = _CountingRedisClient()
+    backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), worker_wakeups=False))
+
+    await backend.notify_worker_control("worker-a")
+
+    assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0) is False
+    assert client.publish_calls == 0
+    assert client.pubsub_calls == 0
+
+
 async def test_redis_enqueue_many_persists_unkeyed_batch_with_one_pipeline_and_one_notification() -> "None":
     client = _CountingRedisClient()
     backend = RedisQueueBackend(backend_config=RedisBackendConfig(client=cast("Any", client), worker_wakeups=True))
@@ -393,10 +439,11 @@ class _CountingPubSub:
         self.subscribe_calls = 0
         self.unsubscribe_calls = 0
         self.get_message_calls = 0
+        self.channels: "list[str]" = []
         self._message: "asyncio.Queue[object]" = asyncio.Queue()
 
     async def subscribe(self, channel: "str") -> "None":
-        del channel
+        self.channels.append(channel)
         self.subscribe_calls += 1
 
     async def unsubscribe(self, channel: "str") -> "None":

--- a/src/tests/unit/backends/test_sqlspec_config.py
+++ b/src/tests/unit/backends/test_sqlspec_config.py
@@ -92,3 +92,38 @@ def test_only_backends_that_own_migrations_advertise_the_hook() -> None:
 
     assert isinstance(SQLSpecBackendConfig(sqlspec_config=AiosqliteConfig()), MigrationConfiguringBackend)
     assert not isinstance(RedisBackendConfig(url="redis://localhost:6379/0"), MigrationConfiguringBackend)
+
+
+@pytest.mark.anyio
+async def test_sqlspec_worker_control_publishes_on_its_own_channel() -> None:
+    """The control hint rides the events channel under its own NOTIFY identifier."""
+    channel = _EventChannel()
+    sqlspec_config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    backend = SQLSpecQueueBackend(
+        backend_config=SQLSpecBackendConfig(
+            sqlspec_config=sqlspec_config,
+            worker_wakeups=SQLSpecWorkerWakeupConfig(channel=cast("AsyncEventChannel", channel)),
+        )
+    )
+
+    await backend.open()
+    try:
+        await backend.notify_worker_control("worker-a")
+        assert channel.published == ["litestar_queues_worker_control"]
+    finally:
+        await backend.close()
+
+
+@pytest.mark.anyio
+async def test_sqlspec_worker_control_falls_back_to_polling_without_wakeups() -> None:
+    """A polling-only adapter keeps the base no-op publish and poll wait."""
+    sqlspec_config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    backend = SQLSpecQueueBackend(backend_config=SQLSpecBackendConfig(sqlspec_config=sqlspec_config))
+
+    await backend.open()
+    try:
+        assert backend.capabilities.supports_worker_wakeups is False
+        await backend.notify_worker_control("worker-a")
+        assert await backend.wait_for_worker_control(worker_id="worker-a", timeout=0) is False
+    finally:
+        await backend.close()

--- a/src/tests/unit/test_consolidated_worker_config.py
+++ b/src/tests/unit/test_consolidated_worker_config.py
@@ -32,6 +32,15 @@ def test_worker_cli_overrides_can_copy_without_mutating_app_config() -> None:
     assert overridden.max_concurrency == 8
 
 
+def test_claim_loss_cancellation_defaults_on_and_is_opt_out() -> None:
+    queue_config = QueueConfig(queue_backend="memory", worker=WorkerConfig(placement="external"))
+    service = QueueService(queue_config, queue_backend=InMemoryQueueBackend(queue_config))
+
+    assert WorkerConfig().cancel_on_claim_loss is True
+    assert Worker(service, WorkerConfig())._heartbeat_manager._on_claim_lost is not None
+    assert Worker(service, WorkerConfig(cancel_on_claim_loss=False))._heartbeat_manager._on_claim_lost is None
+
+
 def test_worker_startup_timeout_must_be_positive() -> None:
     assert WorkerConfig(startup_timeout=0.25).startup_timeout == 0.25
 

--- a/src/tests/unit/test_heartbeat_manager.py
+++ b/src/tests/unit/test_heartbeat_manager.py
@@ -115,7 +115,9 @@ async def test_claim_lost_callback_failure_is_contained() -> "None":
     manager.register(task_id, expected_retry_count=0)
     await manager._tick()
 
-    failures = [name for name, _value, _attributes in service.observability_runtime.counters if name.endswith("failure")]
+    failures = [
+        name for name, _value, _attributes in service.observability_runtime.counters if name.endswith("failure")
+    ]
     assert failures == ["litestar_queues.heartbeat.failure"]
     assert task_id not in manager._registrations
 

--- a/src/tests/unit/test_heartbeat_manager.py
+++ b/src/tests/unit/test_heartbeat_manager.py
@@ -76,6 +76,50 @@ async def test_second_consecutive_miss_claims_lost() -> "None":
     assert task_id not in manager._registrations
 
 
+async def test_claim_lost_invokes_callback_after_unregister() -> "None":
+    """Claim loss should hand the task id to the owner's cancel callback."""
+    task_id = uuid4()
+    record = QueuedTaskRecord(task_name="heartbeat.callback", id=task_id, retry_count=0)
+    backend = FakeBackend(records={task_id: record})
+    backend.touch_results.append(HeartbeatTouchResult(missed_task_ids={task_id}))
+    service = FakeService(backend)
+    seen: "list[UUID]" = []
+    manager = WorkerHeartbeatManager(
+        service, interval=30, miss_threshold=1, worker_id="worker-a", jitter_fraction=0, on_claim_lost=seen.append
+    )
+
+    manager.register(task_id, expected_retry_count=0)
+    await manager._tick()
+
+    assert seen == [task_id]
+    assert task_id not in manager._registrations
+
+
+async def test_claim_lost_callback_failure_is_contained() -> "None":
+    """A raising cancel callback should be recorded, not propagated."""
+    task_id = uuid4()
+    record = QueuedTaskRecord(task_name="heartbeat.callback_error", id=task_id, retry_count=0)
+    backend = FakeBackend(records={task_id: record})
+    backend.touch_results.append(HeartbeatTouchResult(missed_task_ids={task_id}))
+    service = FakeService(backend)
+
+    def explode(task_id: "UUID") -> "None":
+        del task_id
+        msg = "cancel failed"
+        raise RuntimeError(msg)
+
+    manager = WorkerHeartbeatManager(
+        service, interval=30, miss_threshold=1, worker_id="worker-a", jitter_fraction=0, on_claim_lost=explode
+    )
+
+    manager.register(task_id, expected_retry_count=0)
+    await manager._tick()
+
+    failures = [name for name, _value, _attributes in service.observability_runtime.counters if name.endswith("failure")]
+    assert failures == ["litestar_queues.heartbeat.failure"]
+    assert task_id not in manager._registrations
+
+
 async def test_shutdown_flush_and_clear() -> "None":
     """Closing should final-flush current registrations and leave no loop task running."""
     task_id = uuid4()

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -941,6 +941,39 @@ async def test_cancel_task_enforces_running_boundary_and_publishes_once() -> "No
     assert all(event.payload["status"] == "cancelled" for event in cancelled_events)
 
 
+async def test_running_cancel_hints_workers_even_without_a_persisted_owner() -> "None":
+    """The push hint must not depend on a backend that records ``worker_id``."""
+    from litestar_queues import task
+    from litestar_queues.backends import InMemoryQueueBackend
+    from litestar_queues.task import clear_task_registry
+
+    clear_task_registry()
+    hints: "list[str | None]" = []
+
+    class _OwnerlessBackend(InMemoryQueueBackend):
+        __slots__ = ()
+
+        async def notify_worker_control(self, worker_id: "str | None") -> "None":
+            hints.append(worker_id)
+
+    @task("tasks.ownerless_cancel")
+    async def ownerless_cancel() -> "None":
+        return None
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"),
+        queue_backend=_OwnerlessBackend(),
+    ) as service:
+        record = await service.enqueue(ownerless_cancel)
+        claimed = await service.get_queue_backend().claim_task(record.id)
+        assert claimed is not None
+        assert claimed.worker_id is None
+
+        assert await service.cancel_task(record.id, include_running=True) is True
+
+    assert hints == [None]
+
+
 async def test_job_cancelled_error_uses_cancel_task_facade_once() -> "None":
     from litestar_queues import job_cancelled, task
     from litestar_queues.task import clear_task_registry

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -1056,6 +1056,118 @@ async def test_worker_reconciles_durable_running_cancellation() -> "None":
     assert result.status == "cancelled"
 
 
+async def test_control_hint_interrupts_saturated_wait_and_cancels_running() -> "None":
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    @task("tasks.control_hint_cancel")
+    async def control_hint_cancel() -> "None":
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local")
+    ) as service:
+        result = await service.enqueue(control_hint_cancel)
+        backend = cast("InMemoryQueueBackend", service.get_queue_backend())
+        # Both durable slow paths are pinned far out: only a push hint can make
+        # this cancel prompt.
+        worker = Worker(
+            service,
+            WorkerConfig(
+                max_concurrency=1,
+                poll_interval=30,
+                poll_backoff_max=None,
+                cancellation_poll_interval=30,
+                reconcile_interval=3600,
+            ),
+        )
+        worker_task = asyncio.create_task(worker.start())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await wait_until(lambda: backend._pending_read.has_pending, message="worker did not park in its saturated wait")
+
+        assert await service.cancel_task(result.id, include_running=True) is True
+        await asyncio.wait_for(cancelled.wait(), timeout=2)
+
+        await worker.stop()
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait_for(worker_task, timeout=1)
+        await result.refresh()
+
+    assert result.status == "cancelled"
+
+
+async def test_worker_control_read_failure_keeps_loop_alive(caplog: "pytest.LogCaptureFixture") -> "None":
+    @task("tasks.after_control_failure")
+    async def after_control_failure(value: "int") -> "int":
+        return value + 1
+
+    backend = _FailingControlReadInMemoryQueueBackend()
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local"),
+        queue_backend=backend,
+    ) as service:
+        worker = Worker(service, WorkerConfig(poll_interval=0.01))
+
+        with caplog.at_level(logging.ERROR, logger="litestar_queues.worker"):
+            worker_task = asyncio.create_task(worker.start())
+            await asyncio.sleep(0)
+
+            result = await service.enqueue(after_control_failure, 41)
+            await result.wait(timeout=2, poll_interval=0.01)
+
+            await worker.stop()
+            with suppress(asyncio.CancelledError):
+                await asyncio.wait_for(worker_task, timeout=1)
+
+    assert result.status == "completed"
+    assert result.result == 42
+    assert backend.control_read_starts >= 1
+    assert "Queue worker loop iteration failed" in caplog.text
+
+
+async def test_dropped_control_hint_still_cancelled_by_durable_poll() -> "None":
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    @task("tasks.dropped_control_hint")
+    async def dropped_control_hint() -> "None":
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    backend = _DroppedControlHintInMemoryQueueBackend()
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local"),
+        queue_backend=backend,
+    ) as service:
+        result = await service.enqueue(dropped_control_hint)
+        worker = Worker(
+            service, WorkerConfig(poll_interval=0.01, poll_backoff_max=None, cancellation_poll_interval=0.01)
+        )
+        worker_task = asyncio.create_task(worker.start())
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        assert await service.cancel_task(result.id, include_running=True) is True
+        await asyncio.wait_for(cancelled.wait(), timeout=2)
+
+        await worker.stop()
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait_for(worker_task, timeout=1)
+        await result.refresh()
+
+    # The hint was emitted and swallowed; the durable status poll still cancelled.
+    assert backend.control_notify_calls >= 1
+    assert result.status == "cancelled"
+
+
 async def test_heartbeat_claim_loss_cancels_running_coroutine() -> "None":
     started = asyncio.Event()
     cancelled = asyncio.Event()
@@ -1132,8 +1244,7 @@ async def test_claim_loss_cancel_opt_out_preserves_run_to_completion() -> "None"
     ) as service:
         result = await service.enqueue(claim_loss_no_cancel)
         worker = Worker(
-            service,
-            WorkerConfig(heartbeat_interval=60, heartbeat_miss_threshold=1, cancel_on_claim_loss=False),
+            service, WorkerConfig(heartbeat_interval=60, heartbeat_miss_threshold=1, cancel_on_claim_loss=False)
         )
 
         assert await worker.run_once() == 1
@@ -1768,6 +1879,45 @@ class _FailingReadInMemoryQueueBackend(InMemoryQueueBackend):
         task.result()
         self._notification_event.clear()
         return True
+
+
+class _FailingControlReadInMemoryQueueBackend(InMemoryQueueBackend):
+    """Memory backend whose first worker-control read raises."""
+
+    __slots__ = ("_control_fail_pending", "control_read_starts")
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.control_read_starts = 0
+        self._control_fail_pending = True
+
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        self.control_read_starts += 1
+        if self._control_fail_pending:
+            self._control_fail_pending = False
+            msg = "control listener boom"
+            raise RuntimeError(msg)
+        return await super().wait_for_worker_control(worker_id=worker_id, timeout=timeout)
+
+
+class _DroppedControlHintInMemoryQueueBackend(InMemoryQueueBackend):
+    """Memory backend that emits control hints nobody ever receives."""
+
+    __slots__ = ("control_notify_calls",)
+
+    def __init__(self) -> "None":
+        super().__init__()
+        self.control_notify_calls = 0
+
+    async def notify_worker_control(self, worker_id: "str | None") -> "None":
+        del worker_id
+        self.control_notify_calls += 1
+
+    async def wait_for_worker_control(self, *, worker_id: "str", timeout: "float | None" = None) -> "bool":
+        del worker_id
+        if timeout is not None:
+            await asyncio.sleep(timeout)
+        return False
 
 
 class _DroppedNotificationInMemoryQueueBackend(InMemoryQueueBackend):

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -24,6 +24,7 @@ from litestar_queues import (
 from litestar_queues.backends import BaseQueueBackend, InMemoryQueueBackend
 from litestar_queues.events import EventDeliveryConfig, InMemoryQueueEventSink, QueueEventsConfig
 from litestar_queues.execution import BaseExecutionBackend
+from litestar_queues.models import HeartbeatTouchResult
 from tests.helpers._timing import wait_until
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from litestar_queues.events import TaskExecutionContext
-    from litestar_queues.models import HeartbeatTouch, HeartbeatTouchResult, QueuedTaskRecord, StaleTaskRecoveryResult
+    from litestar_queues.models import HeartbeatTouch, QueuedTaskRecord, StaleTaskRecoveryResult
     from litestar_queues.task import TaskResult
     from litestar_queues.worker.heartbeat import WorkerHeartbeatManager
 
@@ -1055,6 +1056,105 @@ async def test_worker_reconciles_durable_running_cancellation() -> "None":
     assert result.status == "cancelled"
 
 
+async def test_heartbeat_claim_loss_cancels_running_coroutine() -> "None":
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    sink = InMemoryQueueEventSink()
+
+    @task("tasks.claim_loss_cancel")
+    async def claim_loss_cancel() -> "None":
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    backend = _ClaimLossInMemoryQueueBackend()
+    async with QueueService(
+        QueueConfig(
+            worker=WorkerConfig(placement="external"),
+            queue_backend="memory",
+            execution_backend="local",
+            events=QueueEventsConfig(delivery=EventDeliveryConfig(sinks=(sink,))),
+        ),
+        queue_backend=backend,
+    ) as service:
+        result = await service.enqueue(claim_loss_cancel)
+        worker = Worker(service, WorkerConfig(heartbeat_interval=60, heartbeat_miss_threshold=1))
+
+        assert await worker.run_once() == 1
+        await asyncio.wait_for(started.wait(), timeout=1)
+        running = next(iter(worker._running_tasks))
+
+        backend.miss_all = True
+        await worker._heartbeat_manager._tick()
+
+        await asyncio.wait_for(cancelled.wait(), timeout=1)
+        with suppress(asyncio.CancelledError):
+            await asyncio.wait_for(running, timeout=1)
+        stored = await backend.get_task(result.id)
+
+    assert running.cancelled() is True
+    # The record is no longer this worker's to finish: no terminal write, and no
+    # requeue (the shutdown gate in ``_execute_claimed`` never opens).
+    assert backend.terminal_calls == []
+    assert backend.interrupt_calls == []
+    assert stored is not None
+    assert stored.status == "running"
+    claim_lost = [event for event in sink.events if event.type == "task.claim_lost"]
+    assert len(claim_lost) == 1
+    assert claim_lost[0].payload["phase"] == "heartbeat"
+
+
+async def test_claim_loss_cancel_opt_out_preserves_run_to_completion() -> "None":
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    sink = InMemoryQueueEventSink()
+
+    @task("tasks.claim_loss_no_cancel")
+    async def claim_loss_no_cancel() -> "str":
+        started.set()
+        await release.wait()
+        finished.set()
+        return "ok"
+
+    backend = _ClaimLossInMemoryQueueBackend(fence_terminal=True)
+    async with QueueService(
+        QueueConfig(
+            worker=WorkerConfig(placement="external"),
+            queue_backend="memory",
+            execution_backend="local",
+            events=QueueEventsConfig(delivery=EventDeliveryConfig(sinks=(sink,))),
+        ),
+        queue_backend=backend,
+    ) as service:
+        result = await service.enqueue(claim_loss_no_cancel)
+        worker = Worker(
+            service,
+            WorkerConfig(heartbeat_interval=60, heartbeat_miss_threshold=1, cancel_on_claim_loss=False),
+        )
+
+        assert await worker.run_once() == 1
+        await asyncio.wait_for(started.wait(), timeout=1)
+        running = next(iter(worker._running_tasks))
+
+        backend.miss_all = True
+        await worker._heartbeat_manager._tick()
+
+        release.set()
+        await asyncio.wait_for(running, timeout=1)
+
+    # Historical behavior: the body runs to completion and its terminal write is
+    # fence-rejected, emitting a second claim-lost for the same attempt.
+    assert finished.is_set() is True
+    assert running.cancelled() is False
+    assert backend.terminal_calls == [("complete_task", result.id)]
+    phases = [event.payload["phase"] for event in sink.events if event.type == "task.claim_lost"]
+    assert phases == ["heartbeat", "complete"]
+
+
 async def test_plugin_shutdown_waits_for_in_flight_worker_task() -> "None":
     started = asyncio.Event()
     release = asyncio.Event()
@@ -1773,6 +1873,62 @@ class _ClaimManyRecordingInMemoryQueueBackend(_ClaimNextRecordingInMemoryQueueBa
                 if claimed is not None:
                     records.append(claimed)
         return records
+
+
+class _ClaimLossInMemoryQueueBackend(InMemoryQueueBackend):
+    """Memory backend that can force heartbeat misses and fence terminal writes."""
+
+    __slots__ = ("fence_terminal", "interrupt_calls", "miss_all", "terminal_calls")
+
+    def __init__(self, *, fence_terminal: "bool" = False) -> "None":
+        super().__init__()
+        self.miss_all = False
+        self.fence_terminal = fence_terminal
+        self.terminal_calls: "list[tuple[str, UUID]]" = []
+        self.interrupt_calls: "list[UUID]" = []
+
+    async def touch_heartbeats(self, touches: "Sequence[HeartbeatTouch]") -> "HeartbeatTouchResult":
+        if self.miss_all:
+            return HeartbeatTouchResult(missed_task_ids={touch.task_id for touch in touches})
+        return await super().touch_heartbeats(touches)
+
+    async def complete_task(
+        self, task_id: "UUID", *, result: "Any" = None, expected_retry_count: "int | None" = None
+    ) -> "QueuedTaskRecord | None":
+        self.terminal_calls.append(("complete_task", task_id))
+        if self.fence_terminal:
+            return None
+        return await super().complete_task(task_id, result=result, expected_retry_count=expected_retry_count)
+
+    async def fail_task(
+        self,
+        task_id: "UUID",
+        error: "str",
+        *,
+        retry: "bool" = True,
+        expected_retry_count: "int | None" = None,
+        retry_at: "datetime | None" = None,
+        queued_at: "datetime | None" = None,
+    ) -> "QueuedTaskRecord | None":
+        self.terminal_calls.append(("fail_task", task_id))
+        if self.fence_terminal:
+            return None
+        return await super().fail_task(
+            task_id,
+            error,
+            retry=retry,
+            expected_retry_count=expected_retry_count,
+            retry_at=retry_at,
+            queued_at=queued_at,
+        )
+
+    async def interrupt_task(
+        self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
+    ) -> "QueuedTaskRecord | None":
+        self.interrupt_calls.append(task_id)
+        return await super().interrupt_task(
+            task_id, expected_retry_count=expected_retry_count, worker_id=worker_id, queued_at=queued_at
+        )
 
 
 class _HeartbeatCleanupRecordingBackend(InMemoryQueueBackend):


### PR DESCRIPTION
Cancelling a running task could take up to 30 seconds to actually stop it, and a worker that lost its claim kept running the task body to completion while a replacement re-executed the same record. This makes cancellation land in about a second and closes the duplicate-execution window.

**Cancels now reach a busy worker promptly.** A worker at `max_concurrency` has nothing to claim, so it sits in an adaptive polling wait that grows to `poll_backoff_max` (30s by default) — meaning cancels were slowest exactly when the system was busiest. Cancelling a running record now publishes a worker-control hint that interrupts that wait and triggers an immediate reconciliation pass.

**Per-backend delivery.** Redis and Valkey publish on a dedicated pub/sub control channel; SQLSpec publishes on its events channel, which is `LISTEN`/`NOTIFY`-backed on PostgreSQL. Everything else keeps polling — the base backend gains a sleep-and-return-nothing wait, so polling-only backends need no changes.

**Hints are lossy, durable status is authoritative.** No cancellation outcome depends on a hint arriving. The periodic status poll remains the correctness path, so a dropped hint costs latency and nothing else.

**Losing a claim now cancels the local coroutine.** When heartbeat writes are rejected, the record belongs to another worker. The losing attempt is cancelled instead of running to completion, so its side effects stop and exactly one ownership-loss event is published for the attempt. `WorkerConfig.cancel_on_claim_loss=False` restores the previous run-to-completion behavior.

**Fixed a hint that could never fire.** The hint was previously gated on a persisted `worker_id`, which backends that return fresh record copies (Redis, Valkey, SQLSpec) never recorded — so the very backends this targets would have stayed silent.

This addresses #117 and #120.

## How you use it

Nothing to turn on. `cancel_task(task_id, include_running=True)` behaves the same, just faster wherever notifications are already enabled, and claim-loss cancellation is on by default.
