### PR TITLE
feat(worker): harden shutdown, interruption, and stale recovery

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,9 +34,11 @@ Unreleased
   hanging. Tasks still alive after ``final_cancel_timeout`` are logged and have
   their heartbeats cleared so stale recovery can reclaim them at once.
 * ``QueueConfig.stale_requeue_priority`` chooses the priority recovered work
-  re-enters with: ``"preserve"``, an integer ceiling clamp (the default ``4``,
-  unchanged behavior), or a callable mapping the old priority to the new one.
-  See :doc:`usage/worker-recovery`.
+  re-enters with: ``"preserve"`` (the default), an integer ceiling clamp, or a
+  callable mapping the old priority to the new one. **Breaking:** stale-recovered
+  work now keeps its original priority instead of being clamped to ``4``. Pass
+  ``stale_requeue_priority=4`` to restore the clamp. See
+  :doc:`usage/worker-recovery`.
 * ``WorkerConfig.queue_concurrency`` sets per-worker caps for named queues.
   These are local limits, not fleet-wide semaphores.
 * ``WorkerConfig.cancellation_poll_interval``: workers reconcile durable

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,45 @@ Unreleased
   streaming-pull deliveries against the authoritative queue backend. The
   official Google emulator backs the integration suite. See
   :doc:`usage/deployment/pubsub`.
+* Shutdown requeue: ``WorkerConfig.requeue_on_shutdown`` returns an in-flight
+  attempt to ``pending`` once its coroutine accepts cancellation, with a
+  per-task ``@task(requeue_on_shutdown=...)`` override,
+  :meth:`~litestar_queues.QueueService.interrupt_task`, and the
+  ``task.interrupted`` lifecycle event. Every shipped backend now performs the
+  requeue behind an owner and generation fence. See :doc:`usage/workers`.
+* ``WorkerConfig.max_interruptions`` (default ``3``) bounds how many times one
+  attempt may be requeued by shutdown. Interruptions are counted in the record's
+  metadata and consume no retry attempt below the cap; at the cap the
+  interruption goes through the ordinary retry policy instead, so a task that is
+  restarted forever eventually fails.
+* ``WorkerConfig.hard_exit_timeout`` (default ``10.0`` seconds, ``None`` to
+  disable) bounds a forced shutdown. When the deadline passes, or a third
+  termination signal arrives, the process exits with ``128 + signum`` instead of
+  hanging. Tasks still alive after ``final_cancel_timeout`` are logged and have
+  their heartbeats cleared so stale recovery can reclaim them at once.
+* ``QueueConfig.stale_requeue_priority`` chooses the priority recovered work
+  re-enters with: ``"preserve"``, an integer ceiling clamp (the default ``4``,
+  unchanged behavior), or a callable mapping the old priority to the new one.
+  See :doc:`usage/worker-recovery`.
+* ``WorkerConfig.queue_concurrency`` sets per-worker caps for named queues.
+  These are local limits, not fleet-wide semaphores.
+* ``WorkerConfig.cancellation_poll_interval``: workers reconcile durable
+  ``cancelled`` state into running executions, so
+  ``cancel_task(..., include_running=True)`` interrupts a cooperative task on
+  another worker. Worker-control notifications make that pickup prompt on
+  notification-capable backends.
+* Service-level cancellation, single and bulk, with task name, queue, kwargs,
+  and metadata filters, plus cooperative in-task cancellation checkpoints. See
+  :doc:`usage/failures-and-cancellation`.
+
+**Changed:**
+
+* Claim ordering is now fair: ready work is ordered by priority, then
+  ``queued_at``, then creation time. A retried, requeued, or interrupted record
+  re-enters the line at its requeue time instead of jumping ahead of newer work.
+  Deployments that relied on retried work being claimed first will see a
+  different claim order.
+* Queue-scoped statistics are enforced filters rather than advisory hints.
 
 0.8.0 - 2026-08-03
 ==================

--- a/docs/usage/worker-recovery.rst
+++ b/docs/usage/worker-recovery.rst
@@ -27,6 +27,26 @@ worker at a time check for stale records. A stale task returns to the queue if
 it has retries left. Otherwise, it ends with a stale failure. A task may turn
 off stale requeueing or register ``on_stale_failure`` for cleanup.
 
+Recovered priority
+------------------
+
+``QueueConfig.stale_requeue_priority`` decides the priority recovered work
+re-enters the queue with:
+
+.. code-block:: python
+
+   QueueConfig(stale_requeue_priority="preserve")   # keep the original priority
+   QueueConfig(stale_requeue_priority=4)            # ceiling clamp (the default)
+   QueueConfig(stale_requeue_priority=lambda p: p - 1)  # map old priority to new
+
+The default clamps to ``4``, which is the historical behavior. That demotion
+protects a queue from a record that crashes its worker repeatedly, but it also
+inverts priority: work enqueued at priority ``9`` re-enters at ``4`` and can be
+starved indefinitely by ordinary priority-``5`` inflow. Prefer ``"preserve"``
+together with bounded shutdown interruptions and a real ``max_retries`` budget
+when the priority actually matters. A callable that returns anything other than
+an integer fails the sweep loudly rather than silently clamping.
+
 Heartbeat timestamps are automatic for every running task. Calling
 ``beat(detail)`` is optional: it replaces the latest short diagnostic detail
 without changing heartbeat cadence. Progress and custom task events are

--- a/docs/usage/worker-recovery.rst
+++ b/docs/usage/worker-recovery.rst
@@ -35,17 +35,17 @@ re-enters the queue with:
 
 .. code-block:: python
 
-   QueueConfig(stale_requeue_priority="preserve")   # keep the original priority
-   QueueConfig(stale_requeue_priority=4)            # ceiling clamp (the default)
+   QueueConfig(stale_requeue_priority="preserve")   # keep the original priority (the default)
+   QueueConfig(stale_requeue_priority=4)            # ceiling clamp
    QueueConfig(stale_requeue_priority=lambda p: p - 1)  # map old priority to new
 
-The default clamps to ``4``, which is the historical behavior. That demotion
-protects a queue from a record that crashes its worker repeatedly, but it also
-inverts priority: work enqueued at priority ``9`` re-enters at ``4`` and can be
-starved indefinitely by ordinary priority-``5`` inflow. Prefer ``"preserve"``
-together with bounded shutdown interruptions and a real ``max_retries`` budget
-when the priority actually matters. A callable that returns anything other than
-an integer fails the sweep loudly rather than silently clamping.
+Recovered work keeps its priority by default. A ceiling clamp protects a queue
+from a record that crashes its worker repeatedly, but it also inverts priority:
+work enqueued at priority ``9`` re-enters at the ceiling and can then be starved
+indefinitely by ordinary priority-``5`` inflow. Reach for a clamp only when that
+trade is one you want, and pair it with bounded shutdown interruptions and a real
+``max_retries`` budget. A callable that returns anything other than an integer
+fails the sweep loudly rather than silently clamping.
 
 Heartbeat timestamps are automatic for every running task. Calling
 ``beat(detail)`` is optional: it replaces the latest short diagnostic detail

--- a/docs/usage/workers.rst
+++ b/docs/usage/workers.rst
@@ -158,16 +158,38 @@ By default, unfinished work remains ``running`` for stale recovery. Set
 ``WorkerConfig.requeue_on_shutdown=True`` to return an attempt to ``pending``
 after its coroutine accepts cancellation and unwinds. Tasks can override this
 with ``@task(requeue_on_shutdown=True)`` or ``False`` and must be idempotent.
+Every shipped backend performs the requeue behind an owner and generation
+fence, so a worker can only requeue the attempt it still owns.
 
-The first termination signal stops new claims and gives running tasks time to
-finish. A second signal cancels them. Server placement must become ready within
-``startup_timeout``. Shutdown then allows ``graceful_shutdown_timeout``, uses
-``final_cancel_timeout`` for cancellation, and finally escalates to bounded
-process-tree termination if the child cannot exit. The standalone CLI returns
-``0`` for a clean shutdown, ``1`` for a worker error, and ``2`` when the
-graceful timeout ends and cancellation begins. Windows uses console Ctrl+C or
-Ctrl+Break semantics. Focused topology smoke tests run on macOS and Windows in
-native CI jobs.
+Each requeue is counted in the record's ``interruptions`` metadata and does not
+spend a retry attempt. ``WorkerConfig.max_interruptions`` (default ``3``) bounds
+that: once an attempt has been interrupted that many times, the next
+interruption goes through the ordinary retry policy instead, so a task that is
+restarted forever eventually fails rather than cycling.
+
+The escalation ladder:
+
+#. **First signal** — stop claiming and drain for ``graceful_shutdown_timeout``.
+#. **Second signal** — cancel running tasks with a ``final_cancel_timeout``
+   budget and arm the hard-exit watchdog.
+#. **Deadline or third signal** — the process exits with ``128 + signum``
+   (``143`` for SIGTERM, ``130`` for SIGINT). ``WorkerConfig.hard_exit_timeout``
+   (default ``10.0`` seconds, ``None`` to disable) is the wall-clock budget from
+   forced shutdown to that exit. The watchdog runs on a daemon thread, because
+   the case it exists for is an event loop that no longer runs callbacks.
+
+Tasks still alive after ``final_cancel_timeout`` are logged with their ids and
+their heartbeats are cleared, so a stale sweep can reclaim them immediately
+instead of waiting out a full heartbeat age. Stale recovery is off by default;
+set ``WorkerConfig.stale_after`` (or the maintenance equivalent) to make that
+handoff useful.
+
+Server placement must become ready within ``startup_timeout``, and shutdown
+finally escalates to bounded process-tree termination if the child cannot exit.
+The standalone CLI returns ``0`` for a clean shutdown, ``1`` for a worker error,
+and ``2`` when the graceful timeout ends and cancellation begins. Windows uses
+console Ctrl+C or Ctrl+Break semantics. Focused topology smoke tests run on
+macOS and Windows in native CI jobs.
 
 See :doc:`worker-wakeups` for idle waiting and :doc:`worker-recovery` for
 heartbeats and stale work.

--- a/src/litestar_queues/_cli.py
+++ b/src/litestar_queues/_cli.py
@@ -13,6 +13,7 @@ import os
 import signal
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from typing import TYPE_CHECKING, cast
 
 import click
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 
     from litestar_queues.maintenance import MaintenancePhase, QueueMaintenanceSummary
     from litestar_queues.service import QueueService
+    from litestar_queues.worker.runtime import ShutdownWatchdog
 
 __all__ = (
     "queues_group",
@@ -181,30 +183,39 @@ def run_consumer_command(
 async def _run_consumer(
     plugin: "QueuePlugin", backend: "BaseConsumerExecutionBackend", max_concurrency: "int", drain_timeout: "float"
 ) -> "int":
+    from litestar_queues.worker.runtime import ShutdownWatchdog
+
     service = _open_service(plugin)
     await service.open()
     task = asyncio.create_task(
         backend.run_consumer(service, max_concurrency=max_concurrency, drain_timeout=drain_timeout)
     )
     loop = asyncio.get_running_loop()
+    watchdog = ShutdownWatchdog(plugin.config.worker.hard_exit_timeout)
     stop_count = 0
 
-    def stop() -> "None":
+    def stop(signum: "int" = int(signal.SIGTERM)) -> "None":
         nonlocal stop_count
         stop_count += 1
+        if stop_count > FORCE_STOP_SIGNAL_COUNT:
+            watchdog.exit_now(signum)
+            return
+        if stop_count >= FORCE_STOP_SIGNAL_COUNT:
+            watchdog.arm(signum)
         task.cancel()
 
     try:
         for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, stop)
+            loop.add_signal_handler(sig, partial(stop, int(sig)))
     except NotImplementedError:
         for sig in (signal.SIGTERM, signal.SIGINT):
-            signal.signal(sig, lambda *_: stop())
+            signal.signal(sig, lambda handled, _frame: stop(int(handled)))
     try:
         await task
     except asyncio.CancelledError:
         return 2 if stop_count > 1 else 0
     finally:
+        watchdog.disarm()
         await service.close()
     return 0
 
@@ -393,7 +404,7 @@ async def _run_worker(
     Returns:
         The process exit code: 0 clean, 1 crashed, 2 escalated.
     """
-    from litestar_queues.worker.runtime import WorkerRunResult, run_worker
+    from litestar_queues.worker.runtime import ShutdownWatchdog, WorkerRunResult, run_worker
 
     config = replace(
         plugin.config,
@@ -404,14 +415,15 @@ async def _run_worker(
             queues=queues,
         ),
     )
-    stop = _CLIStopCoordinator()
+    watchdog = ShutdownWatchdog(config.worker.hard_exit_timeout)
+    stop = _CLIStopCoordinator(watchdog=watchdog)
     loop = asyncio.get_running_loop()
 
     def _register_signal_handler(sig: "signal.Signals") -> "None":
         try:
-            loop.add_signal_handler(sig, stop.request_stop)
+            loop.add_signal_handler(sig, partial(stop.request_stop, int(sig)))
         except NotImplementedError:
-            signal.signal(sig, lambda *_: stop.request_stop())
+            signal.signal(sig, lambda handled, _frame: stop.request_stop(int(handled)))
 
     for sig in (signal.SIGTERM, signal.SIGINT):
         _register_signal_handler(sig)
@@ -434,6 +446,9 @@ async def _run_worker(
         click.echo(f"error: queue worker failed during {_failure_detail(exc)}", err=True)
         logging.getLogger(config.names.logger("cli")).exception("Standalone queue worker failed")
         return int(WorkerRunResult.CRASHED)
+    finally:
+        # A shutdown that actually finished must never trip the deadline.
+        watchdog.disarm()
     return int(result)
 
 
@@ -441,20 +456,28 @@ class _CLIStopCoordinator:
     """Translate repeated termination signals into the runner's two stop events.
 
     The second signal must reach the runner while the first drain is still in
-    flight, so the force request is never queued behind the graceful one.
+    flight, so the force request is never queued behind the graceful one. It
+    also arms the hard-exit watchdog, and a third signal exits at once: by then
+    the operator has asked three times and the loop is demonstrably stuck.
     """
 
-    __slots__ = ("force", "graceful", "stop_count")
+    __slots__ = ("force", "graceful", "stop_count", "watchdog")
 
-    def __init__(self) -> "None":
+    def __init__(self, watchdog: "ShutdownWatchdog | None" = None) -> "None":
         self.graceful = asyncio.Event()
         self.force = asyncio.Event()
         self.stop_count = 0
+        self.watchdog = watchdog
 
-    def request_stop(self) -> "None":
+    def request_stop(self, signum: "int" = signal.SIGTERM) -> "None":
         self.stop_count += 1
+        if self.stop_count > FORCE_STOP_SIGNAL_COUNT and self.watchdog is not None:
+            self.watchdog.exit_now(signum)
+            return
         if self.stop_count >= FORCE_STOP_SIGNAL_COUNT:
             self.force.set()
+            if self.watchdog is not None:
+                self.watchdog.arm(signum)
         self.graceful.set()
 
 

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -364,6 +364,22 @@ class SQLAlchemyBackend(BaseQueueBackend):
                 queued_at=queued_at,
             )
 
+    async def assign_worker(
+        self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
+    ) -> "QueuedTaskRecord | None":
+        async with self._operation() as service:
+            return await service.assign_worker(
+                task_id, worker_id=worker_id, expected_retry_count=expected_retry_count
+            )
+
+    async def interrupt_task(
+        self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
+    ) -> "QueuedTaskRecord | None":
+        async with self._operation() as service:
+            return await service.interrupt_task(
+                task_id, expected_retry_count=expected_retry_count, worker_id=worker_id, queued_at=queued_at
+            )
+
     async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         async with self._operation() as service:
             return await service.cancel_task(task_id, include_running=include_running)

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -368,9 +368,7 @@ class SQLAlchemyBackend(BaseQueueBackend):
         self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
     ) -> "QueuedTaskRecord | None":
         async with self._operation() as service:
-            return await service.assign_worker(
-                task_id, worker_id=worker_id, expected_retry_count=expected_retry_count
-            )
+            return await service.assign_worker(task_id, worker_id=worker_id, expected_retry_count=expected_retry_count)
 
     async def interrupt_task(
         self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
@@ -412,7 +410,9 @@ class SQLAlchemyBackend(BaseQueueBackend):
         self, *, stale_after: "timedelta", limit: "int | None" = None
     ) -> "StaleTaskRecoveryResult":
         async with self._operation() as service:
-            return await service.requeue_stale_running(stale_after=stale_after, limit=limit)
+            return await service.requeue_stale_running(
+                stale_after=stale_after, limit=limit, priority_policy=self._stale_requeue_priority_policy()
+            )
 
     async def set_execution_ref(
         self, task_id: "UUID", execution_backend: "str", execution_ref: "str", *, execution_profile: "str | None" = None

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -20,6 +20,7 @@ from litestar_queues.backends.advanced_alchemy.repository import (
 from litestar_queues.backends.base import (
     EXTERNAL_DISPATCH_RESERVATION_PREFIX,
     STALE_HEARTBEAT_ERROR,
+    STALE_REQUEUE_PRIORITY,
     attempts_consumed,
     interruption_count,
     record_matches_filters,
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
         QueueTaskModelMixin,
         QueueTaskReservationModelMixin,
     )
+    from litestar_queues.config import StaleRequeuePriority
     from litestar_queues.models import HeartbeatTouch, TaskRequest
 
 __all__ = ("QueueEventLogService", "QueueTaskReservationService", "QueueTaskService")
@@ -737,9 +739,7 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         result = await self.repository.session.execute(
             update(model_type)
             .where(
-                model_type.id == task_id,
-                model_type.status == "running",
-                model_type.retry_count == expected_retry_count,
+                model_type.id == task_id, model_type.status == "running", model_type.retry_count == expected_retry_count
             )
             .values(_update_values(model_type, {"worker_id": worker_id}))
             .execution_options(synchronize_session=False)
@@ -979,7 +979,11 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         )
 
     async def requeue_stale_running(
-        self, *, stale_after: "timedelta", limit: "int | None" = None
+        self,
+        *,
+        stale_after: "timedelta",
+        limit: "int | None" = None,
+        priority_policy: "StaleRequeuePriority" = STALE_REQUEUE_PRIORITY,
     ) -> "StaleTaskRecoveryResult":
         cutoff = _utc_now() - stale_after
         model_type = self.model_type
@@ -1024,7 +1028,7 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
                                 "started_at": None,
                                 "heartbeat_at": None,
                                 "retry_count": int(model.retry_count) + 1,
-                                "priority": stale_requeue_priority(int(model.priority)),
+                                "priority": stale_requeue_priority(int(model.priority), priority_policy),
                                 "error": stale_requeue_error(model.error),
                             },
                         )

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -20,6 +20,8 @@ from litestar_queues.backends.advanced_alchemy.repository import (
 from litestar_queues.backends.base import (
     EXTERNAL_DISPATCH_RESERVATION_PREFIX,
     STALE_HEARTBEAT_ERROR,
+    attempts_consumed,
+    interruption_count,
     record_matches_filters,
     retry_schedule,
     stale_requeue_error,
@@ -685,7 +687,7 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         model_type = self.model_type
         retry_fence = expected_retry_count if expected_retry_count is not None else int(model.retry_count)
         criteria = [model_type.id == task_id, model_type.status == "running", model_type.retry_count == retry_fence]
-        if retry and int(model.retry_count) < int(model.max_retries):
+        if retry and attempts_consumed(self.record_from_model(model)) < int(model.max_retries):
             now = queued_at or _utc_now()
             update_result = await self.repository.session.execute(
                 update(model_type)
@@ -757,6 +759,12 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
             The requeued record, or ``None`` when the fence was lost.
         """
         model_type = self.model_type
+        current = await self._select_task(task_id)
+        if current is None:
+            return None
+        metadata = _deserialize_json(current.metadata_json)
+        record = self.record_from_model(current)
+        metadata["interruptions"] = interruption_count(record) + 1
         result = await self.repository.session.execute(
             update(model_type)
             .where(
@@ -777,6 +785,8 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
                         "completed_at": None,
                         "execution_ref": None,
                         "worker_id": None,
+                        "retry_count": int(current.retry_count) + 1,
+                        "metadata_json": _serialize_json(metadata),
                     },
                 )
             )
@@ -999,7 +1009,7 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
             ]
             if use_heartbeat_cutoff:
                 update_criteria.append(stale_heartbeat)
-            if requeue_on_stale and int(model.retry_count) < int(model.max_retries):
+            if requeue_on_stale and attempts_consumed(self.record_from_model(model)) < int(model.max_retries):
                 queued_at, retry_at = retry_schedule(self.record_from_model(model))
                 update_result = await self.repository.session.execute(
                     update(model_type)

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -723,6 +723,71 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         updated = await self._select_task(task_id)
         return self.record_from_model(updated) if updated is not None else None
 
+    async def assign_worker(
+        self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
+    ) -> "QueuedTaskRecord | None":
+        """Persist running-record ownership behind a status/generation fence.
+
+        Returns:
+            The owned record, or ``None`` when the fence was lost.
+        """
+        model_type = self.model_type
+        result = await self.repository.session.execute(
+            update(model_type)
+            .where(
+                model_type.id == task_id,
+                model_type.status == "running",
+                model_type.retry_count == expected_retry_count,
+            )
+            .values(_update_values(model_type, {"worker_id": worker_id}))
+            .execution_options(synchronize_session=False)
+        )
+        if int(result.rowcount or 0) != 1:
+            return None
+        self.repository.session.expire_all()
+        model = await self._select_task(task_id)
+        return self.record_from_model(model) if model is not None else None
+
+    async def interrupt_task(
+        self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
+    ) -> "QueuedTaskRecord | None":
+        """Return an owned running attempt to pending behind an owner/generation fence.
+
+        Returns:
+            The requeued record, or ``None`` when the fence was lost.
+        """
+        model_type = self.model_type
+        result = await self.repository.session.execute(
+            update(model_type)
+            .where(
+                model_type.id == task_id,
+                model_type.status == "running",
+                model_type.retry_count == expected_retry_count,
+                model_type.worker_id == worker_id,
+            )
+            .values(
+                _update_values(
+                    model_type,
+                    {
+                        "status": "pending",
+                        "queued_at": queued_at,
+                        "scheduled_at": None,
+                        "started_at": None,
+                        "heartbeat_at": None,
+                        "completed_at": None,
+                        "execution_ref": None,
+                        "worker_id": None,
+                    },
+                )
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if int(result.rowcount or 0) != 1:
+            return None
+        self.repository.session.expire_all()
+        model = await self._select_task(task_id)
+        return self.record_from_model(model) if model is not None else None
+
     async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         model_type = self.model_type
         now = _utc_now()

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 __all__ = (
     "EXTERNAL_DISPATCH_RESERVATION_PREFIX",
     "BaseQueueBackend",
+    "attempts_consumed",
+    "interruption_count",
     "is_external_dispatch_reservation",
     "retry_schedule",
 )
@@ -37,13 +39,36 @@ STALE_HEARTBEAT_ERROR = "Task heartbeat stale"
 STALE_REQUEUE_PRIORITY = 4
 
 
+def interruption_count(record: "QueuedTaskRecord") -> "int":
+    """Return how many times an attempt has been interrupted by a shutdown.
+
+    Returns:
+        The recorded interruption count, or ``0`` when it is absent or unusable.
+    """
+    value = record.metadata.get("interruptions")
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 0
+
+
+def attempts_consumed(record: "QueuedTaskRecord") -> "int":
+    """Return the retry attempts a record has actually consumed.
+
+    An interruption bumps ``retry_count`` so the old owner's fences can never
+    settle the reclaimed attempt, but it is not a failed attempt: it must not
+    spend the record's retry budget.
+
+    Returns:
+        ``retry_count`` less the recorded interruptions.
+    """
+    return record.retry_count - interruption_count(record)
+
+
 def retry_schedule(record: "QueuedTaskRecord", *, now: "datetime | None" = None) -> "tuple[datetime, datetime | None]":
     """Return refreshed queue and optional due timestamps for a retry."""
     queued_at = now or datetime.now(timezone.utc)
     value = record.metadata.get("retry_backoff")
     if not isinstance(value, dict):
         return queued_at, None
-    delay = float(value.get("initial_delay", 0.0)) * float(value.get("multiplier", 1.0)) ** record.retry_count
+    delay = float(value.get("initial_delay", 0.0)) * float(value.get("multiplier", 1.0)) ** attempts_consumed(record)
     max_delay = value.get("max_delay")
     if max_delay is not None:
         delay = min(delay, float(max_delay))

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -193,12 +193,20 @@ class BaseQueueBackend:
     async def assign_worker(
         self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
     ) -> "QueuedTaskRecord | None":
-        """Persist the owner of a running retry generation."""
-        record = await self.get_task(task_id)
-        if record is None or record.status != "running" or record.retry_count != expected_retry_count:
-            return None
-        record.worker_id = worker_id
-        return record
+        """Persist the owner of a running retry generation.
+
+        The write is fenced on ``status='running' AND retry_count = expected``
+        so a worker can never claim ownership of a generation it lost.
+
+        Args:
+            task_id: Queue record identifier.
+            worker_id: Identity to persist as the record owner.
+            expected_retry_count: Retry generation the caller believes it owns.
+
+        Raises:
+            NotImplementedError: Always; every backend must answer this.
+        """
+        raise NotImplementedError
 
     async def list_pending(
         self, *, limit: "int" = 1, queue: "str | None" = None, execution_backend: "str | None" = None
@@ -381,7 +389,22 @@ class BaseQueueBackend:
     async def interrupt_task(
         self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
     ) -> "QueuedTaskRecord | None":
-        """Return an owned running attempt to pending after interruption."""
+        """Return an owned running attempt to pending after interruption.
+
+        The write is fenced on ``status='running' AND retry_count = expected
+        AND worker_id = worker_id``. It resets the record to ``pending`` with a
+        fresh ``queued_at`` and clears ``scheduled_at``, ``started_at``,
+        ``heartbeat_at``, ``completed_at``, ``execution_ref``, and ``worker_id``.
+
+        Args:
+            task_id: Queue record identifier.
+            expected_retry_count: Retry generation the caller owns.
+            worker_id: Identity that must currently own the record.
+            queued_at: Requeue timestamp used for fair claim ordering.
+
+        Raises:
+            NotImplementedError: Always; every backend must answer this.
+        """
         raise NotImplementedError
 
     async def cancel_tasks(

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 
 from typing_extensions import Self
 
-from litestar_queues.config import queue_backend_name
+from litestar_queues.config import STALE_REQUEUE_PRIORITY, queue_backend_name
+from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import (
     HeartbeatTouchResult,
     QueueBackendCapabilities,
@@ -20,13 +21,14 @@ if TYPE_CHECKING:
     from types import TracebackType
     from uuid import UUID
 
-    from litestar_queues.config import QueueConfig
+    from litestar_queues.config import QueueConfig, StaleRequeuePriority
     from litestar_queues.events import EventHistoryConfig, QueueEventLog
     from litestar_queues.models import HeartbeatTouch, QueuedTaskRecord, TaskRequest, TaskReservation
     from litestar_queues.observability import QueueObservabilityRuntimeProtocol
 
 __all__ = (
     "EXTERNAL_DISPATCH_RESERVATION_PREFIX",
+    "STALE_REQUEUE_PRIORITY",
     "BaseQueueBackend",
     "attempts_consumed",
     "interruption_count",
@@ -36,7 +38,6 @@ __all__ = (
 
 EXTERNAL_DISPATCH_RESERVATION_PREFIX = "__litestar_queues_dispatching__:"
 STALE_HEARTBEAT_ERROR = "Task heartbeat stale"
-STALE_REQUEUE_PRIORITY = 4
 
 
 def interruption_count(record: "QueuedTaskRecord") -> "int":
@@ -120,6 +121,15 @@ class BaseQueueBackend:
         runtime.record_counter(
             "litestar_queues.wakeup.coalesced", count, attributes=self._transport_metric_attributes()
         )
+
+    def _stale_requeue_priority_policy(self) -> "StaleRequeuePriority":
+        """Return the configured stale-recovery priority policy.
+
+        Returns:
+            The owning config's policy, or the historical clamp when a backend
+            was built without a config.
+        """
+        return self.config.stale_requeue_priority if self.config is not None else STALE_REQUEUE_PRIORITY
 
     @property
     def capabilities(self) -> "QueueBackendCapabilities":
@@ -816,6 +826,21 @@ def stale_requeue_error(current_error: "str | None") -> "str":
     return current_error or STALE_HEARTBEAT_ERROR
 
 
-def stale_requeue_priority(priority: "int") -> "int":
-    """Return the priority for a stale requeued task."""
-    return min(priority, STALE_REQUEUE_PRIORITY)
+def stale_requeue_priority(priority: "int", policy: "StaleRequeuePriority") -> "int":
+    """Return the priority a stale-recovered record re-enters the queue with.
+
+    Returns:
+        The priority resolved by ``policy``.
+
+    Raises:
+        QueueConfigurationError: If a callable policy returns a non-integer.
+    """
+    if callable(policy):
+        resolved = policy(priority)
+        if isinstance(resolved, bool) or not isinstance(resolved, int):
+            msg = f"QueueConfig.stale_requeue_priority callable returned {resolved!r}; an int is required."
+            raise QueueConfigurationError(msg)
+        return resolved
+    if policy == "preserve":
+        return priority
+    return min(priority, policy)

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -47,7 +48,11 @@ def interruption_count(record: "QueuedTaskRecord") -> "int":
         The recorded interruption count, or ``0`` when it is absent or unusable.
     """
     value = record.metadata.get("interruptions")
-    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 0
+    # Drivers decode JSON numbers differently: Oracle hands back ``Decimal``.
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        return 0
+    count = int(value)
+    return max(0, count)
 
 
 def attempts_consumed(record: "QueuedTaskRecord") -> "int":

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -131,7 +131,7 @@ class BaseQueueBackend:
         """Return the configured stale-recovery priority policy.
 
         Returns:
-            The owning config's policy, or the historical clamp when a backend
+            The owning config's policy, or the package default when a backend
             was built without a config.
         """
         return self.config.stale_requeue_priority if self.config is not None else STALE_REQUEUE_PRIORITY

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -927,6 +927,8 @@ class EphemeralQueueBackend(BaseQueueBackend):
             The recovery counts and affected task ids.
         """
 
+        policy = self._stale_requeue_priority_policy()
+
         def operation(connection: "sqlite3.Connection") -> "StaleTaskRecoveryResult":
             now = _utc_now()
             cutoff = now - stale_after
@@ -945,7 +947,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
                     record.status = "scheduled" if retry_at is not None else "pending"
                     record.queued_at = queued_at
                     record.scheduled_at = retry_at
-                    record.priority = stale_requeue_priority(record.priority)
+                    record.priority = stale_requeue_priority(record.priority, policy)
                     record.started_at = None
                     record.heartbeat_at = None
                     record.error = stale_requeue_error(record.error)

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -18,6 +18,8 @@ from litestar_queues.backends._notification_wait import PendingNativeRead
 from litestar_queues.backends.base import (
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
+    attempts_consumed,
+    interruption_count,
     is_external_dispatch_reservation,
     record_matches_filters,
     retry_schedule,
@@ -755,7 +757,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
             if record is None:
                 return None
             record.error = error
-            if retry and record.retry_count < record.max_retries:
+            if retry and attempts_consumed(record) < record.max_retries:
                 now = queued_at or _utc_now()
                 record.retry_count += 1
                 record.queued_at = now
@@ -817,6 +819,8 @@ class EphemeralQueueBackend(BaseQueueBackend):
             record.completed_at = None
             record.execution_ref = None
             record.worker_id = None
+            record.metadata["interruptions"] = interruption_count(record) + 1
+            record.retry_count += 1
             _write(connection, record)
             return record
 
@@ -936,7 +940,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
                 candidates = candidates[:limit]
             for record in candidates:
                 requeue_on_stale = record.metadata.get("requeue_on_stale", True) is not False
-                if requeue_on_stale and record.retry_count < record.max_retries:
+                if requeue_on_stale and attempts_consumed(record) < record.max_retries:
                     queued_at, retry_at = retry_schedule(record, now=now)
                     record.status = "scheduled" if retry_at is not None else "pending"
                     record.queued_at = queued_at

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -6,6 +6,8 @@ from litestar_queues.backends._notification_wait import PendingNativeRead
 from litestar_queues.backends.base import (
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
+    attempts_consumed,
+    interruption_count,
     is_external_dispatch_reservation,
     record_matches_filters,
     retry_schedule,
@@ -359,7 +361,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
                 return None
 
             record.error = error
-            if retry and record.retry_count < record.max_retries:
+            if retry and attempts_consumed(record) < record.max_retries:
                 now = queued_at or _utc_now()
                 record.retry_count += 1
                 record.queued_at = now
@@ -406,6 +408,8 @@ class InMemoryQueueBackend(BaseQueueBackend):
             record.completed_at = None
             record.execution_ref = None
             record.worker_id = None
+            record.metadata["interruptions"] = interruption_count(record) + 1
+            record.retry_count += 1
             return record
 
     async def cancel_tasks(
@@ -479,7 +483,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
                 candidates = candidates[:limit]
             for record in candidates:
                 requeue_on_stale = record.metadata.get("requeue_on_stale", True) is not False
-                if requeue_on_stale and record.retry_count < record.max_retries:
+                if requeue_on_stale and attempts_consumed(record) < record.max_retries:
                     queued_at, retry_at = retry_schedule(record)
                     record.status = "scheduled" if retry_at is not None else "pending"
                     record.queued_at = queued_at

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -488,7 +488,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
                     record.status = "scheduled" if retry_at is not None else "pending"
                     record.queued_at = queued_at
                     record.scheduled_at = retry_at
-                    record.priority = stale_requeue_priority(record.priority)
+                    record.priority = stale_requeue_priority(record.priority, self._stale_requeue_priority_policy())
                     record.started_at = None
                     record.heartbeat_at = None
                     record.error = stale_requeue_error(record.error)

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -468,6 +468,7 @@ local zset_action = ARGV[6]
 local score = ARGV[7]
 local channel = ARGV[8]
 local payload = ARGV[9]
+local expected_worker = ARGV[10]
 
 local status = redis.call('HGET', hkey, 'status')
 if not status then
@@ -482,13 +483,19 @@ if expected_retry ~= '' then
         return {0}
     end
 end
+if expected_worker ~= '' then
+    local worker_id = redis.call('HGET', hkey, 'worker_id')
+    if worker_id ~= expected_worker then
+        return {0}
+    end
+end
 if new_status ~= '' then
     redis.call('SREM', prefix .. ':status:' .. status, task_id)
     redis.call('SADD', prefix .. ':status:' .. new_status, task_id)
     redis.call('HSET', hkey, 'status', new_status)
 end
-if #ARGV >= 10 then
-    redis.call('HSET', hkey, unpack(ARGV, 10))
+if #ARGV >= 11 then
+    redis.call('HSET', hkey, unpack(ARGV, 11))
 end
 if zset_action == 'ready' then
     redis.call('ZADD', ready, score, task_id)
@@ -1124,6 +1131,73 @@ class RedisQueueBackend(BaseQueueBackend):
         if record is not None and _decode(outcome[1]) in {"pending", "scheduled"}:
             await self.notify_new_task(record)
         return record
+
+    async def assign_worker(
+        self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
+    ) -> "QueuedTaskRecord | None":
+        """Persist running-record ownership through the fenced transition script.
+
+        Returns:
+            The owned record, or ``None`` when the fence was lost.
+        """
+        committed = await self._commit_transition(
+            task_id,
+            expected_status="running",
+            expected_retry_count=expected_retry_count,
+            patch={"worker_id": worker_id},
+        )
+        return await self.get_task(task_id) if committed else None
+
+    async def interrupt_task(
+        self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
+    ) -> "QueuedTaskRecord | None":
+        """Return an owned running attempt to pending through the fenced transition script.
+
+        Returns:
+            The requeued record, or ``None`` when the fence was lost.
+        """
+        record = await self.get_task(task_id)
+        if (
+            record is None
+            or record.status != "running"
+            or record.retry_count != expected_retry_count
+            or record.worker_id != worker_id
+        ):
+            return None
+        record.status = "pending"
+        record.queued_at = queued_at
+        record.scheduled_at = None
+        record.started_at = None
+        record.heartbeat_at = None
+        record.completed_at = None
+        record.execution_ref = None
+        record.worker_id = None
+        zset_action, score = self._index_action(record)
+        committed = await self._commit_transition(
+            task_id,
+            expected_status="running",
+            expected_retry_count=expected_retry_count,
+            expected_worker_id=worker_id,
+            new_status="pending",
+            patch={
+                "queued_at": _serialize_datetime(queued_at),
+                "scheduled_at": "",
+                "started_at": "",
+                "started_score": "0",
+                "heartbeat_at": "",
+                "heartbeat_score": "0",
+                "completed_at": "",
+                "completed_score": "0",
+                "execution_ref": "",
+                "worker_id": "",
+                "ready_score": repr(_ready_score(record)),
+            },
+            zset_action=zset_action,
+            score=score,
+            publish_channel=self._wakeup_channel if (self._notifications and zset_action == "ready") else "",
+            publish_payload=_json_dumps({"event": "task_available"}),
+        )
+        return await self.get_task(task_id) if committed else None
 
     async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         """Cancel a task via a single fenced script.
@@ -1894,6 +1968,7 @@ class RedisQueueBackend(BaseQueueBackend):
         zset_action: "str" = "none",
         score: "str" = "",
         expected_retry_count: "int | None" = None,
+        expected_worker_id: "str" = "",
         publish_channel: "str" = "",
         publish_payload: "str" = "",
     ) -> "bool":
@@ -1908,6 +1983,7 @@ class RedisQueueBackend(BaseQueueBackend):
             score,
             publish_channel,
             publish_payload,
+            expected_worker_id,
         ]
         if patch:
             for field, value in patch.items():

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -19,6 +19,8 @@ from litestar_queues.backends.base import (
     EXTERNAL_DISPATCH_RESERVATION_PREFIX,
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
+    attempts_consumed,
+    interruption_count,
     is_external_dispatch_reservation,
     record_matches_filters,
     retry_schedule,
@@ -348,7 +350,15 @@ if expected ~= '' and tostring(retry_count) ~= expected then
 end
 redis.call('HSET', hkey, 'error', error)
 local max_retries = tonumber(redis.call('HGET', hkey, 'max_retries')) or 0
-if retry == '1' and retry_count < max_retries then
+local interruptions = 0
+local metadata_json = redis.call('HGET', hkey, 'metadata')
+if metadata_json and metadata_json ~= '' then
+    local decoded_ok, decoded = pcall(cjson.decode, metadata_json)
+    if decoded_ok and type(decoded) == 'table' and type(decoded.interruptions) == 'number' then
+        interruptions = decoded.interruptions
+    end
+end
+if retry == '1' and (retry_count - interruptions) < max_retries then
     local new_retry_count = retry_count + 1
     local retry_status = 'pending'
     if retry_at ~= '' then retry_status = 'scheduled' end
@@ -1172,6 +1182,8 @@ class RedisQueueBackend(BaseQueueBackend):
         record.completed_at = None
         record.execution_ref = None
         record.worker_id = None
+        record.metadata["interruptions"] = interruption_count(record) + 1
+        record.retry_count += 1
         zset_action, score = self._index_action(record)
         committed = await self._commit_transition(
             task_id,
@@ -1190,6 +1202,8 @@ class RedisQueueBackend(BaseQueueBackend):
                 "completed_score": "0",
                 "execution_ref": "",
                 "worker_id": "",
+                "retry_count": str(record.retry_count),
+                "metadata": _json_dumps(record.metadata),
                 "ready_score": repr(_ready_score(record)),
             },
             zset_action=zset_action,
@@ -1343,7 +1357,7 @@ class RedisQueueBackend(BaseQueueBackend):
                 result.skipped += 1
                 continue
             requeue_on_stale = latest.metadata.get("requeue_on_stale", True) is not False
-            if requeue_on_stale and latest.retry_count < latest.max_retries:
+            if requeue_on_stale and attempts_consumed(latest) < latest.max_retries:
                 if await self._commit_stale_requeue(latest):
                     result.requeued += 1
                 else:

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -1378,7 +1378,7 @@ class RedisQueueBackend(BaseQueueBackend):
         record.status = "scheduled" if retry_at is not None else "pending"
         record.queued_at = queued_at
         record.scheduled_at = retry_at
-        record.priority = stale_requeue_priority(record.priority)
+        record.priority = stale_requeue_priority(record.priority, self._stale_requeue_priority_policy())
         record.started_at = None
         record.heartbeat_at = None
         record.error = stale_requeue_error(record.error)

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1108,6 +1108,77 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             self._increment_queue_metric("claim_lost")
         return updated_record
 
+    async def assign_worker(
+        self, task_id: "UUID", *, worker_id: "str", expected_retry_count: "int"
+    ) -> "QueuedTaskRecord | None":
+        store = self._get_store()
+        async with self._session() as driver:
+            await driver.begin()
+            try:
+                result = await driver.execute(
+                    store.assign_worker(
+                        task_id=str(task_id), worker_id=worker_id, expected_retry_count=expected_retry_count
+                    )
+                )
+                rows_affected = self._resolve_rows_affected(result)
+                updated_row = None
+                if rows_affected != 0:
+                    updated_row = await self._select_task(driver, task_id)
+                await driver.commit()
+            except Exception:
+                with suppress(Exception):
+                    await driver.rollback()
+                raise
+        if updated_row is None:
+            return None
+        record = self._record_from_row(updated_row)
+        if record.worker_id != worker_id or record.retry_count != expected_retry_count:
+            return None
+        return record
+
+    async def interrupt_task(
+        self, task_id: "UUID", *, expected_retry_count: "int", worker_id: "str", queued_at: "datetime"
+    ) -> "QueuedTaskRecord | None":
+        store = self._get_store()
+        async with self._session() as driver:
+            await driver.begin()
+            try:
+                current_row = await self._select_task(driver, task_id)
+                if current_row is None:
+                    await driver.commit()
+                    return None
+                current = self._record_from_row(current_row)
+                if (
+                    current.status != "running"
+                    or current.retry_count != expected_retry_count
+                    or current.worker_id != worker_id
+                ):
+                    await driver.commit()
+                    return None
+                result = await driver.execute(
+                    store.interrupt_task(
+                        task_id=str(task_id),
+                        expected_retry_count=expected_retry_count,
+                        worker_id=worker_id,
+                        queued_at=self._serialize_datetime(queued_at),
+                        retry_count=current.retry_count,
+                        metadata_json=store.serialize_json("metadata_json", current.metadata),
+                    )
+                )
+                rows_affected = self._resolve_rows_affected(result)
+                updated_row = None
+                if rows_affected != 0:
+                    updated_row = await self._select_task(driver, task_id)
+                await driver.commit()
+            except Exception:
+                with suppress(Exception):
+                    await driver.rollback()
+                raise
+        if updated_row is None:
+            return None
+        record = self._record_from_row(updated_row)
+        return record if record.status == "pending" else None
+
     async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
         async with self._session() as driver:
             await driver.begin()

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -18,6 +18,8 @@ from litestar_queues.backends.base import (
     EXTERNAL_DISPATCH_RESERVATION_PREFIX,
     STALE_HEARTBEAT_ERROR,
     BaseQueueBackend,
+    attempts_consumed,
+    interruption_count,
     is_external_dispatch_reservation,
     record_matches_filters,
     retry_schedule,
@@ -1055,7 +1057,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                         return None
                     metric = "fail"
                     retry_fence = expected_retry_count if expected_retry_count is not None else record.retry_count
-                    if retry and record.retry_count < record.max_retries:
+                    if retry and attempts_consumed(record) < record.max_retries:
                         updated = await driver.execute(
                             store.retry_task(
                                 task_id=str(task_id),
@@ -1155,14 +1157,16 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 ):
                     await driver.commit()
                     return None
+                metadata = dict(current.metadata)
+                metadata["interruptions"] = interruption_count(current) + 1
                 result = await driver.execute(
                     store.interrupt_task(
                         task_id=str(task_id),
                         expected_retry_count=expected_retry_count,
                         worker_id=worker_id,
                         queued_at=self._serialize_datetime(queued_at),
-                        retry_count=current.retry_count,
-                        metadata_json=store.serialize_json("metadata_json", current.metadata),
+                        retry_count=current.retry_count + 1,
+                        metadata_json=store.serialize_json("metadata_json", metadata),
                     )
                 )
                 rows_affected = self._resolve_rows_affected(result)
@@ -1369,7 +1373,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                     for row in rows:
                         record = self._record_from_row(row)
                         requeue_on_stale = record.metadata.get("requeue_on_stale", True) is not False
-                        if requeue_on_stale and record.retry_count < record.max_retries:
+                        if requeue_on_stale and attempts_consumed(record) < record.max_retries:
                             retry_error = stale_requeue_error(record.error)
                             retry_priority = stale_requeue_priority(record.priority)
                             queued_at, retry_at = retry_schedule(record)

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1375,7 +1375,9 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                         requeue_on_stale = record.metadata.get("requeue_on_stale", True) is not False
                         if requeue_on_stale and attempts_consumed(record) < record.max_retries:
                             retry_error = stale_requeue_error(record.error)
-                            retry_priority = stale_requeue_priority(record.priority)
+                            retry_priority = stale_requeue_priority(
+                                record.priority, self._stale_requeue_priority_policy()
+                            )
                             queued_at, retry_at = retry_schedule(record)
                             updated = await driver.execute(
                                 store.retry_task(

--- a/src/litestar_queues/backends/sqlspec/stores/_dialects.py
+++ b/src/litestar_queues/backends/sqlspec/stores/_dialects.py
@@ -268,6 +268,13 @@ class PostgresQueueStore(SQLSpecQueueStore):
             ),
         ]
 
+    def interruptions_expression(self) -> "str":
+        """Return the JSONB accessor for the record's shutdown-interruption count."""
+        metadata = self._quoted_col("metadata_json")
+        if "metadata_json" not in self._native_json_columns:
+            metadata = f"({metadata})::JSONB"
+        return f"COALESCE(({metadata} ->> 'interruptions')::INT, 0)"
+
     def _json_type(self) -> "str":
         return "JSONB"
 

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -334,7 +334,7 @@ class SQLSpecQueueStore:
             retry_count_col = self._quoted_col("retry_count")
             max_retries_col = self._quoted_col("max_retries")
             retry_at = f"CAST(:retry_at AS {self._timestamp_type()})"
-            can_retry = f":retry = TRUE AND {retry_count_col} < {max_retries_col}"
+            can_retry = f":retry = TRUE AND ({retry_count_col} - {self.interruptions_expression()}) < {max_retries_col}"
             where = f"{self._quoted_col('id')} = :id AND {self._quoted_col('status')} = 'running'"
             if fence_retry_count:
                 where += f" AND {retry_count_col} = :expected_retry_count"
@@ -1269,6 +1269,24 @@ RETURNING {target}.{id_col} AS id
 
     def _result_json_type(self, column_name: "str") -> "str":
         return self._json_type()
+
+    def interruptions_expression(self) -> "str":
+        """Return SQL reading the record's shutdown-interruption count from its metadata.
+
+        Only stores that answer ``supports_dml_returning`` settle a task in one
+        statement, so only they need to read the counter in SQL; every other
+        store subtracts it in Python from the row it already fetched.
+
+        Raises:
+            NotImplementedError: When a store enables single-statement settling
+                without telling the queue how to read the counter.
+        """
+        msg = (
+            f"{type(self).__name__} enables supports_dml_returning but does not implement "
+            f"interruptions_expression(), so its single-statement retry budget would count "
+            f"shutdown interruptions as failed attempts."
+        )
+        raise NotImplementedError(msg)
 
     def _metadata_json_type(self, column_name: "str") -> "str":
         return self._json_type()

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -698,6 +698,51 @@ class SQLSpecQueueStore:
             )
         return statement
 
+    def assign_worker(self, *, task_id: "str", worker_id: "str", expected_retry_count: "int") -> "Update":
+        """Return a fenced UPDATE statement that persists running-record ownership."""
+        return (
+            sql
+            .update(self.table_name)
+            .set(**self._mapped_values({"worker_id": worker_id}))
+            .where_eq(self._col("id"), task_id)
+            .where_eq(self._col("status"), "running")
+            .where_eq(self._col("retry_count"), expected_retry_count)
+        )
+
+    def interrupt_task(
+        self,
+        *,
+        task_id: "str",
+        expected_retry_count: "int",
+        worker_id: "str",
+        queued_at: "DatetimeParam",
+        retry_count: "int",
+        metadata_json: "Any",
+    ) -> "Update":
+        """Return a fenced UPDATE statement that returns an owned running task to pending."""
+        return (
+            sql
+            .update(self.table_name)
+            .set(
+                **self._mapped_values({
+                    "status": "pending",
+                    "queued_at": queued_at,
+                    "scheduled_at": None,
+                    "started_at": None,
+                    "heartbeat_at": None,
+                    "completed_at": None,
+                    "execution_ref": None,
+                    "worker_id": None,
+                    "retry_count": retry_count,
+                    "metadata_json": metadata_json,
+                })
+            )
+            .where_eq(self._col("id"), task_id)
+            .where_eq(self._col("status"), "running")
+            .where_eq(self._col("retry_count"), expected_retry_count)
+            .where_eq(self._col("worker_id"), worker_id)
+        )
+
     def cancel_task(
         self, *, task_id: "str", completed_at: "DatetimeParam", include_running: "bool" = False
     ) -> "Update":

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -229,8 +229,14 @@ class WorkerConfig:
     final_cancel_timeout: "float" = 5
     """Maximum post-cancellation drain time in seconds."""
 
+    hard_exit_timeout: "float | None" = 10.0
+    """Wall-clock budget from forced shutdown to process exit; ``None`` disables the watchdog."""
+
     requeue_on_shutdown: "bool" = False
     """Whether cancelled executions are requeued after shutdown drain timeout."""
+
+    max_interruptions: "int" = 3
+    """Shutdown requeues an attempt may absorb before interruptions consume the retry budget."""
 
     startup_timeout: "float" = 30
     """Maximum time to wait for worker startup readiness in seconds."""
@@ -254,6 +260,7 @@ class WorkerConfig:
             "stale_check_interval": self.stale_check_interval,
             "graceful_shutdown_timeout": self.graceful_shutdown_timeout,
             "final_cancel_timeout": self.final_cancel_timeout,
+            "max_interruptions": self.max_interruptions,
             "startup_timeout": self.startup_timeout,
         }
         for name, value in positive.items():
@@ -271,6 +278,9 @@ class WorkerConfig:
             raise QueueConfigurationError(msg)
         if not 0.0 <= self.heartbeat_jitter_fraction <= 1.0:
             msg = "WorkerConfig.heartbeat_jitter_fraction must be between 0.0 and 1.0, inclusive."
+            raise QueueConfigurationError(msg)
+        if self.hard_exit_timeout is not None and self.hard_exit_timeout <= 0:
+            msg = "WorkerConfig.hard_exit_timeout must be greater than 0 when set."
             raise QueueConfigurationError(msg)
         if self.stale_after is not None and self.stale_after <= 0:
             msg = "WorkerConfig.stale_after must be greater than 0 when set."

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from litestar_queues.task import Task
 
 __all__ = (
+    "STALE_REQUEUE_PRIORITY",
     "ExecutionBackendConfig",
     "ExecutionBackendConfigProtocol",
     "MigrationConfiguringBackend",
@@ -30,6 +31,7 @@ __all__ = (
     "QueueBackendConfigProtocol",
     "QueueConfig",
     "QueueNamespace",
+    "StaleRequeuePriority",
     "TaskDependencyResolver",
     "TaskErrorSanitizer",
     "WorkerConfig",
@@ -39,6 +41,9 @@ __all__ = (
 )
 
 logger = getLogger(__name__)
+
+STALE_REQUEUE_PRIORITY = 4
+"""Historical priority ceiling applied to stale-recovered work."""
 
 _SERVICE_STATE_KEY = "queue_service"
 _WORKER_STATE_KEY = "queue_worker"
@@ -166,6 +171,13 @@ TaskDependencyResolver = Callable[
 
 TaskErrorSanitizer = Callable[["BaseException", "QueuedTaskRecord"], str]
 """User-supplied callable that converts task exceptions into persisted error messages."""
+
+StaleRequeuePriority = Literal["preserve"] | int | Callable[[int], int]
+"""Priority policy applied to work recovered by the stale sweep.
+
+``"preserve"`` keeps the original priority, an ``int`` is a ceiling clamp, and a
+callable maps the current priority to the recovered one.
+"""
 
 
 @dataclass(slots=True)
@@ -362,6 +374,9 @@ class QueueConfig:
     max_argument_identity_bytes: "int | None" = None
     """Maximum canonical argument-identity size in bytes; ``None`` disables the bound."""
 
+    stale_requeue_priority: "StaleRequeuePriority" = STALE_REQUEUE_PRIORITY
+    """Priority applied to stale-recovered work; see :data:`StaleRequeuePriority`."""
+
     names: "QueueNamespace" = field(init=False)
     """Validated format-specific runtime-name renderer."""
 
@@ -379,7 +394,24 @@ class QueueConfig:
         if self.sync_thread_pool_size <= 0:
             msg = "QueueConfig.sync_thread_pool_size must be greater than 0."
             raise QueueConfigurationError(msg)
+        self._validate_stale_requeue_priority()
         self._validate_placement()
+
+    def _validate_stale_requeue_priority(self) -> "None":
+        """Reject a stale-requeue policy that is neither ``"preserve"``, a priority, nor a mapper.
+
+        Raises:
+            QueueConfigurationError: If the configured policy cannot be applied.
+        """
+        policy = self.stale_requeue_priority
+        if callable(policy) or policy == "preserve":
+            return
+        if isinstance(policy, bool) or not isinstance(policy, int) or policy < 0:
+            msg = (
+                "QueueConfig.stale_requeue_priority must be 'preserve', a non-negative priority ceiling, "
+                f"or a callable mapping the old priority to the new one, not {policy!r}."
+            )
+            raise QueueConfigurationError(msg)
 
     def _validate_placement(self) -> "None":
         """Reject storage, execution, and placement combinations that cannot work.

--- a/src/litestar_queues/config.py
+++ b/src/litestar_queues/config.py
@@ -42,8 +42,8 @@ __all__ = (
 
 logger = getLogger(__name__)
 
-STALE_REQUEUE_PRIORITY = 4
-"""Historical priority ceiling applied to stale-recovered work."""
+STALE_REQUEUE_PRIORITY: "StaleRequeuePriority" = "preserve"
+"""Default stale-requeue policy: recovered work keeps the priority it was enqueued with."""
 
 _SERVICE_STATE_KEY = "queue_service"
 _WORKER_STATE_KEY = "queue_worker"

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -696,11 +696,7 @@ class QueueService:
         )
         if updated is None:
             return None
-        payload = {
-            "status": updated.status,
-            "retry_count": updated.retry_count,
-            "will_retry": not updated.is_terminal,
-        }
+        payload = {"status": updated.status, "retry_count": updated.retry_count, "will_retry": not updated.is_terminal}
         context = _task_execution_context(updated, worker_id=worker_id, event_publisher=self.get_event_publisher())
         await context.lifecycle("task.failed", message=INTERRUPTION_LIMIT_ERROR, payload=payload)
         self._log_task_event(

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -19,6 +19,7 @@ from litestar_queues._correlation import (
     reset_correlation_id,
 )
 from litestar_queues._identity import IDENTITY_VERSION, arguments_identity, task_identity
+from litestar_queues.backends.base import interruption_count
 from litestar_queues.config import execution_backend_name, queue_backend_name
 from litestar_queues.events.context import TaskExecutionContext, _bind_task_context, _reset_task_context
 from litestar_queues.events.models import QueueEvent
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
 __all__ = ("QueueService",)
 
 _CLOUD_TASKS_BACKEND = "cloudtasks"
+INTERRUPTION_LIMIT_ERROR = "Interrupted during shutdown"
 
 
 def _utc_now() -> "datetime":
@@ -654,9 +656,24 @@ class QueueService:
         return True
 
     async def interrupt_task(
-        self, record: "QueuedTaskRecord", *, worker_id: "str", reason: "str" = "shutdown"
+        self,
+        record: "QueuedTaskRecord",
+        *,
+        worker_id: "str",
+        reason: "str" = "shutdown",
+        max_interruptions: "int | None" = None,
     ) -> "QueuedTaskRecord | None":
-        """Requeue one owned running attempt after local execution unwinds."""
+        """Requeue one owned running attempt after local execution unwinds.
+
+        An attempt that keeps being interrupted would otherwise cycle forever
+        without ever consuming its retry budget, so at ``max_interruptions`` the
+        interruption is routed through the ordinary retry policy instead.
+
+        Returns:
+            The requeued or failed record, or ``None`` when the fence was lost.
+        """
+        if max_interruptions is not None and interruption_count(record) >= max_interruptions:
+            return await self._fail_interrupted_task(record, worker_id=worker_id)
         updated = await self.get_queue_backend().interrupt_task(
             record.id,
             expected_retry_count=record.retry_count,
@@ -669,6 +686,26 @@ class QueueService:
         context = _task_execution_context(updated, worker_id=worker_id, event_publisher=self.get_event_publisher())
         await context.lifecycle("task.interrupted", payload=payload)
         self._log_task_event("Queue task interrupted", updated, level=logging.INFO, payload=payload)
+        return updated
+
+    async def _fail_interrupted_task(
+        self, record: "QueuedTaskRecord", *, worker_id: "str"
+    ) -> "QueuedTaskRecord | None":
+        updated = await self.get_queue_backend().fail_task(
+            record.id, INTERRUPTION_LIMIT_ERROR, retry=True, expected_retry_count=record.retry_count
+        )
+        if updated is None:
+            return None
+        payload = {
+            "status": updated.status,
+            "retry_count": updated.retry_count,
+            "will_retry": not updated.is_terminal,
+        }
+        context = _task_execution_context(updated, worker_id=worker_id, event_publisher=self.get_event_publisher())
+        await context.lifecycle("task.failed", message=INTERRUPTION_LIMIT_ERROR, payload=payload)
+        self._log_task_event(
+            "Queue task exceeded its shutdown interruption budget", updated, level=logging.ERROR, payload=payload
+        )
         return updated
 
     async def reset_task_identity(self, key: "str") -> "bool":

--- a/src/litestar_queues/typing.py
+++ b/src/litestar_queues/typing.py
@@ -26,6 +26,7 @@ from litestar_queues._typing import (
     otel_trace,
     prometheus_default_registry,
 )
+from litestar_queues.config import StaleRequeuePriority
 from litestar_queues.task import TaskUniqueBy, TaskUniqueUntil
 
 __all__ = (
@@ -41,6 +42,7 @@ __all__ = (
     "PrometheusCounter",
     "PrometheusGauge",
     "PrometheusHistogram",
+    "StaleRequeuePriority",
     "TaskUniqueBy",
     "TaskUniqueUntil",
     "otel_context",

--- a/src/litestar_queues/worker/runtime.py
+++ b/src/litestar_queues/worker/runtime.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import contextlib
+import os
+import threading
 from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Protocol
 
@@ -15,7 +17,71 @@ if TYPE_CHECKING:
     from litestar_queues.config import QueueConfig, WorkerConfig
     from litestar_queues.service import QueueService
 
-__all__ = ()
+__all__ = ("ShutdownWatchdog",)
+
+
+class ShutdownWatchdog:
+    """Force process exit when a forced shutdown does not finish in time.
+
+    The watchdog runs on a daemon thread rather than the event loop: the exact
+    failure it defends against is a loop that no longer runs callbacks, either
+    because a task refuses cancellation or because the loop itself is wedged.
+    """
+
+    __slots__ = ("_exit_fn", "_finished", "_signum", "_thread", "_timeout")
+
+    def __init__(self, timeout: "float | None", *, exit_fn: "Callable[[int], object]" = os._exit) -> "None":
+        """Initialize the watchdog.
+
+        Args:
+            timeout: Seconds from arming to forced exit; ``None`` disables it.
+            exit_fn: Exit callable, injected so tests never end the process.
+        """
+        self._timeout = timeout
+        self._exit_fn = exit_fn
+        self._finished = threading.Event()
+        self._thread: "threading.Thread | None" = None
+        self._signum: "int | None" = None
+
+    @property
+    def is_armed(self) -> "bool":
+        """Whether a deadline is currently running."""
+        return self._thread is not None and not self._finished.is_set()
+
+    def arm(self, signum: "int") -> "None":
+        """Start the exit deadline; the first arming signal wins."""
+        if self._timeout is None or self._thread is not None:
+            return
+        self._signum = signum
+        thread = threading.Thread(target=self._wait_and_exit, name="litestar-queues-shutdown-watchdog", daemon=True)
+        self._thread = thread
+        thread.start()
+
+    def disarm(self) -> "None":
+        """Cancel the deadline; a shutdown that completed must not exit hard."""
+        self._finished.set()
+
+    def exit_now(self, signum: "int") -> "None":
+        """Exit immediately with the conventional signal exit code."""
+        self._finished.set()
+        self._exit_fn(exit_code_for_signal(signum))
+
+    def _wait_and_exit(self) -> "None":
+        timeout = self._timeout
+        if timeout is None:
+            return
+        if self._finished.wait(timeout):
+            return
+        self._exit_fn(exit_code_for_signal(self._signum))
+
+
+def exit_code_for_signal(signum: "int | None") -> "int":
+    """Return the conventional ``128 + signum`` exit code.
+
+    Returns:
+        The shell convention exit code for a signal-terminated process.
+    """
+    return 128 + (signum if signum is not None else 15)
 
 
 class WorkerRunResult(IntEnum):

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -418,6 +418,17 @@ class Worker:
     def _on_execution_done(self, task: "asyncio.Task[None]") -> "None":
         self._running_tasks.pop(task, None)
         self._cancel_requested.discard(task)
+        # Retrieve the outcome here rather than through a drain-time gather, so
+        # a task that finishes outside a drain never trips asyncio's
+        # "exception was never retrieved" reporting.
+        if not task.cancelled():
+            error = task.exception()
+            if error is not None:
+                self._logger.error(
+                    "Queue task execution failed outside its own error handling",
+                    exc_info=error,
+                    extra={"worker_id": self._worker_id},
+                )
         self._completion_event.set()
 
     async def _maybe_cancel_running(self) -> "None":

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -467,7 +467,7 @@ class Worker:
                     updated = await self._service.interrupt_task(
                         record, worker_id=self._worker_id, max_interruptions=self._max_interruptions
                     )
-                except Exception:  # noqa: BLE001 - shutdown requeue failures are reported, never raised.
+                except Exception:
                     self._record_counter(
                         "litestar_queues.worker.interrupt.error", {"messaging.destination.name": record.queue}
                     )
@@ -601,24 +601,24 @@ class Worker:
             return
         self._logger.warning(
             "Queue tasks survived cancellation; abandoning them to stale recovery",
-            extra={
-                "worker_id": self._worker_id,
-                "task_ids": [str(record.id) for record in survivors],
-            },
+            extra={"worker_id": self._worker_id, "task_ids": [str(record.id) for record in survivors]},
         )
         # `null_heartbeats` carries one fence value per call, so group the
         # survivors by the generation this worker still believes it owns.
         by_generation: "dict[int, list[UUID]]" = {}
         for record in survivors:
             by_generation.setdefault(record.retry_count, []).append(record.id)
-        backend = self._service.get_queue_backend()
         for expected_retry_count, task_ids in by_generation.items():
-            try:
-                await backend.null_heartbeats(task_ids, expected_retry_count=expected_retry_count)
-            except Exception:  # noqa: BLE001 - the handoff is best effort during shutdown.
-                self._logger.exception(
-                    "Nulling heartbeats for surviving queue tasks failed", extra={"worker_id": self._worker_id}
-                )
+            await self._null_heartbeats_quietly(task_ids, expected_retry_count=expected_retry_count)
+
+    async def _null_heartbeats_quietly(self, task_ids: "list[UUID]", *, expected_retry_count: "int") -> "None":
+        """Clear one generation's heartbeats, reporting rather than raising a backend failure."""
+        try:
+            await self._service.get_queue_backend().null_heartbeats(task_ids, expected_retry_count=expected_retry_count)
+        except Exception:
+            self._logger.exception(
+                "Nulling heartbeats for surviving queue tasks failed", extra={"worker_id": self._worker_id}
+            )
 
     async def _wait_for_work(self) -> "bool | None":
         """Wait for new work, a backend notification, or a stop signal.

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -66,6 +66,7 @@ class Worker:
 
     __slots__ = (
         "_batch_size",
+        "_cancel_requested",
         "_cancellation_poll_interval",
         "_completion_event",
         "_current_poll_interval",
@@ -139,6 +140,7 @@ class Worker:
         )
         self._queues = worker_config.queues
         self._running_tasks: "dict[asyncio.Task[None], QueuedTaskRecord]" = {}
+        self._cancel_requested: "set[asyncio.Task[None]]" = set()
         self._stop_event = asyncio.Event()
         self._completion_event = asyncio.Event()
         self._startup_completion: "asyncio.Future[BaseException | None] | None" = None
@@ -411,6 +413,7 @@ class Worker:
 
     def _on_execution_done(self, task: "asyncio.Task[None]") -> "None":
         self._running_tasks.pop(task, None)
+        self._cancel_requested.discard(task)
         self._completion_event.set()
 
     async def _maybe_cancel_running(self) -> "None":
@@ -453,7 +456,25 @@ class Worker:
             task_setting = record.metadata.get("requeue_on_shutdown")
             should_requeue = self._requeue_on_shutdown if task_setting is None else task_setting is True
             if self._stop_event.is_set() and should_requeue:
-                await self._service.interrupt_task(record, worker_id=self._worker_id)
+                # A backend failure here must never replace the cancellation:
+                # the exception would be swallowed whole by the drain/cancel
+                # wait and the record would silently stay `running`.
+                try:
+                    updated = await self._service.interrupt_task(record, worker_id=self._worker_id)
+                except Exception:  # noqa: BLE001 - shutdown requeue failures are reported, never raised.
+                    self._record_counter(
+                        "litestar_queues.worker.interrupt.error", {"messaging.destination.name": record.queue}
+                    )
+                    self._logger.exception(
+                        "Queue task shutdown requeue failed; record remains running",
+                        extra={"worker_id": self._worker_id, "task_id": str(record.id)},
+                    )
+                else:
+                    if updated is None:
+                        self._logger.warning(
+                            "Queue task shutdown requeue lost its fence",
+                            extra={"worker_id": self._worker_id, "task_id": str(record.id)},
+                        )
             raise
         finally:
             _reset_beat_sink(beat_token)
@@ -538,12 +559,11 @@ class Worker:
     async def _drain_running(self) -> "bool":
         if not self._running_tasks:
             return False
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*tuple(self._running_tasks), return_exceptions=True),
-                timeout=self._graceful_shutdown_timeout,
-            )
-        except asyncio.TimeoutError:
+        # `asyncio.wait`, not `wait_for(gather(...))`: a timed-out `wait_for`
+        # cancels the gather, and that cancellation propagates into every
+        # execution task as an unaccounted extra delivery.
+        _, pending = await asyncio.wait(tuple(self._running_tasks), timeout=self._graceful_shutdown_timeout)
+        if pending:
             await self._cancel_running()
             return True
         return False
@@ -552,10 +572,15 @@ class Worker:
         tasks = tuple(self._running_tasks)
         if not tasks:
             return
+        # `stop()` and the loop's own shutdown drain both land here. Cancelling
+        # a task twice delivers a second CancelledError into the task's own
+        # shutdown-requeue handler and aborts the backend write mid-flight, so
+        # each execution task is cancelled exactly once per worker.
         for task in tasks:
-            task.cancel()
-        with contextlib.suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=self._final_cancel_timeout)
+            if task not in self._cancel_requested:
+                self._cancel_requested.add(task)
+                task.cancel()
+        await asyncio.wait(tasks, timeout=self._final_cancel_timeout)
 
     async def _wait_for_work(self) -> "bool | None":
         """Wait for new work, a backend notification, or a stop signal.

--- a/src/litestar_queues/worker/worker.py
+++ b/src/litestar_queues/worker/worker.py
@@ -13,6 +13,8 @@ from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.worker.heartbeat import WorkerHeartbeatManager
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from litestar_queues.models import QueuedTaskRecord
     from litestar_queues.service import QueueService
 
@@ -82,6 +84,7 @@ class Worker:
         "_listener_reconnect_pending",
         "_logger",
         "_max_concurrency",
+        "_max_interruptions",
         "_poll_backoff_max",
         "_poll_backoff_multiplier",
         "_poll_interval",
@@ -123,6 +126,7 @@ class Worker:
         self._queue_concurrency = dict(worker_config.queue_concurrency)
         self._reconcile_interval = worker_config.reconcile_interval
         self._requeue_on_shutdown = worker_config.requeue_on_shutdown
+        self._max_interruptions = worker_config.max_interruptions
         self._expiry_check_interval = worker_config.expiry_check_interval
         self._stale_after = (
             timedelta(seconds=worker_config.stale_after) if worker_config.stale_after is not None else None
@@ -460,7 +464,9 @@ class Worker:
                 # the exception would be swallowed whole by the drain/cancel
                 # wait and the record would silently stay `running`.
                 try:
-                    updated = await self._service.interrupt_task(record, worker_id=self._worker_id)
+                    updated = await self._service.interrupt_task(
+                        record, worker_id=self._worker_id, max_interruptions=self._max_interruptions
+                    )
                 except Exception:  # noqa: BLE001 - shutdown requeue failures are reported, never raised.
                     self._record_counter(
                         "litestar_queues.worker.interrupt.error", {"messaging.destination.name": record.queue}
@@ -581,6 +587,38 @@ class Worker:
                 self._cancel_requested.add(task)
                 task.cancel()
         await asyncio.wait(tasks, timeout=self._final_cancel_timeout)
+        await self._hand_off_undead_tasks()
+
+    async def _hand_off_undead_tasks(self) -> "None":
+        """Null the heartbeats of tasks that outlived their cancellation budget.
+
+        The records stay ``running`` and this worker no longer touches their
+        heartbeats, so a stale sweep (``stale_after``) can reclaim them on its
+        next pass instead of waiting out a full heartbeat age.
+        """
+        survivors = [record for task, record in self._running_tasks.items() if not task.done()]
+        if not survivors:
+            return
+        self._logger.warning(
+            "Queue tasks survived cancellation; abandoning them to stale recovery",
+            extra={
+                "worker_id": self._worker_id,
+                "task_ids": [str(record.id) for record in survivors],
+            },
+        )
+        # `null_heartbeats` carries one fence value per call, so group the
+        # survivors by the generation this worker still believes it owns.
+        by_generation: "dict[int, list[UUID]]" = {}
+        for record in survivors:
+            by_generation.setdefault(record.retry_count, []).append(record.id)
+        backend = self._service.get_queue_backend()
+        for expected_retry_count, task_ids in by_generation.items():
+            try:
+                await backend.null_heartbeats(task_ids, expected_retry_count=expected_retry_count)
+            except Exception:  # noqa: BLE001 - the handoff is best effort during shutdown.
+                self._logger.exception(
+                    "Nulling heartbeats for surviving queue tasks failed", extra={"worker_id": self._worker_id}
+                )
 
     async def _wait_for_work(self) -> "bool | None":
         """Wait for new work, a backend notification, or a stop signal.

--- a/src/tests/integration/_interrupt_contract.py
+++ b/src/tests/integration/_interrupt_contract.py
@@ -1,7 +1,7 @@
 """Shared worker-ownership and shutdown-interrupt assertions for every queue backend."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from litestar_queues import (
@@ -25,10 +25,9 @@ async def assert_assign_worker_persists_ownership(queue_backend: "BaseQueueBacke
     record = await queue_backend.enqueue("tasks.owned")
     claimed = await queue_backend.claim_task(record.id)
     assert claimed is not None
+    generation = claimed.retry_count
 
-    assigned = await queue_backend.assign_worker(
-        record.id, worker_id="worker-a", expected_retry_count=claimed.retry_count
-    )
+    assigned = await queue_backend.assign_worker(record.id, worker_id="worker-a", expected_retry_count=generation)
     assert assigned is not None
     assert assigned.worker_id == "worker-a"
 
@@ -37,7 +36,7 @@ async def assert_assign_worker_persists_ownership(queue_backend: "BaseQueueBacke
     assert stored.worker_id == "worker-a"
 
     lost_fence = await queue_backend.assign_worker(
-        record.id, worker_id="worker-b", expected_retry_count=claimed.retry_count + 1
+        record.id, worker_id="worker-b", expected_retry_count=generation + 1
     )
     assert lost_fence is None
     still_owned = await queue_backend.get_task(record.id)
@@ -50,26 +49,35 @@ async def assert_interrupts_owned_running_record(queue_backend: "BaseQueueBacken
     record = await queue_backend.enqueue("tasks.interrupt", priority=7)
     claimed = await queue_backend.claim_task(record.id)
     assert claimed is not None
-    assigned = await queue_backend.assign_worker(
-        record.id, worker_id="worker-a", expected_retry_count=claimed.retry_count
-    )
+    # The memory backend hands back the live record, so snapshot the claimed
+    # generation before any mutation instead of re-reading it later.
+    generation = claimed.retry_count
+    assigned = await queue_backend.assign_worker(record.id, worker_id="worker-a", expected_retry_count=generation)
     assert assigned is not None
 
     requeue_time = datetime.now(timezone.utc)
     wrong_owner = await queue_backend.interrupt_task(
-        record.id, expected_retry_count=claimed.retry_count, worker_id="worker-b", queued_at=requeue_time
+        record.id, expected_retry_count=generation, worker_id="worker-b", queued_at=requeue_time
     )
     assert wrong_owner is None
     wrong_generation = await queue_backend.interrupt_task(
-        record.id, expected_retry_count=claimed.retry_count + 1, worker_id="worker-a", queued_at=requeue_time
+        record.id, expected_retry_count=generation + 1, worker_id="worker-a", queued_at=requeue_time
     )
     assert wrong_generation is None
 
     updated = await queue_backend.interrupt_task(
-        record.id, expected_retry_count=claimed.retry_count, worker_id="worker-a", queued_at=requeue_time
+        record.id, expected_retry_count=generation, worker_id="worker-a", queued_at=requeue_time
     )
     assert updated is not None
     assert updated.status == "pending"
+    assert updated.retry_count == generation + 1
+    assert updated.metadata.get("interruptions") == 1
+
+    # The generation bump locks the previous owner out of every settle fence.
+    assert (
+        await queue_backend.complete_task(record.id, result="stale-owner", expected_retry_count=generation)
+        is None
+    )
 
     stored = await queue_backend.get_task(record.id)
     assert stored is not None
@@ -136,3 +144,48 @@ async def assert_worker_shutdown_requeues_running_task(queue_backend: "BaseQueue
     assert stored.worker_id is None
     assert stored.queued_at >= enqueued.queued_at
     assert any(event.type == "task.interrupted" for event in sink.events)
+
+
+async def assert_interruption_does_not_consume_retry_budget(queue_backend: "BaseQueueBackend") -> "None":
+    """An interruption bumps the fence generation without spending a retry attempt."""
+    record = await queue_backend.enqueue("tasks.interrupt.budget", max_retries=1)
+    claimed = await queue_backend.claim_task(record.id)
+    assert claimed is not None
+    generation = claimed.retry_count
+    assert await queue_backend.assign_worker(record.id, worker_id="worker-a", expected_retry_count=generation)
+    interrupted = await queue_backend.interrupt_task(
+        record.id, expected_retry_count=generation, worker_id="worker-a", queued_at=datetime.now(timezone.utc)
+    )
+    assert interrupted is not None
+    assert interrupted.retry_count == generation + 1
+
+    reclaimed = await queue_backend.claim_task(record.id)
+    assert reclaimed is not None
+
+    result = await queue_backend.requeue_stale_running(stale_after=timedelta(seconds=-2))
+    stored = await queue_backend.get_task(record.id)
+
+    assert result.requeued == 1
+    assert result.failed == 0
+    assert stored is not None
+    assert stored.status in {"pending", "scheduled"}
+
+
+async def assert_interruption_does_not_consume_failure_budget(queue_backend: "BaseQueueBackend") -> "None":
+    """A failure after an interruption still gets the record's full retry budget."""
+    record = await queue_backend.enqueue("tasks.interrupt.fail_budget", max_retries=1)
+    claimed = await queue_backend.claim_task(record.id)
+    assert claimed is not None
+    generation = claimed.retry_count
+    assert await queue_backend.assign_worker(record.id, worker_id="worker-a", expected_retry_count=generation)
+    interrupted = await queue_backend.interrupt_task(
+        record.id, expected_retry_count=generation, worker_id="worker-a", queued_at=datetime.now(timezone.utc)
+    )
+    assert interrupted is not None
+
+    reclaimed = await queue_backend.claim_task(record.id)
+    assert reclaimed is not None
+    failed = await queue_backend.fail_task(record.id, "boom", retry=True)
+
+    assert failed is not None
+    assert failed.status in {"pending", "scheduled"}

--- a/src/tests/integration/_interrupt_contract.py
+++ b/src/tests/integration/_interrupt_contract.py
@@ -35,9 +35,7 @@ async def assert_assign_worker_persists_ownership(queue_backend: "BaseQueueBacke
     assert stored is not None
     assert stored.worker_id == "worker-a"
 
-    lost_fence = await queue_backend.assign_worker(
-        record.id, worker_id="worker-b", expected_retry_count=generation + 1
-    )
+    lost_fence = await queue_backend.assign_worker(record.id, worker_id="worker-b", expected_retry_count=generation + 1)
     assert lost_fence is None
     still_owned = await queue_backend.get_task(record.id)
     assert still_owned is not None
@@ -74,10 +72,7 @@ async def assert_interrupts_owned_running_record(queue_backend: "BaseQueueBacken
     assert updated.metadata.get("interruptions") == 1
 
     # The generation bump locks the previous owner out of every settle fence.
-    assert (
-        await queue_backend.complete_task(record.id, result="stale-owner", expected_retry_count=generation)
-        is None
-    )
+    assert await queue_backend.complete_task(record.id, result="stale-owner", expected_retry_count=generation) is None
 
     stored = await queue_backend.get_task(record.id)
     assert stored is not None
@@ -189,3 +184,31 @@ async def assert_interruption_does_not_consume_failure_budget(queue_backend: "Ba
 
     assert failed is not None
     assert failed.status in {"pending", "scheduled"}
+
+
+async def assert_stale_requeue_priority_policy(queue_backend: "BaseQueueBackend") -> "None":
+    """``QueueConfig.stale_requeue_priority`` decides the priority recovered work re-enters with."""
+    original_config = queue_backend.config
+    # Fixture backends are built without a QueueConfig; the policy is read live
+    # from whatever config the backend carries at sweep time.
+    config = (
+        original_config
+        if original_config is not None
+        else QueueConfig(queue_backend="memory", worker=WorkerConfig(placement="external"))
+    )
+    original_policy = config.stale_requeue_priority
+    config.stale_requeue_priority = "preserve"
+    queue_backend.config = config
+    try:
+        record = await queue_backend.enqueue("tasks.stale.keep", priority=9, max_retries=2)
+        assert await queue_backend.claim_task(record.id) is not None
+
+        result = await queue_backend.requeue_stale_running(stale_after=timedelta(seconds=-2))
+        stored = await queue_backend.get_task(record.id)
+
+        assert result.requeued == 1
+        assert stored is not None
+        assert stored.priority == 9
+    finally:
+        config.stale_requeue_priority = original_policy
+        queue_backend.config = original_config

--- a/src/tests/integration/_interrupt_contract.py
+++ b/src/tests/integration/_interrupt_contract.py
@@ -1,0 +1,138 @@
+"""Shared worker-ownership and shutdown-interrupt assertions for every queue backend."""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from litestar_queues import (
+    EventDeliveryConfig,
+    InMemoryQueueEventSink,
+    QueueConfig,
+    QueueService,
+    Worker,
+    WorkerConfig,
+    task,
+)
+from litestar_queues.events import QueueEventsConfig
+from litestar_queues.task import clear_task_registry
+
+if TYPE_CHECKING:
+    from litestar_queues.backends import BaseQueueBackend
+
+
+async def assert_assign_worker_persists_ownership(queue_backend: "BaseQueueBackend") -> "None":
+    """Worker ownership survives a round trip and is fenced on the retry generation."""
+    record = await queue_backend.enqueue("tasks.owned")
+    claimed = await queue_backend.claim_task(record.id)
+    assert claimed is not None
+
+    assigned = await queue_backend.assign_worker(
+        record.id, worker_id="worker-a", expected_retry_count=claimed.retry_count
+    )
+    assert assigned is not None
+    assert assigned.worker_id == "worker-a"
+
+    stored = await queue_backend.get_task(record.id)
+    assert stored is not None
+    assert stored.worker_id == "worker-a"
+
+    lost_fence = await queue_backend.assign_worker(
+        record.id, worker_id="worker-b", expected_retry_count=claimed.retry_count + 1
+    )
+    assert lost_fence is None
+    still_owned = await queue_backend.get_task(record.id)
+    assert still_owned is not None
+    assert still_owned.worker_id == "worker-a"
+
+
+async def assert_interrupts_owned_running_record(queue_backend: "BaseQueueBackend") -> "None":
+    """``interrupt_task`` returns an owned running attempt to pending, fenced on owner and generation."""
+    record = await queue_backend.enqueue("tasks.interrupt", priority=7)
+    claimed = await queue_backend.claim_task(record.id)
+    assert claimed is not None
+    assigned = await queue_backend.assign_worker(
+        record.id, worker_id="worker-a", expected_retry_count=claimed.retry_count
+    )
+    assert assigned is not None
+
+    requeue_time = datetime.now(timezone.utc)
+    wrong_owner = await queue_backend.interrupt_task(
+        record.id, expected_retry_count=claimed.retry_count, worker_id="worker-b", queued_at=requeue_time
+    )
+    assert wrong_owner is None
+    wrong_generation = await queue_backend.interrupt_task(
+        record.id, expected_retry_count=claimed.retry_count + 1, worker_id="worker-a", queued_at=requeue_time
+    )
+    assert wrong_generation is None
+
+    updated = await queue_backend.interrupt_task(
+        record.id, expected_retry_count=claimed.retry_count, worker_id="worker-a", queued_at=requeue_time
+    )
+    assert updated is not None
+    assert updated.status == "pending"
+
+    stored = await queue_backend.get_task(record.id)
+    assert stored is not None
+    assert stored.status == "pending"
+    assert stored.priority == 7
+    assert stored.scheduled_at is None
+    assert stored.started_at is None
+    assert stored.heartbeat_at is None
+    assert stored.completed_at is None
+    assert stored.execution_ref is None
+    assert stored.worker_id is None
+
+    reclaimed = await queue_backend.claim_task(record.id)
+    assert reclaimed is not None
+
+
+async def assert_worker_shutdown_requeues_running_task(queue_backend: "BaseQueueBackend") -> "None":
+    """``requeue_on_shutdown`` returns an in-flight attempt to pending and reports the interruption."""
+    clear_task_registry()
+    started = asyncio.Event()
+    sink = InMemoryQueueEventSink()
+
+    @task("shutdown.requeue.blocking")
+    async def blocking() -> "None":
+        started.set()
+        await asyncio.Event().wait()
+
+    config = QueueConfig(
+        worker=WorkerConfig(placement="external"),
+        queue_backend="memory",
+        execution_backend="local",
+        events=QueueEventsConfig(delivery=EventDeliveryConfig(sinks=(sink,))),
+    )
+    service = QueueService(config, queue_backend=queue_backend)
+    async with service:
+        result = await service.enqueue(blocking)
+        enqueued = await queue_backend.get_task(result.id)
+        assert enqueued is not None
+        worker = Worker(
+            service,
+            WorkerConfig(
+                placement="external",
+                requeue_on_shutdown=True,
+                max_concurrency=1,
+                graceful_shutdown_timeout=0.05,
+                final_cancel_timeout=5.0,
+                poll_interval=0.05,
+                poll_backoff_max=None,
+            ),
+        )
+        worker_task = asyncio.create_task(worker.start())
+        await asyncio.wait_for(started.wait(), timeout=10)
+
+        escalated = await asyncio.wait_for(worker.stop(), timeout=15)
+        await asyncio.wait_for(worker_task, timeout=15)
+
+        stored = await queue_backend.get_task(result.id)
+
+    assert escalated is True
+    assert stored is not None
+    assert stored.status == "pending"
+    assert stored.started_at is None
+    assert stored.heartbeat_at is None
+    assert stored.worker_id is None
+    assert stored.queued_at >= enqueued.queued_at
+    assert any(event.type == "task.interrupted" for event in sink.events)

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -1046,13 +1046,17 @@ class _FakeListenerSQLAlchemyBackend(SQLAlchemyBackend):
         return self.listener.due_on_reconcile
 
 
-async def test_advanced_alchemy_assign_worker_persists_ownership(advanced_alchemy_backend: "SQLAlchemyBackend") -> "None":
+async def test_advanced_alchemy_assign_worker_persists_ownership(
+    advanced_alchemy_backend: "SQLAlchemyBackend",
+) -> "None":
     from tests.integration._interrupt_contract import assert_assign_worker_persists_ownership
 
     await assert_assign_worker_persists_ownership(advanced_alchemy_backend)
 
 
-async def test_advanced_alchemy_interrupts_owned_running_record(advanced_alchemy_backend: "SQLAlchemyBackend") -> "None":
+async def test_advanced_alchemy_interrupts_owned_running_record(
+    advanced_alchemy_backend: "SQLAlchemyBackend",
+) -> "None":
     from tests.integration._interrupt_contract import assert_interrupts_owned_running_record
 
     await assert_interrupts_owned_running_record(advanced_alchemy_backend)
@@ -1080,3 +1084,9 @@ async def test_advanced_alchemy_interruption_does_not_consume_failure_budget(
     from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
 
     await assert_interruption_does_not_consume_failure_budget(advanced_alchemy_backend)
+
+
+async def test_advanced_alchemy_stale_requeue_priority_policy(advanced_alchemy_backend: "SQLAlchemyBackend") -> "None":
+    from tests.integration._interrupt_contract import assert_stale_requeue_priority_policy
+
+    await assert_stale_requeue_priority_policy(advanced_alchemy_backend)

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -1064,3 +1064,19 @@ async def test_advanced_alchemy_worker_shutdown_requeues_running_task(
     from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
 
     await assert_worker_shutdown_requeues_running_task(advanced_alchemy_backend)
+
+
+async def test_advanced_alchemy_interruption_does_not_consume_retry_budget(
+    advanced_alchemy_backend: "SQLAlchemyBackend",
+) -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_retry_budget
+
+    await assert_interruption_does_not_consume_retry_budget(advanced_alchemy_backend)
+
+
+async def test_advanced_alchemy_interruption_does_not_consume_failure_budget(
+    advanced_alchemy_backend: "SQLAlchemyBackend",
+) -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
+
+    await assert_interruption_does_not_consume_failure_budget(advanced_alchemy_backend)

--- a/src/tests/integration/backends/advanced_alchemy/test_contract.py
+++ b/src/tests/integration/backends/advanced_alchemy/test_contract.py
@@ -1044,3 +1044,23 @@ class _FakeListenerSQLAlchemyBackend(SQLAlchemyBackend):
 
     async def _has_due_tasks(self) -> "bool":
         return self.listener.due_on_reconcile
+
+
+async def test_advanced_alchemy_assign_worker_persists_ownership(advanced_alchemy_backend: "SQLAlchemyBackend") -> "None":
+    from tests.integration._interrupt_contract import assert_assign_worker_persists_ownership
+
+    await assert_assign_worker_persists_ownership(advanced_alchemy_backend)
+
+
+async def test_advanced_alchemy_interrupts_owned_running_record(advanced_alchemy_backend: "SQLAlchemyBackend") -> "None":
+    from tests.integration._interrupt_contract import assert_interrupts_owned_running_record
+
+    await assert_interrupts_owned_running_record(advanced_alchemy_backend)
+
+
+async def test_advanced_alchemy_worker_shutdown_requeues_running_task(
+    advanced_alchemy_backend: "SQLAlchemyBackend",
+) -> "None":
+    from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
+
+    await assert_worker_shutdown_requeues_running_task(advanced_alchemy_backend)

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -663,3 +663,9 @@ async def test_redis_interruption_does_not_consume_failure_budget(redis_backend:
     from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
 
     await assert_interruption_does_not_consume_failure_budget(redis_backend)
+
+
+async def test_redis_stale_requeue_priority_policy(redis_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_stale_requeue_priority_policy
+
+    await assert_stale_requeue_priority_policy(redis_backend)

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -651,3 +651,15 @@ async def test_redis_worker_shutdown_requeues_running_task(redis_backend: "Any")
     from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
 
     await assert_worker_shutdown_requeues_running_task(redis_backend)
+
+
+async def test_redis_interruption_does_not_consume_retry_budget(redis_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_retry_budget
+
+    await assert_interruption_does_not_consume_retry_budget(redis_backend)
+
+
+async def test_redis_interruption_does_not_consume_failure_budget(redis_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
+
+    await assert_interruption_does_not_consume_failure_budget(redis_backend)

--- a/src/tests/integration/backends/redis/test_contract.py
+++ b/src/tests/integration/backends/redis/test_contract.py
@@ -633,3 +633,21 @@ async def test_redis_forever_concurrent_reservation_single_winner(redis_backend:
     from tests.integration._uniqueness_contract import assert_concurrent_reservation_has_single_winner
 
     await assert_concurrent_reservation_has_single_winner(redis_backend)
+
+
+async def test_redis_assign_worker_persists_ownership(redis_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_assign_worker_persists_ownership
+
+    await assert_assign_worker_persists_ownership(redis_backend)
+
+
+async def test_redis_interrupts_owned_running_record(redis_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_interrupts_owned_running_record
+
+    await assert_interrupts_owned_running_record(redis_backend)
+
+
+async def test_redis_worker_shutdown_requeues_running_task(redis_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
+
+    await assert_worker_shutdown_requeues_running_task(redis_backend)

--- a/src/tests/integration/backends/sqlspec/test_contract.py
+++ b/src/tests/integration/backends/sqlspec/test_contract.py
@@ -597,16 +597,18 @@ def test_sqlspec_fail_returning_sql_uses_case_retry_branch() -> "None":
 
     sql = store.fail_returning_sql(fence_retry_count=False)
 
+    # Shutdown interruptions bump the fence generation without spending a retry
+    # attempt, so the single-statement budget subtracts them from retry_count.
+    can_retry = (
+        ':retry = TRUE AND ("retry_count" - COALESCE(("metadata" ->> \'interruptions\')::INT, 0)) < "max_retries"'
+    )
     assert (
-        'CASE WHEN :retry = TRUE AND "retry_count" < "max_retries" THEN '
+        f"CASE WHEN {can_retry} THEN "
         "CASE WHEN CAST(:retry_at AS TIMESTAMPTZ) IS NULL THEN 'pending' ELSE 'scheduled' END ELSE 'failed' END" in sql
     )
     assert '"heartbeat_at" = NULL' in sql
     assert '"error" = :error' in sql
-    assert (
-        '"completed_at" = CASE WHEN :retry = TRUE AND "retry_count" < "max_retries" '
-        "THEN NULL ELSE CAST(:completed_at AS TIMESTAMPTZ) END" in sql
-    )
+    assert f'"completed_at" = CASE WHEN {can_retry} THEN NULL ELSE CAST(:completed_at AS TIMESTAMPTZ) END' in sql
 
 
 def test_sqlspec_returning_columns_alias_remapped_columns() -> "None":

--- a/src/tests/integration/backends/valkey/test_contract.py
+++ b/src/tests/integration/backends/valkey/test_contract.py
@@ -601,3 +601,9 @@ async def test_valkey_interruption_does_not_consume_failure_budget(valkey_backen
     from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
 
     await assert_interruption_does_not_consume_failure_budget(valkey_backend)
+
+
+async def test_valkey_stale_requeue_priority_policy(valkey_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_stale_requeue_priority_policy
+
+    await assert_stale_requeue_priority_policy(valkey_backend)

--- a/src/tests/integration/backends/valkey/test_contract.py
+++ b/src/tests/integration/backends/valkey/test_contract.py
@@ -589,3 +589,15 @@ async def test_valkey_worker_shutdown_requeues_running_task(valkey_backend: "Any
     from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
 
     await assert_worker_shutdown_requeues_running_task(valkey_backend)
+
+
+async def test_valkey_interruption_does_not_consume_retry_budget(valkey_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_retry_budget
+
+    await assert_interruption_does_not_consume_retry_budget(valkey_backend)
+
+
+async def test_valkey_interruption_does_not_consume_failure_budget(valkey_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
+
+    await assert_interruption_does_not_consume_failure_budget(valkey_backend)

--- a/src/tests/integration/backends/valkey/test_contract.py
+++ b/src/tests/integration/backends/valkey/test_contract.py
@@ -571,3 +571,21 @@ async def test_valkey_forever_concurrent_reservation_single_winner(valkey_backen
     from tests.integration._uniqueness_contract import assert_concurrent_reservation_has_single_winner
 
     await assert_concurrent_reservation_has_single_winner(valkey_backend)
+
+
+async def test_valkey_assign_worker_persists_ownership(valkey_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_assign_worker_persists_ownership
+
+    await assert_assign_worker_persists_ownership(valkey_backend)
+
+
+async def test_valkey_interrupts_owned_running_record(valkey_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_interrupts_owned_running_record
+
+    await assert_interrupts_owned_running_record(valkey_backend)
+
+
+async def test_valkey_worker_shutdown_requeues_running_task(valkey_backend: "Any") -> "None":
+    from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
+
+    await assert_worker_shutdown_requeues_running_task(valkey_backend)

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -820,9 +820,7 @@ async def test_backend_contract_interrupts_owned_running_record(queue_backend: "
     await assert_interrupts_owned_running_record(queue_backend)
 
 
-async def test_backend_contract_interruption_does_not_consume_retry_budget(
-    queue_backend: "BaseQueueBackend",
-) -> "None":
+async def test_backend_contract_interruption_does_not_consume_retry_budget(queue_backend: "BaseQueueBackend") -> "None":
     from tests.integration._interrupt_contract import assert_interruption_does_not_consume_retry_budget
 
     await assert_interruption_does_not_consume_retry_budget(queue_backend)
@@ -834,3 +832,9 @@ async def test_backend_contract_interruption_does_not_consume_failure_budget(
     from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
 
     await assert_interruption_does_not_consume_failure_budget(queue_backend)
+
+
+async def test_backend_contract_stale_requeue_priority_policy(queue_backend: "BaseQueueBackend") -> "None":
+    from tests.integration._interrupt_contract import assert_stale_requeue_priority_policy
+
+    await assert_stale_requeue_priority_policy(queue_backend)

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -352,7 +352,9 @@ async def test_backend_contract_recovers_stale_running_records(queue_backend: "B
     assert stored_requeued is not None
     assert stored_requeued.status == "pending"
     assert stored_requeued.retry_count == 2
-    assert stored_requeued.priority == 4
+    # The default policy is "preserve": recovery must carry the enqueued
+    # priority through unchanged rather than demoting the record.
+    assert stored_requeued.priority == 10
     assert stored_requeued.error == "first failure"
     assert stored_failed is not None
     assert stored_failed.status == "failed"

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -818,3 +818,19 @@ async def test_backend_contract_interrupts_owned_running_record(queue_backend: "
     from tests.integration._interrupt_contract import assert_interrupts_owned_running_record
 
     await assert_interrupts_owned_running_record(queue_backend)
+
+
+async def test_backend_contract_interruption_does_not_consume_retry_budget(
+    queue_backend: "BaseQueueBackend",
+) -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_retry_budget
+
+    await assert_interruption_does_not_consume_retry_budget(queue_backend)
+
+
+async def test_backend_contract_interruption_does_not_consume_failure_budget(
+    queue_backend: "BaseQueueBackend",
+) -> "None":
+    from tests.integration._interrupt_contract import assert_interruption_does_not_consume_failure_budget
+
+    await assert_interruption_does_not_consume_failure_budget(queue_backend)

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -806,3 +806,15 @@ async def test_backend_contract_retires_a_record_whose_task_name_is_unknown(
     assert stored.is_terminal
     assert stored.error is not None
     assert "contract.consumer.never_registered" in stored.error
+
+
+async def test_backend_contract_assign_worker_persists_ownership(queue_backend: "BaseQueueBackend") -> "None":
+    from tests.integration._interrupt_contract import assert_assign_worker_persists_ownership
+
+    await assert_assign_worker_persists_ownership(queue_backend)
+
+
+async def test_backend_contract_interrupts_owned_running_record(queue_backend: "BaseQueueBackend") -> "None":
+    from tests.integration._interrupt_contract import assert_interrupts_owned_running_record
+
+    await assert_interrupts_owned_running_record(queue_backend)

--- a/src/tests/integration/test_worker_shutdown_requeue.py
+++ b/src/tests/integration/test_worker_shutdown_requeue.py
@@ -1,0 +1,16 @@
+"""Behavioral shutdown-requeue proof for every registered queue backend."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.integration._interrupt_contract import assert_worker_shutdown_requeues_running_task
+
+if TYPE_CHECKING:
+    from litestar_queues.backends import BaseQueueBackend
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_worker_shutdown_requeues_running_task(queue_backend: "BaseQueueBackend") -> "None":
+    await assert_worker_shutdown_requeues_running_task(queue_backend)

--- a/src/tests/unit/backends/test_base_backend.py
+++ b/src/tests/unit/backends/test_base_backend.py
@@ -5,7 +5,8 @@ import pytest
 
 from litestar_queues import HeartbeatTouch, InMemoryQueueBackend
 from litestar_queues.backends import BaseQueueBackend
-from litestar_queues.backends.base import attempts_consumed, interruption_count, retry_schedule
+from litestar_queues.backends.base import attempts_consumed, interruption_count, retry_schedule, stale_requeue_priority
+from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import QueuedTaskRecord
 
 pytestmark = pytest.mark.anyio
@@ -113,9 +114,7 @@ def test_attempts_consumed_discounts_interruptions() -> "None":
 
 def test_retry_schedule_backoff_uses_attempts_consumed() -> "None":
     backoff = {"initial_delay": 1.0, "multiplier": 2.0}
-    interrupted = QueuedTaskRecord(
-        "tasks.a", retry_count=3, metadata={"interruptions": 2, "retry_backoff": backoff}
-    )
+    interrupted = QueuedTaskRecord("tasks.a", retry_count=3, metadata={"interruptions": 2, "retry_backoff": backoff})
     plain = QueuedTaskRecord("tasks.a", retry_count=1, metadata={"retry_backoff": backoff})
 
     queued_at, retry_at = retry_schedule(interrupted)
@@ -124,3 +123,15 @@ def test_retry_schedule_backoff_uses_attempts_consumed() -> "None":
     assert retry_at is not None
     assert plain_retry_at is not None
     assert (retry_at - queued_at) == (plain_retry_at - plain_queued_at)
+
+
+def test_stale_requeue_priority_policies() -> "None":
+    assert stale_requeue_priority(9, 4) == 4
+    assert stale_requeue_priority(2, 4) == 2
+    assert stale_requeue_priority(9, "preserve") == 9
+    assert stale_requeue_priority(9, lambda priority: priority - 1) == 8
+
+
+def test_stale_requeue_priority_rejects_a_non_integer_callable() -> "None":
+    with pytest.raises(QueueConfigurationError):
+        stale_requeue_priority(9, lambda _priority: "high")  # type: ignore[arg-type,return-value]

--- a/src/tests/unit/backends/test_base_backend.py
+++ b/src/tests/unit/backends/test_base_backend.py
@@ -5,6 +5,8 @@ import pytest
 
 from litestar_queues import HeartbeatTouch, InMemoryQueueBackend
 from litestar_queues.backends import BaseQueueBackend
+from litestar_queues.backends.base import attempts_consumed, interruption_count, retry_schedule
+from litestar_queues.models import QueuedTaskRecord
 
 pytestmark = pytest.mark.anyio
 
@@ -60,6 +62,10 @@ _REQUIRED_CONTRACT_CALLS = {
     "get_statistics": lambda b: b.get_statistics(),
     "list_completed_by_task": lambda b: b.list_completed_by_task("tasks.sync"),
     "list_running_external": lambda b: b.list_running_external(),
+    "assign_worker": lambda b: b.assign_worker(uuid4(), worker_id="worker-a", expected_retry_count=0),
+    "interrupt_task": lambda b: b.interrupt_task(
+        uuid4(), expected_retry_count=0, worker_id="worker-a", queued_at=datetime.now(timezone.utc)
+    ),
     "null_heartbeats": lambda b: b.null_heartbeats([uuid4()]),
     "requeue_stale_running": lambda b: b.requeue_stale_running(stale_after=timedelta(seconds=60)),
     "set_execution_backend": lambda b: b.set_execution_backend(uuid4(), "cloudrun"),
@@ -88,3 +94,33 @@ async def test_worker_lock_is_fenced_on_a_backend_with_real_maintenance() -> "No
 
     assert first is True
     assert second is False
+
+
+def test_interruption_count_reads_only_positive_integers() -> "None":
+    assert interruption_count(QueuedTaskRecord("tasks.a")) == 0
+    assert interruption_count(QueuedTaskRecord("tasks.a", metadata={"interruptions": None})) == 0
+    assert interruption_count(QueuedTaskRecord("tasks.a", metadata={"interruptions": "two"})) == 0
+    assert interruption_count(QueuedTaskRecord("tasks.a", metadata={"interruptions": -1})) == 0
+    assert interruption_count(QueuedTaskRecord("tasks.a", metadata={"interruptions": 2})) == 2
+
+
+def test_attempts_consumed_discounts_interruptions() -> "None":
+    record = QueuedTaskRecord("tasks.a", retry_count=3, metadata={"interruptions": 2})
+
+    assert attempts_consumed(record) == 1
+    assert attempts_consumed(QueuedTaskRecord("tasks.a", retry_count=3)) == 3
+
+
+def test_retry_schedule_backoff_uses_attempts_consumed() -> "None":
+    backoff = {"initial_delay": 1.0, "multiplier": 2.0}
+    interrupted = QueuedTaskRecord(
+        "tasks.a", retry_count=3, metadata={"interruptions": 2, "retry_backoff": backoff}
+    )
+    plain = QueuedTaskRecord("tasks.a", retry_count=1, metadata={"retry_backoff": backoff})
+
+    queued_at, retry_at = retry_schedule(interrupted)
+    plain_queued_at, plain_retry_at = retry_schedule(plain)
+
+    assert retry_at is not None
+    assert plain_retry_at is not None
+    assert (retry_at - queued_at) == (plain_retry_at - plain_queued_at)

--- a/src/tests/unit/backends/test_memory.py
+++ b/src/tests/unit/backends/test_memory.py
@@ -300,7 +300,7 @@ async def test_memory_backend_requeues_stale_running_task_when_policy_allows() -
 
 
 async def test_memory_backend_demotes_stale_requeue_priority_and_preserves_prior_error() -> "None":
-    backend = InMemoryQueueBackend()
+    backend = InMemoryQueueBackend(config=QueueConfig(stale_requeue_priority=4))
     record = await backend.enqueue(
         "tasks.stale_demote", priority=10, max_retries=2, metadata={"requeue_on_stale": True}
     )

--- a/src/tests/unit/test_consolidated_worker_config.py
+++ b/src/tests/unit/test_consolidated_worker_config.py
@@ -124,7 +124,7 @@ def test_worker_config_hard_exit_timeout_defaults_and_validates() -> "None":
 
 
 def test_queue_config_validates_the_stale_requeue_priority_policy() -> "None":
-    assert QueueConfig().stale_requeue_priority == 4
+    assert QueueConfig().stale_requeue_priority == "preserve"
     assert QueueConfig(stale_requeue_priority="preserve").stale_requeue_priority == "preserve"
     with pytest.raises(QueueConfigurationError, match=r"QueueConfig\.stale_requeue_priority"):
         QueueConfig(stale_requeue_priority=-1)

--- a/src/tests/unit/test_consolidated_worker_config.py
+++ b/src/tests/unit/test_consolidated_worker_config.py
@@ -107,3 +107,17 @@ def test_effective_cpu_count_honors_cgroup_quota(monkeypatch: pytest.MonkeyPatch
 def test_sync_thread_pool_size_must_be_positive(size: int) -> None:
     with pytest.raises(QueueConfigurationError, match="sync_thread_pool_size must be greater than 0"):
         QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", sync_thread_pool_size=size)
+
+
+def test_worker_config_max_interruptions_defaults_and_validates() -> "None":
+    assert WorkerConfig().max_interruptions == 3
+    assert WorkerConfig(max_interruptions=1).max_interruptions == 1
+    with pytest.raises(QueueConfigurationError, match=r"WorkerConfig\.max_interruptions"):
+        WorkerConfig(max_interruptions=0)
+
+
+def test_worker_config_hard_exit_timeout_defaults_and_validates() -> "None":
+    assert WorkerConfig().hard_exit_timeout == 10.0
+    assert WorkerConfig(hard_exit_timeout=None).hard_exit_timeout is None
+    with pytest.raises(QueueConfigurationError, match=r"WorkerConfig\.hard_exit_timeout"):
+        WorkerConfig(hard_exit_timeout=0)

--- a/src/tests/unit/test_consolidated_worker_config.py
+++ b/src/tests/unit/test_consolidated_worker_config.py
@@ -121,3 +121,14 @@ def test_worker_config_hard_exit_timeout_defaults_and_validates() -> "None":
     assert WorkerConfig(hard_exit_timeout=None).hard_exit_timeout is None
     with pytest.raises(QueueConfigurationError, match=r"WorkerConfig\.hard_exit_timeout"):
         WorkerConfig(hard_exit_timeout=0)
+
+
+def test_queue_config_validates_the_stale_requeue_priority_policy() -> "None":
+    assert QueueConfig().stale_requeue_priority == 4
+    assert QueueConfig(stale_requeue_priority="preserve").stale_requeue_priority == "preserve"
+    with pytest.raises(QueueConfigurationError, match=r"QueueConfig\.stale_requeue_priority"):
+        QueueConfig(stale_requeue_priority=-1)
+    with pytest.raises(QueueConfigurationError, match=r"QueueConfig\.stale_requeue_priority"):
+        QueueConfig(stale_requeue_priority="keep")  # type: ignore[arg-type]
+    with pytest.raises(QueueConfigurationError, match=r"QueueConfig\.stale_requeue_priority"):
+        QueueConfig(stale_requeue_priority=True)

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -1210,3 +1210,67 @@ class _EventLogBackend(InMemoryQueueBackend):
     def get_event_log(self, config: "EventHistoryConfig") -> "QueueEventLog | None":
         del config
         return self._event_log
+
+
+async def _interrupt_cycles(backend: "InMemoryQueueBackend", service: "QueueService", task_id: "UUID", count: "int") -> "None":
+    for _ in range(count):
+        claimed = await backend.claim_task(task_id)
+        assert claimed is not None
+        assert await backend.assign_worker(task_id, worker_id="worker-a", expected_retry_count=claimed.retry_count)
+        assert await service.interrupt_task(claimed, worker_id="worker-a", max_interruptions=3) is not None
+
+
+async def test_interrupt_task_over_the_cap_consumes_the_retry_budget() -> "None":
+    backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=backend
+    )
+    async with service:
+        record = await backend.enqueue("tasks.capped", max_retries=2)
+        await _interrupt_cycles(backend, service, record.id, 3)
+        claimed = await backend.claim_task(record.id)
+        assert claimed is not None
+        assert await backend.assign_worker(record.id, worker_id="worker-a", expected_retry_count=claimed.retry_count)
+
+        updated = await service.interrupt_task(claimed, worker_id="worker-a", max_interruptions=3)
+
+        assert updated is not None
+        assert updated.status == "pending"
+        assert updated.retry_count == 4
+        assert updated.metadata.get("interruptions") == 3
+        assert updated.error == "Interrupted during shutdown"
+
+
+async def test_interrupt_task_over_the_cap_fails_terminally_without_retries() -> "None":
+    backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=backend
+    )
+    async with service:
+        record = await backend.enqueue("tasks.capped.terminal", max_retries=0)
+        await _interrupt_cycles(backend, service, record.id, 3)
+        claimed = await backend.claim_task(record.id)
+        assert claimed is not None
+        assert await backend.assign_worker(record.id, worker_id="worker-a", expected_retry_count=claimed.retry_count)
+
+        updated = await service.interrupt_task(claimed, worker_id="worker-a", max_interruptions=3)
+
+        assert updated is not None
+        assert updated.status == "failed"
+        assert updated.error == "Interrupted during shutdown"
+
+
+async def test_interrupt_task_under_the_cap_requeues() -> "None":
+    backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=backend
+    )
+    async with service:
+        record = await backend.enqueue("tasks.uncapped", max_retries=0)
+        await _interrupt_cycles(backend, service, record.id, 1)
+        stored = await backend.get_task(record.id)
+
+        assert stored is not None
+        assert stored.status == "pending"
+        assert stored.metadata.get("interruptions") == 1
+        assert stored.error is None

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -1212,7 +1212,9 @@ class _EventLogBackend(InMemoryQueueBackend):
         return self._event_log
 
 
-async def _interrupt_cycles(backend: "InMemoryQueueBackend", service: "QueueService", task_id: "UUID", count: "int") -> "None":
+async def _interrupt_cycles(
+    backend: "InMemoryQueueBackend", service: "QueueService", task_id: "UUID", count: "int"
+) -> "None":
     for _ in range(count):
         claimed = await backend.claim_task(task_id)
         assert claimed is not None

--- a/src/tests/unit/test_shutdown_watchdog.py
+++ b/src/tests/unit/test_shutdown_watchdog.py
@@ -1,0 +1,74 @@
+"""Hard-exit watchdog behavior for workers whose loop or task will not die."""
+
+import signal
+import time
+
+import pytest
+
+from litestar_queues._cli import _CLIStopCoordinator
+from litestar_queues.worker.runtime import ShutdownWatchdog
+
+pytestmark = pytest.mark.anyio
+
+
+def test_watchdog_exits_after_its_deadline() -> "None":
+    exits: "list[int]" = []
+    watchdog = ShutdownWatchdog(timeout=0.05, exit_fn=exits.append)
+
+    watchdog.arm(signal.SIGTERM)
+    time.sleep(0.4)
+
+    assert exits == [128 + int(signal.SIGTERM)]
+
+
+def test_watchdog_disarm_prevents_the_exit() -> "None":
+    exits: "list[int]" = []
+    watchdog = ShutdownWatchdog(timeout=0.2, exit_fn=exits.append)
+
+    watchdog.arm(signal.SIGINT)
+    watchdog.disarm()
+    time.sleep(0.4)
+
+    assert exits == []
+
+
+def test_watchdog_without_a_timeout_never_arms() -> "None":
+    exits: "list[int]" = []
+    watchdog = ShutdownWatchdog(timeout=None, exit_fn=exits.append)
+
+    watchdog.arm(signal.SIGTERM)
+    time.sleep(0.2)
+
+    assert exits == []
+
+
+def test_watchdog_arm_is_idempotent_and_keeps_the_first_signal() -> "None":
+    exits: "list[int]" = []
+    watchdog = ShutdownWatchdog(timeout=0.05, exit_fn=exits.append)
+
+    watchdog.arm(signal.SIGINT)
+    watchdog.arm(signal.SIGTERM)
+    time.sleep(0.4)
+
+    assert exits == [128 + int(signal.SIGINT)]
+
+
+async def test_second_signal_arms_the_watchdog_and_the_third_exits_immediately() -> "None":
+    exits: "list[int]" = []
+    watchdog = ShutdownWatchdog(timeout=30.0, exit_fn=exits.append)
+    coordinator = _CLIStopCoordinator(watchdog=watchdog)
+
+    coordinator.request_stop(signal.SIGTERM)
+    assert coordinator.graceful.is_set()
+    assert not coordinator.force.is_set()
+    assert exits == []
+
+    coordinator.request_stop(signal.SIGTERM)
+    assert coordinator.force.is_set()
+    assert watchdog.is_armed
+    assert exits == []
+
+    coordinator.request_stop(signal.SIGTERM)
+    assert exits == [128 + int(signal.SIGTERM)]
+
+    watchdog.disarm()

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -2206,8 +2206,7 @@ async def test_worker_nulls_heartbeats_for_tasks_that_survive_cancellation() -> 
         result = await service.enqueue(undead)
         backend = service.get_queue_backend()
         worker = Worker(
-            service,
-            WorkerConfig(placement="external", graceful_shutdown_timeout=0.05, final_cancel_timeout=0.1),
+            service, WorkerConfig(placement="external", graceful_shutdown_timeout=0.05, final_cancel_timeout=0.1)
         )
         worker_task = asyncio.create_task(worker.start())
         await asyncio.wait_for(started.wait(), timeout=2)

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -2186,3 +2186,44 @@ async def test_worker_warns_when_shutdown_requeue_loses_its_fence(caplog: "pytes
     assert any(
         record.levelno == logging.WARNING and "fence" in record.getMessage().lower() for record in caplog.records
     )
+
+
+async def test_worker_nulls_heartbeats_for_tasks_that_survive_cancellation() -> "None":
+    started = asyncio.Event()
+    hang = asyncio.Event()
+
+    @task("tasks.undead")
+    async def undead() -> "None":
+        started.set()
+        try:
+            await hang.wait()
+        except asyncio.CancelledError:
+            await hang.wait()
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local")
+    ) as service:
+        result = await service.enqueue(undead)
+        backend = service.get_queue_backend()
+        worker = Worker(
+            service,
+            WorkerConfig(placement="external", graceful_shutdown_timeout=0.05, final_cancel_timeout=0.1),
+        )
+        worker_task = asyncio.create_task(worker.start())
+        await asyncio.wait_for(started.wait(), timeout=2)
+        await wait_until(lambda: _has_heartbeat(backend, result.id), timeout=5)
+
+        await asyncio.wait_for(worker.stop(), timeout=5)
+        stored = await backend.get_task(result.id)
+        assert stored is not None
+        assert stored.status == "running"
+        assert stored.heartbeat_at is None
+
+        hang.set()
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(worker_task, timeout=5)
+
+
+async def _has_heartbeat(backend: "BaseQueueBackend", task_id: "UUID") -> "bool":
+    record = await backend.get_task(task_id)
+    return record is not None and record.heartbeat_at is not None

--- a/src/tests/unit/test_worker.py
+++ b/src/tests/unit/test_worker.py
@@ -2109,3 +2109,80 @@ class _NextDueQueryCountingBackend(InMemoryQueueBackend):
     async def time_until_next_due(self, *, queues: "tuple[str, ...]" = ()) -> "float | None":
         self.next_due_calls += 1
         return await super().time_until_next_due(queues=queues)
+
+
+async def test_worker_logs_shutdown_requeue_backend_failure(caplog: "pytest.LogCaptureFixture") -> "None":
+    started = asyncio.Event()
+
+    @task("tasks.shutdown_requeue_error")
+    async def blocking() -> "None":
+        started.set()
+        await asyncio.Event().wait()
+
+    async def failing_interrupt(*args: "Any", **kwargs: "Any") -> "QueuedTaskRecord | None":
+        msg = "backend down"
+        raise RuntimeError(msg)
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local")
+    ) as service:
+        result = await service.enqueue(blocking)
+        backend = service.get_queue_backend()
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(type(backend), "interrupt_task", failing_interrupt, raising=True)
+            worker = Worker(
+                service,
+                WorkerConfig(
+                    placement="external",
+                    requeue_on_shutdown=True,
+                    graceful_shutdown_timeout=0.05,
+                    final_cancel_timeout=1.0,
+                ),
+            )
+            worker_task = asyncio.create_task(worker.start())
+            await asyncio.wait_for(started.wait(), timeout=2)
+            with caplog.at_level(logging.ERROR):
+                await asyncio.wait_for(worker.stop(), timeout=5)
+            await asyncio.wait_for(worker_task, timeout=5)
+
+    errors = [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert errors, "Expected the failed shutdown requeue to be logged at ERROR"
+    assert any(str(result.id) in str(record.__dict__.get("task_id")) for record in errors)
+
+
+async def test_worker_warns_when_shutdown_requeue_loses_its_fence(caplog: "pytest.LogCaptureFixture") -> "None":
+    started = asyncio.Event()
+
+    @task("tasks.shutdown_requeue_fence")
+    async def blocking() -> "None":
+        started.set()
+        await asyncio.Event().wait()
+
+    async def lost_fence(*args: "Any", **kwargs: "Any") -> "QueuedTaskRecord | None":
+        return None
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="local")
+    ) as service:
+        await service.enqueue(blocking)
+        backend = service.get_queue_backend()
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(type(backend), "interrupt_task", lost_fence, raising=True)
+            worker = Worker(
+                service,
+                WorkerConfig(
+                    placement="external",
+                    requeue_on_shutdown=True,
+                    graceful_shutdown_timeout=0.05,
+                    final_cancel_timeout=1.0,
+                ),
+            )
+            worker_task = asyncio.create_task(worker.start())
+            await asyncio.wait_for(started.wait(), timeout=2)
+            with caplog.at_level(logging.WARNING):
+                await asyncio.wait_for(worker.stop(), timeout=5)
+            await asyncio.wait_for(worker_task, timeout=5)
+
+    assert any(
+        record.levelno == logging.WARNING and "fence" in record.getMessage().lower() for record in caplog.records
+    )


### PR DESCRIPTION
`requeue_on_shutdown=True` was a no-op on every production backend: the four
durable backends raised `NotImplementedError` from `interrupt_task` and the
error disappeared inside the shutdown cancellation handler, so an interrupted
task stayed `running` until something else reclaimed it. This makes the
interrupt contract real everywhere, bounds interruption loops, gives hostile
shutdowns a way out, and makes stale-requeue priority a policy instead of a
constant. Closes #115, #116, #122, #123, and #119.

- **Shutdown requeue now works on every backend.** SQLSpec, Redis, Valkey, and
  Advanced Alchemy return an owned running attempt to `pending` behind an owner
  and generation fence, and they persist worker ownership so that fence has
  something to check. A backend failure during shutdown is logged with the task
  id instead of vanishing, and the cancellation is always re-raised.
- **A drain timeout no longer aborts its own requeue.** The drain and the
  worker loop's own shutdown both escalate to cancellation, and the second
  cancellation used to land inside the task's requeue handler and kill the
  backend write mid-flight. Each execution task is now cancelled exactly once.
- **Interruptions are counted and bounded.** Each requeue bumps the fence
  generation but not the retry budget, so ordinary restarts cost a task
  nothing. `WorkerConfig.max_interruptions` (default `3`) caps that: past the
  cap the interruption goes through the normal retry policy, so a task that is
  restarted forever eventually fails instead of cycling.
- **A worker that will not die still exits.** A forced shutdown arms a
  daemon-thread watchdog; when `WorkerConfig.hard_exit_timeout` (default `10`
  seconds) passes, or a third termination signal arrives, the process exits
  with `128 + signum`. It is a thread rather than a loop callback precisely
  because the failure being defended against is a wedged event loop.
- **Abandoned work is handed to stale recovery.** Tasks still alive after
  `final_cancel_timeout` are logged with their ids and have their heartbeats
  cleared, so a stale sweep can reclaim them at once instead of waiting out a
  full heartbeat age.
- **Recovered work can keep its priority.** `QueueConfig.stale_requeue_priority`
  accepts `"preserve"`, an integer ceiling clamp, or a callable. The default
  stays the historical clamp to `4`.
- **The changelog now covers the worker lifecycle controls that already
  shipped** — shutdown requeue, per-queue concurrency caps, durable running
  cancellation, the cancellation facade, and the fair `queued_at` claim
  ordering, which is a behavior change existing deployments should know about.

## How you use it

```python
QueueConfig(
    worker=WorkerConfig(
        requeue_on_shutdown=True,   # return in-flight work to pending on SIGTERM
        max_interruptions=3,        # then let the retry policy take over
        hard_exit_timeout=10.0,     # never leave a hung pod behind
        stale_after=120,            # let the sweep reclaim abandoned work
    ),
    stale_requeue_priority="preserve",  # or 4 (default), or lambda p: p - 1
)
```

The escalation ladder is: first signal drains, second signal cancels and arms
the watchdog, and the deadline or a third signal exits with `128 + signum`.
