### PR TITLE
feat(events): public actor attachment and backend-neutral extra= query filtering (#125)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,25 @@ Notable changes to Litestar Queues are recorded here. Entries focus on
 user-visible behavior, public API changes, and important operational fixes. The
 project is pre-1.0, so minor releases may make intentional API breaks.
 
+Unreleased
+==========
+
+**Added:**
+
+* Universal actor attachment and lifecycle propagation: ``@task(actor=...)``
+  accepts a literal ``QueueEventActor`` or zero-argument resolver,
+  ``TaskExecutionContext.actor`` provides attempt-scoped defaults, and
+  ``publish()``, ``progress()``, ``log()``, ``event()``, and module helpers
+  accept per-call ``actor=`` overrides. Worker lifecycle events automatically inherit
+  the context actor.
+* Backend-neutral event history ``extra=`` query surface: ``extra=`` is promoted
+  to the :class:`~litestar_queues.events.QueueEventLog` protocol and supported across
+  all six backends (Memory, Ephemeral, Redis, Valkey, Advanced Alchemy, SQLSpec).
+  **Breaking:** ``EventHistoryExtraColumn`` and ``validate_event_history_extra_columns``
+  are moved from ``litestar_queues.backends.sqlspec`` to ``litestar_queues.events``,
+  and extra columns are declared on :class:`~litestar_queues.events.EventHistoryConfig`
+  via ``extra_columns``. Querying undeclared extra keys raises ``QueueConfigurationError``.
+
 0.9.0 - 2026-08-14
 ==================
 
@@ -23,19 +42,6 @@ project is pre-1.0, so minor releases may make intentional API breaks.
   :func:`~litestar_queues.events.bind_beat_sink` are public, so the module-level
   publish helpers resolve against a context that external code binds. See
   :doc:`usage/events-standalone`.
-* Universal actor attachment and lifecycle propagation: ``@task(actor=...)``
-  accepts a literal ``QueueEventActor`` or zero-argument resolver,
-  ``TaskExecutionContext.actor`` provides attempt-scoped defaults, and
-  ``publish()``, ``progress()``, ``log()``, ``event()``, and module helpers
-  accept per-call ``actor=`` overrides. Worker lifecycle events automatically inherit
-  the context actor.
-* Backend-neutral event history ``extra=`` query surface: ``extra=`` is promoted
-  to the :class:`~litestar_queues.events.QueueEventLog` protocol and supported across
-  all six backends (Memory, Ephemeral, Redis, Valkey, Advanced Alchemy, SQLSpec).
-  **Breaking:** ``EventHistoryExtraColumn`` and ``validate_event_history_extra_columns``
-  are moved from ``litestar_queues.backends.sqlspec`` to ``litestar_queues.events``,
-  and extra columns are declared on :class:`~litestar_queues.events.EventHistoryConfig`
-  via ``extra_columns``. Querying undeclared extra keys raises ``QueueConfigurationError``.
 * The SQLSpec event-history table accepts adopter-defined columns for scoping
   dimensions the queue does not model, such as a tenant or project id, with
   matching filters on ``list_events()``. See :doc:`usage/event-history-extending`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,19 @@ project is pre-1.0, so minor releases may make intentional API breaks.
   :func:`~litestar_queues.events.bind_beat_sink` are public, so the module-level
   publish helpers resolve against a context that external code binds. See
   :doc:`usage/events-standalone`.
+* Universal actor attachment and lifecycle propagation: ``@task(actor=...)``
+  accepts a literal ``QueueEventActor`` or zero-argument resolver,
+  ``TaskExecutionContext.actor`` provides attempt-scoped defaults, and
+  ``publish()``, ``progress()``, ``log()``, ``event()``, and module helpers
+  accept per-call ``actor=`` overrides. Worker lifecycle events automatically inherit
+  the context actor.
+* Backend-neutral event history ``extra=`` query surface: ``extra=`` is promoted
+  to the :class:`~litestar_queues.events.QueueEventLog` protocol and supported across
+  all six backends (Memory, Ephemeral, Redis, Valkey, Advanced Alchemy, SQLSpec).
+  **Breaking:** ``EventHistoryExtraColumn`` and ``validate_event_history_extra_columns``
+  are moved from ``litestar_queues.backends.sqlspec`` to ``litestar_queues.events``,
+  and extra columns are declared on :class:`~litestar_queues.events.EventHistoryConfig`
+  via ``extra_columns``. Querying undeclared extra keys raises ``QueueConfigurationError``.
 * The SQLSpec event-history table accepts adopter-defined columns for scoping
   dimensions the queue does not model, such as a tenant or project id, with
   matching filters on ``list_events()``. See :doc:`usage/event-history-extending`.

--- a/docs/usage/event-history-extending.rst
+++ b/docs/usage/event-history-extending.rst
@@ -15,27 +15,25 @@ text columns. Implementing :class:`~litestar_queues.events.QueueEventLog`
 replaces the store entirely and gives you your own schema, indexes, and query
 surface.
 
-Declaring extra columns on the built-in SQLSpec store
-=====================================================
+Declaring extra columns on event history
+=========================================
 
-If you want to keep the built-in SQLSpec store and only need indexed,
-filterable columns, declare them on the backend config:
+If you need indexed, filterable columns across any backend, declare them on
+``EventHistoryConfig``:
 
 .. code-block:: python
 
-   from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig
+   from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn
 
-   backend_config = SQLSpecBackendConfig(
-       sqlspec_config=sqlspec_config,
-       event_history_extra_columns=(
+   history_config = EventHistoryConfig(
+       extra_columns=(
            EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),
        ),
    )
 
-``sqlspec_config`` is the SQLSpec database config for your own database; see
-:doc:`backends/sqlspec` for how to build one.
+``indexed`` is a SQL physical index hint; non-SQL backends safely ignore it.
 
-Each declaration adds one column to the event-history table. ``source`` is the
+Each declaration adds one column or extra mapping to event history. ``source`` is the
 key read from the event payload, so publishing carries the value automatically
 from inside a task body:
 
@@ -49,8 +47,7 @@ from inside a task body:
    async def import_catalog(tenant_id: str) -> None:
        await publish_task_log("importing", payload={"tenant_id": tenant_id})
 
-Query it with the additive ``extra`` filter on the SQLSpec event log. This
-continues from the ``backend_config`` declared above:
+Query it with the additive ``extra`` filter on any event log implementation:
 
 .. code-block:: python
 
@@ -60,8 +57,7 @@ continues from the ``backend_config`` declared above:
 
    async def tenant_history(tenant_id: str) -> None:
        queue_config = QueueConfig(
-           queue_backend=backend_config,
-           events=QueueEventsConfig(history=EventHistoryConfig()),
+           events=QueueEventsConfig(history=history_config),
        )
        async with QueueService(queue_config) as service:
            event_log = service.get_event_log()
@@ -73,8 +69,8 @@ continues from the ``backend_config`` declared above:
 
 ``extra`` uses equality and is ANDed with the built-in ``task_id``,
 ``task_name``, ``actor_id``, and ``actor_type`` filters. An undeclared key
-raises ``ValueError`` naming the declared columns, so the filter never reaches
-SQL unvalidated.
+raises ``QueueConfigurationError`` naming the declared columns, so the filter never reaches
+persistence unvalidated.
 
 A declared name must be a valid unquoted SQL identifier and must not collide
 with a column the package already owns — including ``actor_type`` and
@@ -91,10 +87,8 @@ Three things to know:
 * Values are stored as text and read from the event payload. They stay in
   ``detail`` too — the column is an indexable, filterable copy, and ``detail``
   remains the complete record.
-* The ``extra`` filter lives on the concrete SQLSpec event log, not on the
-  :class:`~litestar_queues.events.QueueEventLog` protocol. ``get_event_log()``
-  is annotated with the protocol, so a type checker needs a ``cast`` to the
-  concrete SQLSpec store before it accepts the keyword.
+* The ``extra`` filter lives directly on the :class:`~litestar_queues.events.QueueEventLog`
+  protocol and is supported by all backends.
 * ``summarize_stages`` does not accept the filter. Scoped aggregates are a
   reason to implement the protocol instead.
 

--- a/docs/usage/events-standalone.rst
+++ b/docs/usage/events-standalone.rst
@@ -83,6 +83,45 @@ last-value-wins diagnostic detail. Implement
    with bind_task_context(context), bind_beat_sink(beats):
        context.beat("row 30000")
 
+Actor attachment
+================
+
+Attach a :class:`~litestar_queues.events.QueueEventActor` to identify who or what
+triggered the work. The actor persists to durable event history and is queryable
+via ``list_events(actor_id=...)`` or ``list_events(actor_type=...)``.
+
+There are three ways to attach an actor, evaluated in precedence order:
+
+1. **Per-call override:** Pass ``actor=QueueEventActor(...)`` directly to
+   ``ctx.publish()``, ``ctx.progress()``, ``ctx.log()``, ``ctx.event()``, or module helpers like
+   ``publish_task_log(..., actor=...)``.
+2. **Context actor:** Set ``context.actor = QueueEventActor(...)`` on the active
+   :class:`~litestar_queues.events.TaskExecutionContext`. All events published under the context
+   inherit this actor unless overridden per-call.
+3. **Decorator declaration:** When using queue tasks, declare ``@task(actor=...)`` with a
+   literal :class:`~litestar_queues.events.QueueEventActor` or zero-arg callable resolver.
+
+.. code-block:: python
+
+   from litestar_queues.events import (
+       QueueEventActor,
+       publish_task_log,
+       publish_task_progress,
+   )
+
+   # Explicit context actor
+   context.actor = QueueEventActor(type="service", id="cron-sync")
+
+   # Inherits context actor ("service", "cron-sync")
+   await publish_task_log("Starting sync")
+
+   # Per-call override for a specific sub-action
+   await publish_task_progress(
+       current=10,
+       total=100,
+       actor=QueueEventActor(type="user", id="usr_123"),
+   )
+
 Cancellation
 ============
 

--- a/src/litestar_queues/backends/advanced_alchemy/event_log.py
+++ b/src/litestar_queues/backends/advanced_alchemy/event_log.py
@@ -6,9 +6,10 @@ import time
 from typing import TYPE_CHECKING
 
 from litestar_queues.events._log_records import event_log_record_from_event
+from litestar_queues.events.history import validate_event_extra_filter
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from contextlib import AbstractAsyncContextManager
     from datetime import datetime
 
@@ -35,8 +36,8 @@ class AdvancedAlchemyQueueEventLog:
 
     def __init__(
         self,
-        *,
         config: "EventHistoryConfig",
+        *,
         service_factory: 'Callable[[], AbstractAsyncContextManager["QueueEventLogService"]]',
         transaction_factory: 'Callable[[], AbstractAsyncContextManager["QueueEventLogService"]]',
         runtime_logger: "logging.Logger | None" = None,
@@ -53,7 +54,7 @@ class AdvancedAlchemyQueueEventLog:
         """Buffer a queue event and flush when configured thresholds are reached."""
         should_flush = False
         async with self._flush_lock:
-            self._pending.append(event_log_record_from_event(event))
+            self._pending.append(event_log_record_from_event(event, extra_columns=self._config.extra_columns))
             should_flush = len(self._pending) >= max(1, self._config.batch_size) or self._flush_interval_elapsed()
         if should_flush:
             await self.flush_events()
@@ -82,13 +83,20 @@ class AdvancedAlchemyQueueEventLog:
         task_name: "str | None" = None,
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
+        extra: "Mapping[str, str] | None" = None,
         limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return durable event history records."""
+        resolved_extra = validate_event_extra_filter(extra, self._config.extra_columns)
         await self.flush_events()
         async with self._service_factory() as service:
             return await service.list_events(
-                task_id=task_id, task_name=task_name, actor_id=actor_id, actor_type=actor_type, limit=limit
+                task_id=task_id,
+                task_name=task_name,
+                actor_id=actor_id,
+                actor_type=actor_type,
+                extra=resolved_extra,
+                limit=limit,
             )
 
     async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -82,6 +82,7 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
         task_name: "str | None" = None,
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
+        extra: "Mapping[str, str] | None" = None,
         limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return matching event-history records in ascending event order."""
@@ -99,10 +100,13 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
         if criteria:
             statement = statement.where(*criteria)
         statement = statement.order_by(model_type.occurred_at, model_type.sequence, model_type.event_id)
-        if limit is not None:
+        if limit is not None and not extra:
             statement = statement.limit(limit)
         models = await self.get_many(statement=statement)
-        return [self.record_from_model(model) for model in models]
+        records = [self.record_from_model(model) for model in models]
+        if extra:
+            records = [record for record in records if all(record.extra.get(k) == v for k, v in extra.items())]
+        return records[:limit] if limit is not None else records
 
     async def cleanup_before(self, before: "datetime", *, limit: "int | None" = None) -> "int":
         """Delete event-history records older than ``before``.
@@ -114,21 +118,21 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
             Number of deleted event-history rows.
         """
         model_type = self.model_type
-        if limit is None:
-            result = await self.repository.session.execute(delete(model_type).where(model_type.occurred_at < before))
-            return int(result.rowcount or 0)
-        id_statement = (
-            select(model_type.id)
-            .where(model_type.occurred_at < before)
-            .order_by(model_type.occurred_at, model_type.id)
-            .limit(limit)
-        )
-        ids = (await self.repository.session.execute(id_statement)).scalars().all()
-        if not ids:
-            return 0
-        result = await self.repository.session.execute(
-            delete(model_type).where(model_type.id.in_(ids)).execution_options(synchronize_session=False)
-        )
+        if limit is not None:
+            bounded_query = (
+                select(model_type.event_id)
+                .where(model_type.occurred_at < before)
+                .order_by(model_type.occurred_at, model_type.sequence, model_type.event_id)
+                .limit(limit)
+            )
+            oldest_rows = await self.get_many(statement=bounded_query)
+            target_ids = [row.event_id if hasattr(row, "event_id") else row[0] for row in oldest_rows]
+            if not target_ids:
+                return 0
+            statement = delete(model_type).where(model_type.event_id.in_(target_ids))
+        else:
+            statement = delete(model_type).where(model_type.occurred_at < before)
+        result = await self.repository.session.execute(statement)
         return int(result.rowcount or 0)
 
     def model_from_record(self, record: "QueueEventLogRecord") -> "Any":
@@ -137,6 +141,9 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
         Returns:
             Advanced Alchemy event-history model.
         """
+        detail = dict(record.detail)
+        if record.extra:
+            detail["__extra__"] = record.extra
         return self.model_type(
             event_id=record.event_id,
             event_type=record.event_type,
@@ -150,7 +157,7 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
             actor_id=record.actor_id,
             level=record.level,
             message=record.message,
-            detail_json=_serialize_json(record.detail),
+            detail_json=_serialize_json(detail),
             progress_current=record.progress_current,
             progress_total=record.progress_total,
             progress_percent=record.progress_percent,
@@ -169,6 +176,7 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
         detail = _deserialize_json(model.detail_json)
         if not isinstance(detail, dict):
             detail = {}
+        extra = dict(detail.pop("__extra__", None) or {})
         return QueueEventLogRecord(
             event_id=str(model.event_id),
             event_type=str(model.event_type),
@@ -191,6 +199,7 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
             sequence=int(model.sequence) if model.sequence is not None else None,
             occurred_at=cast("datetime", _coerce_datetime(model.occurred_at)),
             created_at=cast("datetime", _coerce_datetime(model.created_at)),
+            extra=extra,
         )
 
 

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -125,8 +125,8 @@ class QueueEventLogService(SQLAlchemyAsyncRepositoryService[Any]):
                 .order_by(model_type.occurred_at, model_type.sequence, model_type.event_id)
                 .limit(limit)
             )
-            oldest_rows = await self.get_many(statement=bounded_query)
-            target_ids = [row.event_id if hasattr(row, "event_id") else row[0] for row in oldest_rows]
+            raw_result = await self.repository.session.execute(bounded_query)
+            target_ids = list(raw_result.scalars().all())
             if not target_ids:
                 return 0
             statement = delete(model_type).where(model_type.event_id.in_(target_ids))

--- a/src/litestar_queues/backends/ephemeral/codec.py
+++ b/src/litestar_queues/backends/ephemeral/codec.py
@@ -90,6 +90,7 @@ _EVENT_FIELDS = (
     "sequence",
     "occurred_at",
     "created_at",
+    "extra",
 )
 
 

--- a/src/litestar_queues/backends/ephemeral/event_log.py
+++ b/src/litestar_queues/backends/ephemeral/event_log.py
@@ -4,9 +4,11 @@ from typing import TYPE_CHECKING, Any
 
 from litestar_queues.backends.ephemeral.codec import event_from_payload, event_to_payload
 from litestar_queues.events._log_records import event_log_record_from_event, event_log_record_sort_key
+from litestar_queues.events.history import validate_event_extra_filter
 
 if TYPE_CHECKING:
     import sqlite3
+    from collections.abc import Mapping
     from datetime import datetime
 
     from litestar_queues.backends.ephemeral.backend import EphemeralQueueBackend
@@ -30,7 +32,7 @@ class EphemeralQueueEventLog:
 
     async def publish_event(self, event: "QueueEvent") -> "None":
         """Append an event record and prune the oldest rows beyond capacity."""
-        record = event_log_record_from_event(event)
+        record = event_log_record_from_event(event, extra_columns=self._config.extra_columns)
         capacity = self._config.memory_capacity
 
         def operation(connection: "sqlite3.Connection") -> "None":
@@ -71,6 +73,7 @@ class EphemeralQueueEventLog:
         task_name: "str | None" = None,
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
+        extra: "Mapping[str, str] | None" = None,
         limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return matching event records in ascending event order.
@@ -78,6 +81,7 @@ class EphemeralQueueEventLog:
         Returns:
             The matching event history records.
         """
+        resolved_extra = validate_event_extra_filter(extra, self._config.extra_columns)
 
         def operation(connection: "sqlite3.Connection") -> "list[QueueEventLogRecord]":
             sql = "SELECT payload FROM queue_event WHERE 1 = 1"
@@ -98,6 +102,8 @@ class EphemeralQueueEventLog:
             records = [record for record in records if record.actor_id == actor_id]
         if actor_type is not None:
             records = [record for record in records if record.actor_type == actor_type]
+        if resolved_extra:
+            records = [record for record in records if all(record.extra.get(k) == v for k, v in resolved_extra.items())]
         records.sort(key=event_log_record_sort_key)
         return records[:limit] if limit is not None else records
 

--- a/src/litestar_queues/backends/memory/event_log.py
+++ b/src/litestar_queues/backends/memory/event_log.py
@@ -4,8 +4,10 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from litestar_queues.events._log_records import event_log_record_from_event, event_log_record_sort_key
+from litestar_queues.events.history import validate_event_extra_filter
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from datetime import datetime
 
     from litestar_queues.events import EventHistoryConfig, QueueEvent, QueueEventLogRecord, QueueEventStageSummary
@@ -25,7 +27,7 @@ class InMemoryQueueEventLog:
 
     async def publish_event(self, event: "QueueEvent") -> "None":
         """Append an event history record and prune the oldest records."""
-        record = event_log_record_from_event(event)
+        record = event_log_record_from_event(event, extra_columns=self._config.extra_columns)
         async with self._lock:
             self._records.append(record)
             overflow = len(self._records) - self._config.memory_capacity
@@ -45,9 +47,11 @@ class InMemoryQueueEventLog:
         task_name: "str | None" = None,
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
+        extra: "Mapping[str, str] | None" = None,
         limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return matching event history records in ascending event order."""
+        resolved_extra = validate_event_extra_filter(extra, self._config.extra_columns)
         async with self._lock:
             records = [
                 record
@@ -56,6 +60,7 @@ class InMemoryQueueEventLog:
                 and (task_name is None or record.task_name == task_name)
                 and (actor_id is None or record.actor_id == actor_id)
                 and (actor_type is None or record.actor_type == actor_type)
+                and (not resolved_extra or all(record.extra.get(k) == v for k, v in resolved_extra.items()))
             ]
         records.sort(key=event_log_record_sort_key)
         return records[:limit] if limit is not None else records

--- a/src/litestar_queues/backends/redis/event_log.py
+++ b/src/litestar_queues/backends/redis/event_log.py
@@ -24,7 +24,8 @@ from litestar_queues.events.history import QueueEventLogRecord, validate_event_e
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from litestar_queues.backends.redis.backend import ClientLike, PipelineLike, RedisQueueBackend
+    from litestar_queues.backends._protocol import ClientLike, PipelineLike
+    from litestar_queues.backends.redis.backend import RedisQueueBackend
     from litestar_queues.events import EventHistoryConfig, QueueEvent, QueueEventStageSummary
 
 __all__ = ("RedisQueueEventLog",)

--- a/src/litestar_queues/backends/redis/event_log.py
+++ b/src/litestar_queues/backends/redis/event_log.py
@@ -19,11 +19,12 @@ from litestar_queues.events._log_records import (
     optional_str,
     parse_datetime,
 )
-from litestar_queues.events.history import QueueEventLogRecord
+from litestar_queues.events.history import QueueEventLogRecord, validate_event_extra_filter
 
 if TYPE_CHECKING:
-    from litestar_queues.backends._protocol import ClientLike, PipelineLike
-    from litestar_queues.backends.redis.backend import RedisQueueBackend
+    from collections.abc import Mapping
+
+    from litestar_queues.backends.redis.backend import ClientLike, PipelineLike, RedisQueueBackend
     from litestar_queues.events import EventHistoryConfig, QueueEvent, QueueEventStageSummary
 
 __all__ = ("RedisQueueEventLog",)
@@ -48,7 +49,9 @@ class RedisQueueEventLog:
         """Buffer a queue event and flush when configured thresholds are reached."""
         should_flush = False
         async with self._flush_lock:
-            self._pending.append(self._mapping_from_record(event_log_record_from_event(event)))
+            self._pending.append(
+                self._mapping_from_record(event_log_record_from_event(event, extra_columns=self._config.extra_columns))
+            )
             should_flush = len(self._pending) >= max(1, self._config.batch_size) or self._flush_interval_elapsed()
         if should_flush:
             await self.flush_events()
@@ -77,9 +80,11 @@ class RedisQueueEventLog:
         task_name: "str | None" = None,
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
+        extra: "Mapping[str, str] | None" = None,
         limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return durable event history records."""
+        resolved_extra = validate_event_extra_filter(extra, self._config.extra_columns)
         await self.flush_events()
         client = await self._backend._get_client()
         index_key = self._select_index_key(task_id=task_id, task_name=task_name)
@@ -92,6 +97,7 @@ class RedisQueueEventLog:
             and (task_name is None or record.task_name == task_name)
             and (actor_id is None or record.actor_id == actor_id)
             and (actor_type is None or record.actor_type == actor_type)
+            and (not resolved_extra or all(record.extra.get(k) == v for k, v in resolved_extra.items()))
         ]
         records.sort(key=event_log_record_sort_key)
         return records[:limit] if limit is not None else records
@@ -178,7 +184,7 @@ class RedisQueueEventLog:
             index_keys.append(self._backend._event_log_task_key(record.task_id))
         if record.task_name is not None:
             index_keys.append(self._backend._event_log_task_name_key(record.task_name))
-        return {
+        result_mapping = {
             "event_id": record.event_id,
             "event_type": record.event_type,
             "task_id": record.task_id or "",
@@ -200,6 +206,9 @@ class RedisQueueEventLog:
             "created_at": _serialize_datetime(record.created_at),
             "index_keys": _json_dumps(index_keys),
         }
+        for extra_key, extra_val in record.extra.items():
+            result_mapping[f"extra:{extra_key}"] = str(extra_val)
+        return result_mapping
 
     async def _records_from_ids(self, client: "ClientLike", event_ids: "list[Any]") -> "list[QueueEventLogRecord]":
         return [
@@ -232,6 +241,7 @@ def _record_from_mapping(mapping: "dict[str, Any]") -> "QueueEventLogRecord":
     detail = _json_loads(mapping.get("detail"), {})
     if not isinstance(detail, dict):
         detail = {}
+    extra = {key[6:]: str(val) for key, val in mapping.items() if key.startswith("extra:")}
     return QueueEventLogRecord(
         event_id=str(mapping["event_id"]),
         event_type=str(mapping["event_type"]),
@@ -254,6 +264,7 @@ def _record_from_mapping(mapping: "dict[str, Any]") -> "QueueEventLogRecord":
         sequence=optional_int(mapping.get("sequence") or None),
         occurred_at=parse_datetime(mapping["occurred_at"]),
         created_at=parse_datetime(mapping["created_at"]),
+        extra=extra,
     )
 
 

--- a/src/litestar_queues/backends/sqlspec/__init__.py
+++ b/src/litestar_queues/backends/sqlspec/__init__.py
@@ -3,10 +3,8 @@
 from litestar_queues.backends.sqlspec.backend import SQLSpecQueueBackend
 from litestar_queues.backends.sqlspec.config import SQLSpecBackendConfig, SQLSpecWorkerWakeupConfig
 from litestar_queues.backends.sqlspec.extension import configure_queue_migration_extension
-from litestar_queues.backends.sqlspec.schema import EventHistoryExtraColumn
 
 __all__ = (
-    "EventHistoryExtraColumn",
     "SQLSpecBackendConfig",
     "SQLSpecQueueBackend",
     "SQLSpecWorkerWakeupConfig",

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     from litestar_queues.backends.sqlspec.reservation import SQLSpecTaskReservationStore
     from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore
     from litestar_queues.config import QueueConfig
-    from litestar_queues.events import EventHistoryConfig, QueueEventLog
+    from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEventLog
     from litestar_queues.models import HeartbeatTouch
 
 __all__ = ("SQLSpecQueueBackend",)
@@ -268,12 +268,14 @@ class SQLSpecQueueBackend(BaseQueueBackend):
 
     def get_event_log(self, config: "EventHistoryConfig") -> "QueueEventLog | None":
         """Return SQLSpec-managed durable queue event history when enabled."""
-        if self._event_log is None:
+        if self._event_log is None or (
+            config.extra_columns and getattr(self._event_log, "extra_columns", ()) != config.extra_columns
+        ):
             self._event_log = SQLSpecQueueEventLog(
                 session_factory=self._session,
                 datetime_serializer=self._serialize_datetime,
                 config=config,
-                store=self._get_event_log_store(),
+                store=self._get_event_log_store(extra_columns=config.extra_columns),
                 runtime_logger=self._logger,
             )
         return self._event_log
@@ -2119,14 +2121,17 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             )
         return self._store
 
-    def _get_event_log_store(self) -> "Any":
-        if self._event_log_store is None:
+    def _get_event_log_store(self, extra_columns: "Sequence[EventHistoryExtraColumn] | None" = None) -> "Any":
+        effective_columns = tuple(extra_columns) if extra_columns is not None else self._event_history_extra_columns
+        if self._event_log_store is None or (
+            extra_columns is not None and getattr(self._event_log_store, "extra_columns", ()) != effective_columns
+        ):
             store = create_event_log_store(
                 self._get_sqlspec_config(),
                 queue_table_name=self._resolve_queue_table_name(),
                 event_history_table_name=self._event_history_table_name,
                 manage_schema=self._manage_schema,
-                extra_columns=self._event_history_extra_columns,
+                extra_columns=effective_columns,
             )
             self._event_history_table_name = store.table_name
             self._event_log_store = store

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -42,11 +42,11 @@ from litestar_queues.backends.sqlspec.reservation import create_task_reservation
 from litestar_queues.backends.sqlspec.schema import (
     DEFAULT_TABLE_NAME,
     resolve_column_map,
-    validate_event_history_extra_columns,
     validate_native_json_columns,
     validate_table_name,
 )
 from litestar_queues.backends.sqlspec.stores.factory import create_queue_store
+from litestar_queues.events import validate_event_history_extra_columns
 from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.models import (
     HeartbeatTouchResult,

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -3,179 +3,113 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from litestar_queues.backends.sqlspec.schema import (
-    EventHistoryExtraColumn,
-    resolve_column_map,
-    validate_event_history_extra_columns,
-    validate_native_json_columns,
-    validate_table_name,
-)
-from litestar_queues.exceptions import QueueConfigurationError
+from litestar_queues.backends.sqlspec.schema import resolve_column_map, validate_table_name
+from litestar_queues.events import EventHistoryExtraColumn, validate_event_history_extra_columns
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from sqlspec import SQLSpec
-    from sqlspec.extensions.events import AsyncEventChannel
 
     from litestar_queues.backends.sqlspec._typing import SQLSpecConfig, SQLSpecStoreConfig
     from litestar_queues.config import QueueConfig
 
 __all__ = (
     "DEFAULT_CONTROL_CHANNEL",
+    "DEFAULT_EVENT_HISTORY_TABLE_SUFFIX",
+    "DEFAULT_MAINTENANCE_TABLE_SUFFIX",
+    "DEFAULT_TABLE_NAME",
+    "DEFAULT_TASK_RESERVATION_TABLE_SUFFIX",
     "DEFAULT_WAKEUP_CHANNEL",
-    "WAKEUP_TRANSPORTS",
     "SQLSpecBackendConfig",
     "SQLSpecWorkerWakeupConfig",
 )
 
-DEFAULT_WAKEUP_CHANNEL = "litestar_queues_tasks"
-
-DEFAULT_CONTROL_CHANNEL = "litestar_queues_worker_control"
-
-WAKEUP_TRANSPORTS: "frozenset[str]" = frozenset({"aq", "notify", "notify_queue", "poll_queue", "polling", "txeventq"})
-"""Valid worker-wakeup transports for :attr:`SQLSpecWorkerWakeupConfig.transport`.
-
-``notify`` uses native push wakeups, ``notify_queue`` uses native push wakeups
-with a durable queue fallback, ``poll_queue`` uses the durable events table,
-``aq`` and ``txeventq`` use Oracle Advanced Queuing backends, and ``polling``
-disables push wakeups so workers fall back to interval polling.
-"""
+DEFAULT_TABLE_NAME = "queue_task"
+DEFAULT_EVENT_HISTORY_TABLE_SUFFIX = "_event_history"
+DEFAULT_MAINTENANCE_TABLE_SUFFIX = "_maintenance"
+DEFAULT_TASK_RESERVATION_TABLE_SUFFIX = "_reservation"
+DEFAULT_WAKEUP_CHANNEL = "litestar_queues_wakeups"
+DEFAULT_CONTROL_CHANNEL = "litestar_queues_control"
 
 
-@dataclass(slots=True)
+@dataclass
 class SQLSpecWorkerWakeupConfig:
-    """SQLSpec worker-wakeup channel and transport configuration."""
+    """Configuration for push-based worker wakeup notifications."""
 
-    channel: "AsyncEventChannel | None" = None
-    """Explicit SQLSpec event channel; ``None`` constructs one from configuration."""
+    enabled: "bool" = True
+    """Whether push notifications wake idle workers immediately."""
 
-    transport: "str | None" = None
-    """Explicit wakeup transport; ``None`` selects the adapter capability."""
-
-    channel_name: "str | None" = None
-    """Logical worker-wakeup channel name; ``None`` uses the package default."""
-
-    queue_table_name: "str | None" = None
-    """Durable SQLSpec event-queue table; ``None`` derives it from the adapter."""
-
-    poll_interval: "float | None" = None
-    """SQLSpec event-store poll interval in seconds; ``None`` uses SQLSpec defaults."""
-
-    settings: "dict[str, Any]" = field(default_factory=dict)
-    """Additional SQLSpec events-extension settings."""
-
-    def __post_init__(self) -> "None":
-        """Validate wakeup transport, table name, and poll interval."""
-        if self.transport is not None and self.transport not in WAKEUP_TRANSPORTS:
-            valid = ", ".join(sorted(WAKEUP_TRANSPORTS))
-            msg = f"Invalid SQLSpec worker wakeup transport {self.transport!r}; expected one of: {valid}."
-            raise QueueConfigurationError(msg)
-        if self.queue_table_name is not None:
-            self.queue_table_name = validate_table_name(self.queue_table_name)
-        if self.poll_interval is not None and self.poll_interval <= 0:
-            msg = "SQLSpecWorkerWakeupConfig.poll_interval must be greater than 0."
-            raise QueueConfigurationError(msg)
+    channel_name: "str" = DEFAULT_WAKEUP_CHANNEL
+    """Event channel used for worker wakeup broadcasts."""
 
 
-@dataclass(slots=True)
+@dataclass
 class SQLSpecBackendConfig:
-    """Configuration values for the SQLSpec queue backend."""
+    """Configuration for the SQLSpec queue backend."""
 
-    backend_name: "ClassVar[str]" = "sqlspec"
+    is_async: "ClassVar[bool]" = True
+    """Backend execution mode."""
+
     sqlspec: "SQLSpec | None" = None
-    """Injected SQLSpec manager; ``None`` creates a manager owned by the queue backend."""
+    """Dedicated SQLSpec client instance for queue storage."""
 
-    sqlspec_config: "SQLSpecStoreConfig | None" = None
-    """SQLSpec adapter configuration used for queue operations; ``None`` resolves or creates one."""
+    config_name: "str | None" = None
+    """Named database configuration from the application SQLSpec plugin."""
 
-    heartbeat_pool_config: "SQLSpecStoreConfig | None" = None
-    """Dedicated heartbeat adapter configuration; ``None`` reuses normal queue operations."""
-
-    queue_table_name: "str | None" = None
-    """Queue-task table name; ``None`` uses ``queue_task`` or SQLSpec extension settings."""
-
-    worker_wakeups: "SQLSpecWorkerWakeupConfig | None" = field(default_factory=SQLSpecWorkerWakeupConfig)
-    """Worker wakeup transport configuration; ``None`` disables wakeups."""
+    table_name: "str" = DEFAULT_TABLE_NAME
+    """Base table name for queue tasks."""
 
     event_history_table_name: "str | None" = None
-    """Task-event history table name; ``None`` derives it from the queue-task table."""
+    """Table name for queue event history records."""
 
-    event_history_extra_columns: "tuple[EventHistoryExtraColumn, ...]" = ()
-    """Adopter-declared extra scoping columns on the event-history table."""
+    event_history_extra_columns: "tuple[EventHistoryExtraColumn, ...]" = field(default_factory=tuple)
+    """Adopter-declared scoping columns on the event-history table."""
 
     maintenance_table_name: "str | None" = None
-    """Maintenance coordination table name; ``None`` derives the package default."""
+    """Table name for distributed queue maintenance metadata."""
 
     task_reservation_table_name: "str | None" = None
-    """Permanent task-reservation table name; ``None`` derives it from the queue-task table."""
+    """Table name for forever-uniqueness task reservations."""
 
-    column_map: "Mapping[str, str]" = field(default_factory=dict)
-    """Overrides mapping logical queue fields to adopter-owned database columns."""
+    column_map: "Mapping[str, str] | None" = None
+    """Mapping of canonical column names to custom database column names."""
 
-    native_json_columns: "frozenset[str]" = field(default_factory=frozenset)
-    """Logical queue fields stored in database-native JSON columns."""
+    store_config: "SQLSpecStoreConfig | None" = None
+    """Driver-specific configuration overrides for the queue store."""
 
-    manage_schema: "bool" = True
-    """Whether backend startup and migrations may create package-owned queue tables."""
+    event_log_store_config: "SQLSpecStoreConfig | None" = None
+    """Driver-specific configuration overrides for the event log store."""
+
+    maintenance_store_config: "SQLSpecStoreConfig | None" = None
+    """Driver-specific configuration overrides for the maintenance store."""
+
+    task_reservation_store_config: "SQLSpecStoreConfig | None" = None
+    """Driver-specific configuration overrides for the task reservation store."""
+
+    worker_wakeups: "SQLSpecWorkerWakeupConfig" = field(default_factory=SQLSpecWorkerWakeupConfig)
+    """Configuration for push-based worker wakeup notifications."""
+
+    heartbeat_pool_config: "dict[str, Any] | None" = None
+    """Dedicated connection pool configuration for the worker heartbeat loop."""
 
     def __post_init__(self) -> "None":
-        """Validate adopter-owned table and wakeup-transport configuration."""
-        if self.queue_table_name is not None:
-            self.queue_table_name = validate_table_name(self.queue_table_name)
+        """Validate and normalize SQLSpec backend configuration."""
+        self.table_name = validate_table_name(self.table_name)
         if self.event_history_table_name is not None:
             self.event_history_table_name = validate_table_name(self.event_history_table_name)
         if self.maintenance_table_name is not None:
             self.maintenance_table_name = validate_table_name(self.maintenance_table_name)
         if self.task_reservation_table_name is not None:
             self.task_reservation_table_name = validate_table_name(self.task_reservation_table_name)
+        if self.column_map is not None:
+            self.column_map = resolve_column_map(self.column_map)
         self.event_history_extra_columns = validate_event_history_extra_columns(self.event_history_extra_columns)
-        self.column_map = resolve_column_map(self.column_map)
-        self.native_json_columns = validate_native_json_columns(frozenset(self.native_json_columns))
 
-    def configure_migrations(self, config: "QueueConfig") -> "None":
-        """Register the queue and durable-events migrations with the SQLSpec config.
-
-        Implements :class:`~litestar_queues.config.MigrationConfiguringBackend`, so
-        ``QueuePlugin`` reaches this without importing the SQLSpec backend.
-        """
-        from litestar_queues.backends.sqlspec.backend import resolve_events_migration_backend
-        from litestar_queues.backends.sqlspec.extension import (
-            configure_events_migration_extension,
-            configure_queue_migration_extension,
-        )
-        from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME
-
-        sqlspec_config = self.sqlspec_config
-        if sqlspec_config is None and self.sqlspec is not None:
-            registered_configs = tuple(self.sqlspec.configs.values())
-            if len(registered_configs) == 1:
-                sqlspec_config = registered_configs[0]
-        if sqlspec_config is None:
-            return
-
-        # Register the durable events queue migration first: a capability-native
-        # adapter (asyncpg/psycopg/psqlpy notify_queue, DuckDB poll_queue) needs
-        # its events table provisioned on migrate-up so zero-config native wakeups
-        # work on a fresh database.
-        events_backend = resolve_events_migration_backend(self, cast("SQLSpecConfig", sqlspec_config))
-        if events_backend is not None:
-            configure_events_migration_extension(
-                cast("SQLSpecConfig", sqlspec_config),
-                backend=events_backend,
-                queue_table=(self.worker_wakeups.queue_table_name if self.worker_wakeups is not None else None),
-            )
-
-        extension_config = sqlspec_config.extension_config or {}
-        queue_settings = dict(extension_config.get("litestar_queues", {}) or {})
-        queue_table_name = self.queue_table_name or queue_settings.get("table_name") or DEFAULT_TABLE_NAME
-        event_log_config = config.events.history if config.events is not None else None
-        configure_queue_migration_extension(
-            cast("SQLSpecConfig", sqlspec_config),
-            queue_table_name=str(queue_table_name),
-            event_history_enabled=event_log_config is not None,
-            event_history_table_name=self.event_history_table_name,
-            event_history_extra_columns=self.event_history_extra_columns,
-            maintenance_table_name=self.maintenance_table_name,
-            task_reservation_table_name=self.task_reservation_table_name,
-        )
+    def get_store_config(self, parent_config: "QueueConfig") -> "SQLSpecConfig":
+        """Resolve the effective SQLSpec configuration for the queue store."""
+        if self.sqlspec is not None:
+            return self.sqlspec.config
+        if self.config_name is not None:
+            return self.config_name
+        return cast("SQLSpecConfig", parent_config.signature_namespace.get("sqlspec_config"))

--- a/src/litestar_queues/backends/sqlspec/config.py
+++ b/src/litestar_queues/backends/sqlspec/config.py
@@ -3,113 +3,178 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from litestar_queues.backends.sqlspec.schema import resolve_column_map, validate_table_name
+from litestar_queues.backends.sqlspec.schema import (
+    resolve_column_map,
+    validate_native_json_columns,
+    validate_table_name,
+)
 from litestar_queues.events import EventHistoryExtraColumn, validate_event_history_extra_columns
+from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from sqlspec import SQLSpec
+    from sqlspec.extensions.events import AsyncEventChannel
 
     from litestar_queues.backends.sqlspec._typing import SQLSpecConfig, SQLSpecStoreConfig
     from litestar_queues.config import QueueConfig
 
 __all__ = (
     "DEFAULT_CONTROL_CHANNEL",
-    "DEFAULT_EVENT_HISTORY_TABLE_SUFFIX",
-    "DEFAULT_MAINTENANCE_TABLE_SUFFIX",
-    "DEFAULT_TABLE_NAME",
-    "DEFAULT_TASK_RESERVATION_TABLE_SUFFIX",
     "DEFAULT_WAKEUP_CHANNEL",
+    "WAKEUP_TRANSPORTS",
     "SQLSpecBackendConfig",
     "SQLSpecWorkerWakeupConfig",
 )
 
-DEFAULT_TABLE_NAME = "queue_task"
-DEFAULT_EVENT_HISTORY_TABLE_SUFFIX = "_event_history"
-DEFAULT_MAINTENANCE_TABLE_SUFFIX = "_maintenance"
-DEFAULT_TASK_RESERVATION_TABLE_SUFFIX = "_reservation"
-DEFAULT_WAKEUP_CHANNEL = "litestar_queues_wakeups"
-DEFAULT_CONTROL_CHANNEL = "litestar_queues_control"
+DEFAULT_WAKEUP_CHANNEL = "litestar_queues_tasks"
+
+DEFAULT_CONTROL_CHANNEL = "litestar_queues_worker_control"
+
+WAKEUP_TRANSPORTS: "frozenset[str]" = frozenset({"aq", "notify", "notify_queue", "poll_queue", "polling", "txeventq"})
+"""Valid worker-wakeup transports for :attr:`SQLSpecWorkerWakeupConfig.transport`.
+
+``notify`` uses native push wakeups, ``notify_queue`` uses native push wakeups
+with a durable queue fallback, ``poll_queue`` uses the durable events table,
+``aq`` and ``txeventq`` use Oracle Advanced Queuing backends, and ``polling``
+disables push wakeups so workers fall back to interval polling.
+"""
 
 
-@dataclass
+@dataclass(slots=True)
 class SQLSpecWorkerWakeupConfig:
-    """Configuration for push-based worker wakeup notifications."""
+    """SQLSpec worker-wakeup channel and transport configuration."""
 
-    enabled: "bool" = True
-    """Whether push notifications wake idle workers immediately."""
+    channel: "AsyncEventChannel | None" = None
+    """Explicit SQLSpec event channel; ``None`` constructs one from configuration."""
 
-    channel_name: "str" = DEFAULT_WAKEUP_CHANNEL
-    """Event channel used for worker wakeup broadcasts."""
+    transport: "str | None" = None
+    """Explicit wakeup transport; ``None`` selects the adapter capability."""
 
+    channel_name: "str | None" = None
+    """Logical worker-wakeup channel name; ``None`` uses the package default."""
 
-@dataclass
-class SQLSpecBackendConfig:
-    """Configuration for the SQLSpec queue backend."""
+    queue_table_name: "str | None" = None
+    """Durable SQLSpec event-queue table; ``None`` derives it from the adapter."""
 
-    is_async: "ClassVar[bool]" = True
-    """Backend execution mode."""
+    poll_interval: "float | None" = None
+    """SQLSpec event-store poll interval in seconds; ``None`` uses SQLSpec defaults."""
 
-    sqlspec: "SQLSpec | None" = None
-    """Dedicated SQLSpec client instance for queue storage."""
-
-    config_name: "str | None" = None
-    """Named database configuration from the application SQLSpec plugin."""
-
-    table_name: "str" = DEFAULT_TABLE_NAME
-    """Base table name for queue tasks."""
-
-    event_history_table_name: "str | None" = None
-    """Table name for queue event history records."""
-
-    event_history_extra_columns: "tuple[EventHistoryExtraColumn, ...]" = field(default_factory=tuple)
-    """Adopter-declared scoping columns on the event-history table."""
-
-    maintenance_table_name: "str | None" = None
-    """Table name for distributed queue maintenance metadata."""
-
-    task_reservation_table_name: "str | None" = None
-    """Table name for forever-uniqueness task reservations."""
-
-    column_map: "Mapping[str, str] | None" = None
-    """Mapping of canonical column names to custom database column names."""
-
-    store_config: "SQLSpecStoreConfig | None" = None
-    """Driver-specific configuration overrides for the queue store."""
-
-    event_log_store_config: "SQLSpecStoreConfig | None" = None
-    """Driver-specific configuration overrides for the event log store."""
-
-    maintenance_store_config: "SQLSpecStoreConfig | None" = None
-    """Driver-specific configuration overrides for the maintenance store."""
-
-    task_reservation_store_config: "SQLSpecStoreConfig | None" = None
-    """Driver-specific configuration overrides for the task reservation store."""
-
-    worker_wakeups: "SQLSpecWorkerWakeupConfig" = field(default_factory=SQLSpecWorkerWakeupConfig)
-    """Configuration for push-based worker wakeup notifications."""
-
-    heartbeat_pool_config: "dict[str, Any] | None" = None
-    """Dedicated connection pool configuration for the worker heartbeat loop."""
+    settings: "dict[str, Any]" = field(default_factory=dict)
+    """Additional SQLSpec events-extension settings."""
 
     def __post_init__(self) -> "None":
-        """Validate and normalize SQLSpec backend configuration."""
-        self.table_name = validate_table_name(self.table_name)
+        """Validate wakeup transport, table name, and poll interval."""
+        if self.transport is not None and self.transport not in WAKEUP_TRANSPORTS:
+            valid = ", ".join(sorted(WAKEUP_TRANSPORTS))
+            msg = f"Invalid SQLSpec worker wakeup transport {self.transport!r}; expected one of: {valid}."
+            raise QueueConfigurationError(msg)
+        if self.queue_table_name is not None:
+            self.queue_table_name = validate_table_name(self.queue_table_name)
+        if self.poll_interval is not None and self.poll_interval <= 0:
+            msg = "SQLSpecWorkerWakeupConfig.poll_interval must be greater than 0."
+            raise QueueConfigurationError(msg)
+
+
+@dataclass(slots=True)
+class SQLSpecBackendConfig:
+    """Configuration values for the SQLSpec queue backend."""
+
+    backend_name: "ClassVar[str]" = "sqlspec"
+    sqlspec: "SQLSpec | None" = None
+    """Injected SQLSpec manager; ``None`` creates a manager owned by the queue backend."""
+
+    sqlspec_config: "SQLSpecStoreConfig | None" = None
+    """SQLSpec adapter configuration used for queue operations; ``None`` resolves or creates one."""
+
+    heartbeat_pool_config: "SQLSpecStoreConfig | None" = None
+    """Dedicated heartbeat adapter configuration; ``None`` reuses normal queue operations."""
+
+    queue_table_name: "str | None" = None
+    """Queue-task table name; ``None`` uses ``queue_task`` or SQLSpec extension settings."""
+
+    worker_wakeups: "SQLSpecWorkerWakeupConfig | None" = field(default_factory=SQLSpecWorkerWakeupConfig)
+    """Worker wakeup transport configuration; ``None`` disables wakeups."""
+
+    event_history_table_name: "str | None" = None
+    """Task-event history table name; ``None`` derives it from the queue-task table."""
+
+    event_history_extra_columns: "tuple[EventHistoryExtraColumn, ...]" = ()
+    """Adopter-declared extra scoping columns on the event-history table."""
+
+    maintenance_table_name: "str | None" = None
+    """Maintenance coordination table name; ``None`` derives the package default."""
+
+    task_reservation_table_name: "str | None" = None
+    """Permanent task-reservation table name; ``None`` derives it from the queue-task table."""
+
+    column_map: "Mapping[str, str]" = field(default_factory=dict)
+    """Overrides mapping logical queue fields to adopter-owned database columns."""
+
+    native_json_columns: "frozenset[str]" = field(default_factory=frozenset)
+    """Logical queue fields stored in database-native JSON columns."""
+
+    manage_schema: "bool" = True
+    """Whether backend startup and migrations may create package-owned queue tables."""
+
+    def __post_init__(self) -> "None":
+        """Validate adopter-owned table and wakeup-transport configuration."""
+        if self.queue_table_name is not None:
+            self.queue_table_name = validate_table_name(self.queue_table_name)
         if self.event_history_table_name is not None:
             self.event_history_table_name = validate_table_name(self.event_history_table_name)
         if self.maintenance_table_name is not None:
             self.maintenance_table_name = validate_table_name(self.maintenance_table_name)
         if self.task_reservation_table_name is not None:
             self.task_reservation_table_name = validate_table_name(self.task_reservation_table_name)
-        if self.column_map is not None:
-            self.column_map = resolve_column_map(self.column_map)
         self.event_history_extra_columns = validate_event_history_extra_columns(self.event_history_extra_columns)
+        self.column_map = resolve_column_map(self.column_map)
+        self.native_json_columns = validate_native_json_columns(frozenset(self.native_json_columns))
 
-    def get_store_config(self, parent_config: "QueueConfig") -> "SQLSpecConfig":
-        """Resolve the effective SQLSpec configuration for the queue store."""
-        if self.sqlspec is not None:
-            return self.sqlspec.config
-        if self.config_name is not None:
-            return self.config_name
-        return cast("SQLSpecConfig", parent_config.signature_namespace.get("sqlspec_config"))
+    def configure_migrations(self, config: "QueueConfig") -> "None":
+        """Register the queue and durable-events migrations with the SQLSpec config.
+
+        Implements :class:`~litestar_queues.config.MigrationConfiguringBackend`, so
+        ``QueuePlugin`` reaches this without importing the SQLSpec backend.
+        """
+        from litestar_queues.backends.sqlspec.backend import resolve_events_migration_backend
+        from litestar_queues.backends.sqlspec.extension import (
+            configure_events_migration_extension,
+            configure_queue_migration_extension,
+        )
+        from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME
+
+        sqlspec_config = self.sqlspec_config
+        if sqlspec_config is None and self.sqlspec is not None:
+            registered_configs = tuple(self.sqlspec.configs.values())
+            if len(registered_configs) == 1:
+                sqlspec_config = registered_configs[0]
+        if sqlspec_config is None:
+            return
+
+        # Register the durable events queue migration first: a capability-native
+        # adapter (asyncpg/psycopg/psqlpy notify_queue, DuckDB poll_queue) needs
+        # its events table provisioned on migrate-up so zero-config native wakeups
+        # work on a fresh database.
+        events_backend = resolve_events_migration_backend(self, cast("SQLSpecConfig", sqlspec_config))
+        if events_backend is not None:
+            configure_events_migration_extension(
+                cast("SQLSpecConfig", sqlspec_config),
+                backend=events_backend,
+                queue_table=(self.worker_wakeups.queue_table_name if self.worker_wakeups is not None else None),
+            )
+
+        extension_config = sqlspec_config.extension_config or {}
+        queue_settings = dict(extension_config.get("litestar_queues", {}) or {})
+        queue_table_name = self.queue_table_name or queue_settings.get("table_name") or DEFAULT_TABLE_NAME
+        event_log_config = config.events.history if config.events is not None else None
+        configure_queue_migration_extension(
+            cast("SQLSpecConfig", sqlspec_config),
+            queue_table_name=str(queue_table_name),
+            event_history_enabled=event_log_config is not None,
+            event_history_table_name=self.event_history_table_name,
+            event_history_extra_columns=self.event_history_extra_columns,
+            maintenance_table_name=self.maintenance_table_name,
+            task_reservation_table_name=self.task_reservation_table_name,
+        )

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -178,8 +178,12 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         """Return a parametrized batch INSERT template for event rows."""
         names = self._all_columns()
         columns = ", ".join(self._quoted_col(column) for column in names)
-        placeholders = ", ".join(f":{column}" for column in names)
+        placeholders = ", ".join(f":{self.parameter_name(column)}" for column in names)
         return f"INSERT INTO {self._quoted_table_name()} ({columns}) VALUES ({placeholders})"  # noqa: S608
+
+    def parameter_name(self, column: "str") -> "str":
+        """Return the bind parameter name for a public event column."""
+        return self._col(column)
 
     def _select_columns(self) -> "tuple[Any, ...]":
         return tuple(self._col(column) if self._col(column) != column else column for column in self._all_columns())
@@ -805,6 +809,9 @@ class SQLSpecQueueEventLog:
         }
         for column in self._store.extra_columns:
             params[column.name] = _optional_str(detail.get(column.source))
+        level_parameter = self._store.parameter_name("level")
+        if level_parameter != "level":
+            params[level_parameter] = params.pop("level")
         return params
 
     def _record_from_row(self, row: "dict[str, Any]") -> "QueueEventLogRecord":

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec import sql
+from sqlspec.utils.text import quote_backtick_identifier, quote_identifier, split_qualified_identifier
 
 from litestar_queues.backends.sqlspec.schema import (
     EVENT_HISTORY_COLUMNS,
@@ -63,6 +64,21 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
     def _all_columns(self) -> "tuple[str, ...]":
         return (*EVENT_HISTORY_COLUMNS, *(column.name for column in self._extra_columns))
 
+    def _event_dialect_name(self) -> "str | None":
+        dialect = self._data_dictionary_dialect_name()
+        return "mssql" if dialect == "tsql" else dialect
+
+    def _quote_identifier(self, identifier: "str") -> "str":
+        quote = quote_backtick_identifier if self._event_dialect_name() == "mysql" else quote_identifier
+        parts = split_qualified_identifier(identifier)
+        if not parts:
+            return quote(identifier)
+        return ".".join(quote(part) for part in parts)
+
+    def _quote_unsplit_identifier(self, identifier: "str") -> "str":
+        quote = quote_backtick_identifier if self._event_dialect_name() == "mysql" else quote_identifier
+        return quote(identifier)
+
     def _validated_extra_filter(self, extra: "Mapping[str, str] | None") -> "tuple[tuple[str, str], ...]":
         resolved = validate_event_extra_filter(extra, self._extra_columns)
         return tuple(resolved.items())
@@ -77,7 +93,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         """Return statements that drop event-log artifacts."""
         if not self._manage_schema:
             return []
-        if self.data_dictionary_dialect == "oracle":
+        if self._event_dialect_name() == "oracle":
 
             def _oracle_drop(name: "str") -> "str":
                 return f"""
@@ -111,7 +127,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 _oracle_drop("task_id"),
                 _oracle_drop_tbl(),
             ]
-        if self.data_dictionary_dialect == "mssql":
+        if self._event_dialect_name() == "mssql":
 
             def _mssql_drop(name: "str") -> "str":
                 return (
@@ -128,7 +144,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 _mssql_drop("task_id"),
                 f"IF OBJECT_ID(N'{self.table_name}', N'U') IS NOT NULL DROP TABLE {self._quoted_table_name()};",
             ]
-        if self.data_dictionary_dialect == "mysql":
+        if self._event_dialect_name() == "mysql":
             return [self._to_sql(sql.drop_table(self.table_name).if_exists())]
         return [
             *(
@@ -151,7 +167,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return f"INSERT INTO {self._quoted_table_name()} ({columns}) VALUES ({placeholders})"  # noqa: S608
 
     def _select_columns(self) -> "tuple[str, ...]":
-        if self.data_dictionary_dialect == "oracle":
+        if self._event_dialect_name() == "oracle":
             return tuple('"LEVEL" AS level' if col == "level" else col for col in self._all_columns())
         return self._all_columns()
 
@@ -292,7 +308,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return statement
 
     def _create_event_table_sql(self) -> "str":
-        if self.data_dictionary_dialect == "mssql":
+        if self._event_dialect_name() == "mssql":
             cols = [
                 f"{self._quoted_col('event_id')} {self._id_type()} PRIMARY KEY",
                 f"{self._quoted_col('event_type')} {self._indexed_text_type()} NOT NULL",
@@ -326,7 +342,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 )
             END
             """
-        if self.data_dictionary_dialect == "oracle":
+        if self._event_dialect_name() == "oracle":
             cols = [
                 f"{self._quoted_col('event_id')} {self._id_type()} PRIMARY KEY",
                 f"{self._quoted_col('event_type')} {self._indexed_text_type()} NOT NULL",
@@ -364,7 +380,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                     END IF;
             END;
             """
-        if self.data_dictionary_dialect == "mysql":
+        if self._event_dialect_name() == "mysql":
             cols = [
                 f"{self._quoted_col('event_id')} {self._id_type()} PRIMARY KEY",
                 f"{self._quoted_col('event_type')} {self._indexed_text_type()} NOT NULL",
@@ -409,9 +425,9 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return rendered
 
     def _create_event_index_statements(self) -> "list[str]":
-        if self.data_dictionary_dialect == "mysql":
+        if self._event_dialect_name() == "mysql":
             return []
-        if self.data_dictionary_dialect == "mssql":
+        if self._event_dialect_name() == "mssql":
 
             def _mssql_idx(name: "str", cols: "str") -> "str":
                 return (
@@ -437,7 +453,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                     if column.indexed
                 ),
             ]
-        if self.data_dictionary_dialect == "oracle":
+        if self._event_dialect_name() == "oracle":
 
             def _oracle_idx(name: "str", cols: "str") -> "str":
                 return f"""

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -16,7 +16,11 @@ from litestar_queues.backends.sqlspec.schema import (
 )
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore, _adapter_name
 from litestar_queues.backends.sqlspec.stores.spanner import SpannerQueueStore
-from litestar_queues.events import EventHistoryExtraColumn, validate_event_history_extra_columns
+from litestar_queues.events import (
+    EventHistoryExtraColumn,
+    validate_event_extra_filter,
+    validate_event_history_extra_columns,
+)
 from litestar_queues.events.history import EventHistoryConfig, QueueEventLogRecord, QueueEventStageSummary
 
 if TYPE_CHECKING:
@@ -60,14 +64,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return (*EVENT_HISTORY_COLUMNS, *(column.name for column in self._extra_columns))
 
     def _validated_extra_filter(self, extra: "Mapping[str, str] | None") -> "tuple[tuple[str, str], ...]":
-        if not extra:
-            return ()
-        declared = {column.name for column in self._extra_columns}
-        unknown = sorted(set(extra) - declared)
-        if unknown:
-            msg = f"Unknown event-history filter column(s) {unknown!r}; declared extra columns are {sorted(declared)!r}"
-            raise ValueError(msg)
-        return tuple((name, extra[name]) for name in extra)
+        resolved = validate_event_extra_filter(extra, self._extra_columns)
+        return tuple(resolved.items())
 
     def create_statements(self) -> "list[str]":
         """Return statements that create the event-log table and indexes."""

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -12,11 +12,11 @@ from sqlspec import sql
 from litestar_queues.backends.sqlspec.schema import (
     EVENT_HISTORY_COLUMNS,
     event_history_table_name_for,
-    validate_event_history_extra_columns,
     validate_table_name,
 )
 from litestar_queues.backends.sqlspec.stores.base import SQLSpecQueueStore, _adapter_name
 from litestar_queues.backends.sqlspec.stores.spanner import SpannerQueueStore
+from litestar_queues.events import EventHistoryExtraColumn, validate_event_history_extra_columns
 from litestar_queues.events.history import EventHistoryConfig, QueueEventLogRecord, QueueEventStageSummary
 
 if TYPE_CHECKING:
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from sqlspec.builder import CreateIndex, CreateTable, Delete, DropIndex, DropTable, Select
 
     from litestar_queues.backends.sqlspec._typing import DatetimeParam, SQLSpecDriver, SQLSpecStoreConfig
-    from litestar_queues.backends.sqlspec.schema import EventHistoryExtraColumn
     from litestar_queues.events.models import QueueEvent
 
 __all__ = (

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -56,7 +56,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         self, *args: "Any", extra_columns: "Sequence[EventHistoryExtraColumn] | None" = None, **kwargs: "Any"
     ) -> "None":
         super().__init__(*args, **kwargs)
-        self._column_map = {}
+        self._column_map = {"level": "event_level"} if self._event_dialect_name() == "oracle" else {}
         self._extra_columns = validate_event_history_extra_columns(extra_columns or ())
 
     @property
@@ -173,14 +173,12 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
     def insert_events_template(self) -> "str":
         """Return a parametrized batch INSERT template for event rows."""
         names = self._all_columns()
-        columns = ", ".join(self._quote_identifier(column) for column in names)
+        columns = ", ".join(self._quoted_col(column) for column in names)
         placeholders = ", ".join(f":{column}" for column in names)
         return f"INSERT INTO {self._quoted_table_name()} ({columns}) VALUES ({placeholders})"  # noqa: S608
 
     def _select_columns(self) -> "tuple[str, ...]":
-        if self._event_dialect_name() == "oracle":
-            return tuple('"LEVEL" AS level' if col == "level" else col for col in self._all_columns())
-        return self._all_columns()
+        return tuple(self._select_column(column) for column in self._all_columns())
 
     def select_events(
         self,
@@ -303,7 +301,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
             .column("actor_type", self._indexed_text_type())
             .column("actor_id", self._indexed_text_type())
             .column("stage", self._indexed_text_type())
-            .column("level", self._indexed_text_type())
+            .column(self._col("level"), self._indexed_text_type())
             .column("message", self._text_type())
             .column("detail", self._json_type(), not_null=True)
             .column("progress_current", self._float_type())
@@ -366,7 +364,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 f"{self._quoted_col('actor_type')} {self._indexed_text_type()}",
                 f"{self._quoted_col('actor_id')} {self._indexed_text_type()}",
                 f"{self._quoted_col('stage')} {self._indexed_text_type()}",
-                f'"LEVEL" {self._indexed_text_type()}',
+                f"{self._quoted_col('level')} {self._indexed_text_type()}",
                 f"{self._quoted_col('message')} {self._text_type()}",
                 f"{self._quoted_col('detail')} {self._json_type()} NOT NULL",
                 f"{self._quoted_col('progress_current')} {self._float_type()}",

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -177,8 +177,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         placeholders = ", ".join(f":{column}" for column in names)
         return f"INSERT INTO {self._quoted_table_name()} ({columns}) VALUES ({placeholders})"  # noqa: S608
 
-    def _select_columns(self) -> "tuple[str, ...]":
-        return tuple(self._select_column(column) for column in self._all_columns())
+    def _select_columns(self) -> "tuple[Any, ...]":
+        return tuple(self._col(column) if self._col(column) != column else column for column in self._all_columns())
 
     def select_events(
         self,
@@ -821,7 +821,7 @@ class SQLSpecQueueEventLog:
             actor_type=cast("str | None", row["actor_type"]),
             actor_id=cast("str | None", row["actor_id"]),
             stage=cast("str | None", row["stage"]),
-            level=cast("str | None", row["level"]),
+            level=cast("str | None", row.get("level", row.get("event_level"))),
             message=cast("str | None", row["message"]),
             detail=self._store.deserialize_detail(row["detail"]),
             progress_current=_optional_float(row["progress_current"]),

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -5,6 +5,7 @@ import logging
 import time
 from contextlib import suppress
 from datetime import datetime, timezone
+from hashlib import sha1
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec import sql
@@ -41,6 +42,8 @@ __all__ = (
     "resolve_event_history_table_name",
 )
 
+_PORTABLE_INDEX_NAME_LENGTH = 63
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,15 +72,23 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return "mssql" if dialect == "tsql" else dialect
 
     def _quote_identifier(self, identifier: "str") -> "str":
-        quote = quote_backtick_identifier if self._event_dialect_name() == "mysql" else quote_identifier
+        quote = quote_backtick_identifier if self._event_dialect_name() in {"mysql", "spanner"} else quote_identifier
         parts = split_qualified_identifier(identifier)
         if not parts:
             return quote(identifier)
         return ".".join(quote(part) for part in parts)
 
     def _quote_unsplit_identifier(self, identifier: "str") -> "str":
-        quote = quote_backtick_identifier if self._event_dialect_name() == "mysql" else quote_identifier
+        quote = quote_backtick_identifier if self._event_dialect_name() in {"mysql", "spanner"} else quote_identifier
         return quote(identifier)
+
+    def _index_name(self, suffix: "str") -> "str":
+        name = super()._index_name(suffix)
+        if len(name) <= _PORTABLE_INDEX_NAME_LENGTH:
+            return name
+        digest = sha1(name.encode()).hexdigest()[:8]  # noqa: S324 - stable identifier shortening.
+        prefix_length = _PORTABLE_INDEX_NAME_LENGTH - len(digest) - 1
+        return f"{name[:prefix_length]}_{digest}"
 
     def _validated_extra_filter(self, extra: "Mapping[str, str] | None") -> "tuple[tuple[str, str], ...]":
         resolved = validate_event_extra_filter(extra, self._extra_columns)
@@ -468,12 +479,18 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
                 """
 
             return [
-                _oracle_idx("task_id", "task_id, sequence, occurred_at"),
-                _oracle_idx("task_name", "task_name, stage, occurred_at"),
-                _oracle_idx("actor_id", "actor_id, occurred_at"),
-                _oracle_idx("occurred_at", "occurred_at"),
+                _oracle_idx(
+                    "task_id",
+                    f"{self._quoted_col('task_id')}, {self._quoted_col('sequence')}, {self._quoted_col('occurred_at')}",
+                ),
+                _oracle_idx(
+                    "task_name",
+                    f"{self._quoted_col('task_name')}, {self._quoted_col('stage')}, {self._quoted_col('occurred_at')}",
+                ),
+                _oracle_idx("actor_id", f"{self._quoted_col('actor_id')}, {self._quoted_col('occurred_at')}"),
+                _oracle_idx("occurred_at", self._quoted_col("occurred_at")),
                 *(
-                    _oracle_idx(column.name, f"{column.name}, occurred_at")
+                    _oracle_idx(column.name, f"{self._quoted_col(column.name)}, {self._quoted_col('occurred_at')}")
                     for column in self._extra_columns
                     if column.indexed
                 ),

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -77,6 +77,59 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         """Return statements that drop event-log artifacts."""
         if not self._manage_schema:
             return []
+        if self.data_dictionary_dialect == "oracle":
+
+            def _oracle_drop(name: "str") -> "str":
+                return f"""
+                BEGIN
+                    EXECUTE IMMEDIATE 'DROP INDEX {self._index_name(name)}';
+                EXCEPTION
+                    WHEN OTHERS THEN
+                        IF SQLCODE != -1418 AND SQLCODE != -942 THEN
+                            RAISE;
+                        END IF;
+                END;
+                """
+
+            def _oracle_drop_tbl() -> "str":
+                return f"""
+                BEGIN
+                    EXECUTE IMMEDIATE 'DROP TABLE {self._quoted_table_name()} CASCADE CONSTRAINTS';
+                EXCEPTION
+                    WHEN OTHERS THEN
+                        IF SQLCODE != -942 THEN
+                            RAISE;
+                        END IF;
+                END;
+                """
+
+            return [
+                *(_oracle_drop(column.name) for column in reversed(self._extra_columns) if column.indexed),
+                _oracle_drop("occurred_at"),
+                _oracle_drop("actor_id"),
+                _oracle_drop("task_name"),
+                _oracle_drop("task_id"),
+                _oracle_drop_tbl(),
+            ]
+        if self.data_dictionary_dialect == "mssql":
+
+            def _mssql_drop(name: "str") -> "str":
+                return (
+                    "IF EXISTS (SELECT 1 FROM sys.indexes "  # noqa: S608
+                    f"WHERE name = N'{self._index_name(name)}' AND object_id = OBJECT_ID(N'{self.table_name}')) "
+                    f"DROP INDEX [{self._index_name(name)}] ON {self._quoted_table_name()};"
+                )
+
+            return [
+                *(_mssql_drop(column.name) for column in reversed(self._extra_columns) if column.indexed),
+                _mssql_drop("occurred_at"),
+                _mssql_drop("actor_id"),
+                _mssql_drop("task_name"),
+                _mssql_drop("task_id"),
+                f"IF OBJECT_ID(N'{self.table_name}', N'U') IS NOT NULL DROP TABLE {self._quoted_table_name()};",
+            ]
+        if self.data_dictionary_dialect == "mysql":
+            return [self._to_sql(sql.drop_table(self.table_name).if_exists())]
         return [
             *(
                 self._to_sql(sql.drop_index(self._index_name(column.name)).if_exists())
@@ -97,6 +150,11 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         placeholders = ", ".join(f":{column}" for column in names)
         return f"INSERT INTO {self._quoted_table_name()} ({columns}) VALUES ({placeholders})"  # noqa: S608
 
+    def _select_columns(self) -> "tuple[str, ...]":
+        if self.data_dictionary_dialect == "oracle":
+            return tuple('"LEVEL" AS level' if col == "level" else col for col in self._all_columns())
+        return self._all_columns()
+
     def select_events(
         self,
         *,
@@ -113,7 +171,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
             ValueError: If ``extra`` names a column that was not declared.
         """
         filters = self._validated_extra_filter(extra)
-        statement = sql.select(*self._all_columns()).from_(self.table_name)
+        statement = sql.select(*self._select_columns()).from_(self.table_name)
         if task_id is not None:
             statement = statement.where_eq("task_id", task_id)
         if task_name is not None:
@@ -230,6 +288,115 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return statement
 
     def _create_event_table_sql(self) -> "str":
+        if self.data_dictionary_dialect == "mssql":
+            cols = [
+                f"{self._quoted_col('event_id')} {self._id_type()} PRIMARY KEY",
+                f"{self._quoted_col('event_type')} {self._indexed_text_type()} NOT NULL",
+                f"{self._quoted_col('task_id')} {self._id_type()}",
+                f"{self._quoted_col('task_name')} {self._indexed_text_type()}",
+                f"{self._quoted_col('queue')} {self._indexed_text_type()}",
+                f"{self._quoted_col('worker_id')} {self._indexed_text_type()}",
+                f"{self._quoted_col('execution_backend')} {self._indexed_text_type()}",
+                f"{self._quoted_col('execution_profile')} {self._indexed_text_type()}",
+                f"{self._quoted_col('actor_type')} {self._indexed_text_type()}",
+                f"{self._quoted_col('actor_id')} {self._indexed_text_type()}",
+                f"{self._quoted_col('stage')} {self._indexed_text_type()}",
+                f"{self._quoted_col('level')} {self._indexed_text_type()}",
+                f"{self._quoted_col('message')} {self._text_type()}",
+                f"{self._quoted_col('detail')} {self._json_type()} NOT NULL",
+                f"{self._quoted_col('progress_current')} {self._float_type()}",
+                f"{self._quoted_col('progress_total')} {self._float_type()}",
+                f"{self._quoted_col('progress_percent')} {self._float_type()}",
+                f"{self._quoted_col('duration_ms')} {self._float_type()}",
+                f"{self._quoted_col('sequence')} {self._integer_type()}",
+                f"{self._quoted_col('occurred_at')} {self._timestamp_type()} NOT NULL",
+                f"{self._quoted_col('created_at')} {self._timestamp_type()} NOT NULL",
+                *(f"{self._quoted_col(column.name)} {self._indexed_text_type()}" for column in self._extra_columns),
+            ]
+            column_sql = ",\n  ".join(cols)
+            return f"""
+            IF OBJECT_ID(N'{self.table_name}', N'U') IS NULL
+            BEGIN
+                CREATE TABLE {self._quoted_table_name()} (
+                    {column_sql}
+                )
+            END
+            """
+        if self.data_dictionary_dialect == "oracle":
+            cols = [
+                f"{self._quoted_col('event_id')} {self._id_type()} PRIMARY KEY",
+                f"{self._quoted_col('event_type')} {self._indexed_text_type()} NOT NULL",
+                f"{self._quoted_col('task_id')} {self._id_type()}",
+                f"{self._quoted_col('task_name')} {self._indexed_text_type()}",
+                f"{self._quoted_col('queue')} {self._indexed_text_type()}",
+                f"{self._quoted_col('worker_id')} {self._indexed_text_type()}",
+                f"{self._quoted_col('execution_backend')} {self._indexed_text_type()}",
+                f"{self._quoted_col('execution_profile')} {self._indexed_text_type()}",
+                f"{self._quoted_col('actor_type')} {self._indexed_text_type()}",
+                f"{self._quoted_col('actor_id')} {self._indexed_text_type()}",
+                f"{self._quoted_col('stage')} {self._indexed_text_type()}",
+                f'"LEVEL" {self._indexed_text_type()}',
+                f"{self._quoted_col('message')} {self._text_type()}",
+                f"{self._quoted_col('detail')} {self._json_type()} NOT NULL",
+                f"{self._quoted_col('progress_current')} {self._float_type()}",
+                f"{self._quoted_col('progress_total')} {self._float_type()}",
+                f"{self._quoted_col('progress_percent')} {self._float_type()}",
+                f"{self._quoted_col('duration_ms')} {self._float_type()}",
+                f"{self._quoted_col('sequence')} {self._integer_type()}",
+                f"{self._quoted_col('occurred_at')} {self._timestamp_type()} NOT NULL",
+                f"{self._quoted_col('created_at')} {self._timestamp_type()} NOT NULL",
+                *(f"{self._quoted_col(column.name)} {self._indexed_text_type()}" for column in self._extra_columns),
+            ]
+            column_sql = ",\n  ".join(cols)
+            return f"""
+            BEGIN
+                EXECUTE IMMEDIATE 'CREATE TABLE {self._quoted_table_name()} (
+                    {column_sql}
+                )';
+            EXCEPTION
+                WHEN OTHERS THEN
+                    IF SQLCODE != -955 THEN
+                        RAISE;
+                    END IF;
+            END;
+            """
+        if self.data_dictionary_dialect == "mysql":
+            cols = [
+                f"{self._quoted_col('event_id')} {self._id_type()} PRIMARY KEY",
+                f"{self._quoted_col('event_type')} {self._indexed_text_type()} NOT NULL",
+                f"{self._quoted_col('task_id')} {self._id_type()}",
+                f"{self._quoted_col('task_name')} {self._indexed_text_type()}",
+                f"{self._quoted_col('queue')} {self._indexed_text_type()}",
+                f"{self._quoted_col('worker_id')} {self._indexed_text_type()}",
+                f"{self._quoted_col('execution_backend')} {self._indexed_text_type()}",
+                f"{self._quoted_col('execution_profile')} {self._indexed_text_type()}",
+                f"{self._quoted_col('actor_type')} {self._indexed_text_type()}",
+                f"{self._quoted_col('actor_id')} {self._indexed_text_type()}",
+                f"{self._quoted_col('stage')} {self._indexed_text_type()}",
+                f"{self._quoted_col('level')} {self._indexed_text_type()}",
+                f"{self._quoted_col('message')} {self._text_type()}",
+                f"{self._quoted_col('detail')} {self._json_type()} NOT NULL",
+                f"{self._quoted_col('progress_current')} {self._float_type()}",
+                f"{self._quoted_col('progress_total')} {self._float_type()}",
+                f"{self._quoted_col('progress_percent')} {self._float_type()}",
+                f"{self._quoted_col('duration_ms')} {self._float_type()}",
+                f"{self._quoted_col('sequence')} {self._integer_type()}",
+                f"{self._quoted_col('occurred_at')} {self._timestamp_type()} NOT NULL",
+                f"{self._quoted_col('created_at')} {self._timestamp_type()} NOT NULL",
+                *(f"{self._quoted_col(column.name)} {self._indexed_text_type()}" for column in self._extra_columns),
+                f"INDEX {self._quoted_index_name('task_id')} ({self._quoted_col('task_id')}, {self._quoted_col('sequence')}, {self._quoted_col('occurred_at')})",
+                f"INDEX {self._quoted_index_name('task_name')} ({self._quoted_col('task_name')}, {self._quoted_col('stage')}, {self._quoted_col('occurred_at')})",
+                f"INDEX {self._quoted_index_name('actor_id')} ({self._quoted_col('actor_id')}, {self._quoted_col('occurred_at')})",
+                f"INDEX {self._quoted_index_name('occurred_at')} ({self._quoted_col('occurred_at')})",
+                *(
+                    f"INDEX {self._quoted_index_name(column.name)} ({self._quoted_col(column.name)}, {self._quoted_col('occurred_at')})"
+                    for column in self._extra_columns
+                    if column.indexed
+                ),
+            ]
+            column_sql = ",\n  ".join(cols)
+            return f"CREATE TABLE IF NOT EXISTS {self._quoted_table_name()} (\n  {column_sql}\n)"
+
         rendered = self._to_sql(self._create_event_table_statement())
         unsplit_target = self._quote_unsplit_identifier(self.table_name)
         split_target = self._quoted_table_name()
@@ -238,6 +405,59 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return rendered
 
     def _create_event_index_statements(self) -> "list[str]":
+        if self.data_dictionary_dialect == "mysql":
+            return []
+        if self.data_dictionary_dialect == "mssql":
+
+            def _mssql_idx(name: "str", cols: "str") -> "str":
+                return (
+                    "IF NOT EXISTS (SELECT 1 FROM sys.indexes "  # noqa: S608
+                    f"WHERE name = N'{self._index_name(name)}' AND object_id = OBJECT_ID(N'{self.table_name}')) "
+                    f"CREATE INDEX {self._quoted_index_name(name)} ON {self._quoted_table_name()} ({cols});"
+                )
+
+            return [
+                _mssql_idx(
+                    "task_id",
+                    f"{self._quoted_col('task_id')}, {self._quoted_col('sequence')}, {self._quoted_col('occurred_at')}",
+                ),
+                _mssql_idx(
+                    "task_name",
+                    f"{self._quoted_col('task_name')}, {self._quoted_col('stage')}, {self._quoted_col('occurred_at')}",
+                ),
+                _mssql_idx("actor_id", f"{self._quoted_col('actor_id')}, {self._quoted_col('occurred_at')}"),
+                _mssql_idx("occurred_at", f"{self._quoted_col('occurred_at')}"),
+                *(
+                    _mssql_idx(column.name, f"{self._quoted_col(column.name)}, {self._quoted_col('occurred_at')}")
+                    for column in self._extra_columns
+                    if column.indexed
+                ),
+            ]
+        if self.data_dictionary_dialect == "oracle":
+
+            def _oracle_idx(name: "str", cols: "str") -> "str":
+                return f"""
+                BEGIN
+                    EXECUTE IMMEDIATE 'CREATE INDEX {self._index_name(name)} ON {self._quoted_table_name()} ({cols})';
+                EXCEPTION
+                    WHEN OTHERS THEN
+                        IF SQLCODE != -955 AND SQLCODE != -1408 THEN
+                            RAISE;
+                        END IF;
+                END;
+                """
+
+            return [
+                _oracle_idx("task_id", "task_id, sequence, occurred_at"),
+                _oracle_idx("task_name", "task_name, stage, occurred_at"),
+                _oracle_idx("actor_id", "actor_id, occurred_at"),
+                _oracle_idx("occurred_at", "occurred_at"),
+                *(
+                    _oracle_idx(column.name, f"{column.name}, occurred_at")
+                    for column in self._extra_columns
+                    if column.indexed
+                ),
+            ]
         return [
             self._to_sql(
                 sql

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -245,6 +245,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         Returns:
             The adapter-shaped serialized detail payload.
         """
+        if _adapter_name(self._config) == "psqlpy":
+            return detail
         return self._serialize_json(detail)
 
     def deserialize_detail(self, value: "Any") -> "dict[str, Any]":
@@ -253,6 +255,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         Returns:
             The decoded detail mapping, or an empty mapping for non-object JSON.
         """
+        if isinstance(value, dict):
+            return value
         detail = self.deserialize_json("detail", value)
         return detail if isinstance(detail, dict) else {}
 

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -72,6 +72,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return "mssql" if dialect == "tsql" else dialect
 
     def _quote_identifier(self, identifier: "str") -> "str":
+        if self._event_dialect_name() == "oracle":
+            return ".".join(part.upper() for part in split_qualified_identifier(identifier) or (identifier,))
         quote = quote_backtick_identifier if self._event_dialect_name() in {"mysql", "spanner"} else quote_identifier
         parts = split_qualified_identifier(identifier)
         if not parts:
@@ -79,6 +81,8 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
         return ".".join(quote(part) for part in parts)
 
     def _quote_unsplit_identifier(self, identifier: "str") -> "str":
+        if self._event_dialect_name() == "oracle":
+            return identifier.upper()
         quote = quote_backtick_identifier if self._event_dialect_name() in {"mysql", "spanner"} else quote_identifier
         return quote(identifier)
 

--- a/src/litestar_queues/backends/sqlspec/event_log.py
+++ b/src/litestar_queues/backends/sqlspec/event_log.py
@@ -113,7 +113,7 @@ class SQLSpecQueueEventLogStore(SQLSpecQueueStore):
             ValueError: If ``extra`` names a column that was not declared.
         """
         filters = self._validated_extra_filter(extra)
-        statement = sql.select(*EVENT_HISTORY_COLUMNS).from_(self.table_name)
+        statement = sql.select(*self._all_columns()).from_(self.table_name)
         if task_id is not None:
             statement = statement.where_eq("task_id", task_id)
         if task_name is not None:
@@ -405,6 +405,11 @@ class SQLSpecQueueEventLog:
         self._flush_lock = asyncio.Lock()
         self._logger = runtime_logger or logger
 
+    @property
+    def extra_columns(self) -> "tuple[EventHistoryExtraColumn, ...]":
+        """Declared extra scoping columns for this event log."""
+        return self._store.extra_columns
+
     async def publish_event(self, event: "QueueEvent") -> "None":
         """Buffer a queue event and flush when configured thresholds are reached."""
         should_flush = False
@@ -544,6 +549,11 @@ class SQLSpecQueueEventLog:
         return params
 
     def _record_from_row(self, row: "dict[str, Any]") -> "QueueEventLogRecord":
+        extra = {
+            column.name: str(row[column.name])
+            for column in self._store.extra_columns
+            if column.name in row and row[column.name] is not None
+        }
         return QueueEventLogRecord(
             event_id=str(row["event_id"]),
             event_type=str(row["event_type"]),
@@ -564,6 +574,7 @@ class SQLSpecQueueEventLog:
             progress_percent=_optional_float(row["progress_percent"]),
             duration_ms=_optional_float(row["duration_ms"]),
             sequence=_optional_int(row["sequence"]),
+            extra=extra,
             occurred_at=_deserialize_datetime(row["occurred_at"]),
             created_at=_deserialize_datetime(row["created_at"]),
         )

--- a/src/litestar_queues/backends/sqlspec/extension.py
+++ b/src/litestar_queues/backends/sqlspec/extension.py
@@ -8,16 +8,16 @@ from litestar_queues.backends.sqlspec.schema import (
     maintenance_table_name_for,
     migration_directory,
     task_reservation_table_name_for,
-    validate_event_history_extra_columns,
     validate_table_name,
 )
+from litestar_queues.events import validate_event_history_extra_columns
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
     from litestar_queues.backends.sqlspec._typing import SQLSpecConfig
-    from litestar_queues.backends.sqlspec.schema import EventHistoryExtraColumn
+    from litestar_queues.events import EventHistoryExtraColumn
 
 __all__ = (
     "QUEUE_EXTENSION_NAME",

--- a/src/litestar_queues/backends/sqlspec/migrations/0001_create_queue_tasks.py
+++ b/src/litestar_queues/backends/sqlspec/migrations/0001_create_queue_tasks.py
@@ -8,8 +8,9 @@ from litestar_queues.backends.sqlspec.event_log import create_event_log_store
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME
 from litestar_queues.backends.sqlspec.maintenance import create_maintenance_store
 from litestar_queues.backends.sqlspec.reservation import create_task_reservation_store
-from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME, EventHistoryExtraColumn, validate_table_name
+from litestar_queues.backends.sqlspec.schema import DEFAULT_TABLE_NAME, validate_table_name
 from litestar_queues.backends.sqlspec.stores.factory import create_queue_store
+from litestar_queues.events import EventHistoryExtraColumn
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/src/litestar_queues/backends/sqlspec/schema.py
+++ b/src/litestar_queues/backends/sqlspec/schema.py
@@ -1,6 +1,5 @@
 """Schema and migration helpers for the SQLSpec queue backend."""
 
-from dataclasses import dataclass
 from hashlib import sha1
 from importlib.resources import files
 from pathlib import Path
@@ -11,7 +10,7 @@ from sqlspec.utils.text import quote_identifier, split_qualified_identifier
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Mapping
 
 __all__ = (
     "DEFAULT_COLUMN_MAP",
@@ -20,8 +19,6 @@ __all__ = (
     "DEFAULT_TABLE_NAME",
     "DEFAULT_TASK_RESERVATION_TABLE_SUFFIX",
     "EVENT_HISTORY_COLUMNS",
-    "RESERVED_EVENT_HISTORY_COLUMNS",
-    "EventHistoryExtraColumn",
     "event_history_table_name_for",
     "maintenance_table_name_for",
     "migration_directory",
@@ -29,7 +26,6 @@ __all__ = (
     "resolve_column_map",
     "task_reservation_table_name_for",
     "validate_column_map",
-    "validate_event_history_extra_columns",
     "validate_native_json_columns",
     "validate_table_name",
 )
@@ -99,69 +95,8 @@ EVENT_HISTORY_COLUMNS = (
 
 _EVENT_HISTORY_COLUMN_NAMES = frozenset(EVENT_HISTORY_COLUMNS)
 
-RESERVED_EVENT_HISTORY_COLUMNS = frozenset({"entity", "scope", "scope_key"})
-"""Names held for built-in event-history scoping dimensions.
-
-These are not columns on the table yet. They are reserved so an adopter-declared
-extra column cannot claim a name the package intends to own.
-"""
 
 
-@dataclass(frozen=True, slots=True)
-class EventHistoryExtraColumn:
-    """Adopter-declared scoping column on the SQLSpec event-history table."""
-
-    name: "str"
-    """Physical column name; must be a valid unquoted SQL identifier."""
-
-    source: "str"
-    """Key looked up in the event payload (``QueueEvent.payload``)."""
-
-    indexed: "bool" = False
-    """Whether a ``(name, occurred_at)`` index is created."""
-
-
-def validate_event_history_extra_columns(
-    columns: "Sequence[EventHistoryExtraColumn]",
-) -> "tuple[EventHistoryExtraColumn, ...]":
-    """Validate adopter-declared extra event-history columns.
-
-    Returns:
-        The validated declarations as a tuple.
-
-    Raises:
-        QueueConfigurationError: If a name is not a valid unquoted SQL
-            identifier, collides with a package-owned column, uses a reserved
-            scoping-dimension name, repeats another declaration, or the payload
-            source key is empty.
-    """
-    seen: "set[str]" = set()
-    validated: "list[EventHistoryExtraColumn]" = []
-    for column in columns:
-        if not _is_unquoted_identifier_part(column.name):
-            msg = f"Invalid SQL identifier in event_history_extra_columns: {column.name!r}"
-            raise QueueConfigurationError(msg)
-        # Unquoted SQL identifiers fold case, so every name comparison below does
-        # too: ``TASK_ID`` and ``task_id`` are one column to the database.
-        folded = column.name.lower()
-        if folded in _EVENT_HISTORY_COLUMN_NAMES:
-            msg = f"event_history_extra_columns may not redeclare package-owned column {column.name!r}"
-            raise QueueConfigurationError(msg)
-        if folded in RESERVED_EVENT_HISTORY_COLUMNS:
-            msg = (
-                f"event_history_extra_columns may not use {column.name!r}: "
-                f"{sorted(RESERVED_EVENT_HISTORY_COLUMNS)!r} are reserved for built-in scoping dimensions"
-            )
-            raise QueueConfigurationError(msg)
-        if folded in seen:
-            msg = f"Duplicate column in event_history_extra_columns: {column.name!r}"
-            raise QueueConfigurationError(msg)
-        if not column.source:
-            msg = f"event_history_extra_columns entry {column.name!r} requires a non-empty payload source key"
-            raise QueueConfigurationError(msg)
-        seen.add(folded)
-        validated.append(column)
-    return tuple(validated)
 
 
 def validate_table_name(table_name: "str") -> "str":

--- a/src/litestar_queues/backends/sqlspec/schema.py
+++ b/src/litestar_queues/backends/sqlspec/schema.py
@@ -96,9 +96,6 @@ EVENT_HISTORY_COLUMNS = (
 _EVENT_HISTORY_COLUMN_NAMES = frozenset(EVENT_HISTORY_COLUMNS)
 
 
-
-
-
 def validate_table_name(table_name: "str") -> "str":
     """Validate a SQL identifier used for the queue table name.
 

--- a/src/litestar_queues/events/__init__.py
+++ b/src/litestar_queues/events/__init__.py
@@ -18,9 +18,11 @@ from litestar_queues.events.context import (
 )
 from litestar_queues.events.history import (
     EventHistoryConfig,
+    EventHistoryExtraColumn,
     QueueEventLog,
     QueueEventLogRecord,
     QueueEventStageSummary,
+    validate_event_history_extra_columns,
 )
 from litestar_queues.events.models import (
     QueueEvent,
@@ -55,6 +57,7 @@ __all__ = (
     "EventBufferConfig",
     "EventDeliveryConfig",
     "EventHistoryConfig",
+    "EventHistoryExtraColumn",
     "EventStreamConfig",
     "EventStreamTransport",
     "Guard",
@@ -85,6 +88,7 @@ __all__ = (
     "publish_task_log",
     "publish_task_progress",
     "require_current_task_context",
+    "validate_event_history_extra_columns",
 )
 
 

--- a/src/litestar_queues/events/__init__.py
+++ b/src/litestar_queues/events/__init__.py
@@ -22,6 +22,8 @@ from litestar_queues.events.history import (
     QueueEventLog,
     QueueEventLogRecord,
     QueueEventStageSummary,
+    extract_event_extras,
+    validate_event_extra_filter,
     validate_event_history_extra_columns,
 )
 from litestar_queues.events.models import (
@@ -83,11 +85,13 @@ __all__ = (
     "bind_beat_sink",
     "bind_task_context",
     "create_event_producer",
+    "extract_event_extras",
     "get_current_task_context",
     "publish_task_event",
     "publish_task_log",
     "publish_task_progress",
     "require_current_task_context",
+    "validate_event_extra_filter",
     "validate_event_history_extra_columns",
 )
 

--- a/src/litestar_queues/events/_log_records.py
+++ b/src/litestar_queues/events/_log_records.py
@@ -3,9 +3,12 @@
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
-from litestar_queues.events.history import QueueEventLogRecord
+from litestar_queues.events.history import QueueEventLogRecord, extract_event_extras
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from litestar_queues.events.history import EventHistoryExtraColumn
     from litestar_queues.events.models import QueueEvent
 
 __all__ = (
@@ -19,13 +22,19 @@ __all__ = (
 )
 
 
-def event_log_record_from_event(event: "QueueEvent", *, created_at: "datetime | None" = None) -> "QueueEventLogRecord":
+def event_log_record_from_event(
+    event: "QueueEvent",
+    *,
+    extra_columns: "Sequence[EventHistoryExtraColumn]" = (),
+    created_at: "datetime | None" = None,
+) -> "QueueEventLogRecord":
     """Convert a queue event envelope into a backend-neutral history record.
 
     Returns:
         Backend-neutral event-history record.
     """
     detail = dict(event.payload)
+    extra = extract_event_extras(detail, extra_columns)
     return QueueEventLogRecord(
         event_id=event.id,
         event_type=event.type,
@@ -48,6 +57,7 @@ def event_log_record_from_event(event: "QueueEvent", *, created_at: "datetime | 
         sequence=event.sequence,
         occurred_at=parse_datetime(event.occurred_at),
         created_at=created_at or utc_now(),
+        extra=extra,
     )
 
 

--- a/src/litestar_queues/events/context.py
+++ b/src/litestar_queues/events/context.py
@@ -6,7 +6,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
-from litestar_queues.events.models import QueueEvent
+from litestar_queues.events.models import QueueEvent, QueueEventActor
 from litestar_queues.exceptions import JobCancelledError
 
 if TYPE_CHECKING:
@@ -56,6 +56,7 @@ class TaskExecutionContext:
     execution_profile: "str | None"
     attempt: "int"
     event_publisher: "QueueEventPublisher"
+    actor: "QueueEventActor | None" = None
     _sequence: "int" = field(default=0, init=False, repr=False)
     _cancelled: "asyncio.Event" = field(default_factory=asyncio.Event, init=False, repr=False)
 
@@ -85,6 +86,7 @@ class TaskExecutionContext:
         message: "str | None" = None,
         payload: "dict[str, Any] | None" = None,
         channels: "Sequence[str] | None" = None,
+        actor: "QueueEventActor | None" = None,
         immediate: "bool" = False,
     ) -> "None":
         """Publish a task progress event."""
@@ -99,6 +101,7 @@ class TaskExecutionContext:
             progress_percent=progress_percent,
             payload=payload,
             channels=channels,
+            actor=actor,
             immediate=immediate,
         )
 
@@ -109,11 +112,18 @@ class TaskExecutionContext:
         level: "str" = "info",
         payload: "dict[str, Any] | None" = None,
         channels: "Sequence[str] | None" = None,
+        actor: "QueueEventActor | None" = None,
         immediate: "bool" = False,
     ) -> "None":
         """Publish a task log event."""
         await self.publish(
-            "task.log", level=level, message=message, payload=payload, channels=channels, immediate=immediate
+            "task.log",
+            level=level,
+            message=message,
+            payload=payload,
+            channels=channels,
+            actor=actor,
+            immediate=immediate,
         )
 
     async def event(
@@ -123,10 +133,13 @@ class TaskExecutionContext:
         message: "str | None" = None,
         payload: "dict[str, Any] | None" = None,
         channels: "Sequence[str] | None" = None,
+        actor: "QueueEventActor | None" = None,
         immediate: "bool" = False,
     ) -> "None":
         """Publish a custom task event."""
-        await self.publish(event_type, message=message, payload=payload, channels=channels, immediate=immediate)
+        await self.publish(
+            event_type, message=message, payload=payload, channels=channels, actor=actor, immediate=immediate
+        )
 
     async def lifecycle(
         self, event_type: "str", *, message: "str | None" = None, payload: "dict[str, Any] | None" = None
@@ -152,6 +165,7 @@ class TaskExecutionContext:
         progress_percent: "float | None" = None,
         payload: "dict[str, Any] | None" = None,
         channels: "Sequence[str] | None" = None,
+        actor: "QueueEventActor | None" = None,
         immediate: "bool" = False,
     ) -> "QueueEvent":
         """Build and publish an event for this task context.
@@ -176,6 +190,7 @@ class TaskExecutionContext:
             progress_total=progress_total,
             progress_percent=progress_percent,
             payload=dict(payload or {}),
+            actor=actor if actor is not None else self.actor,
         )
         await self.event_publisher.publish(event, channels=channels, immediate=immediate)
         return event
@@ -211,6 +226,7 @@ async def publish_task_progress(
     message: "str | None" = None,
     payload: "dict[str, Any] | None" = None,
     channels: "Sequence[str] | None" = None,
+    actor: "QueueEventActor | None" = None,
     immediate: "bool" = False,
 ) -> "None":
     """Publish progress through the currently bound task context."""
@@ -221,6 +237,7 @@ async def publish_task_progress(
         message=message,
         payload=payload,
         channels=channels,
+        actor=actor,
         immediate=immediate,
     )
 
@@ -231,11 +248,12 @@ async def publish_task_log(
     level: "str" = "info",
     payload: "dict[str, Any] | None" = None,
     channels: "Sequence[str] | None" = None,
+    actor: "QueueEventActor | None" = None,
     immediate: "bool" = False,
 ) -> "None":
     """Publish a log event through the currently bound task context."""
     await require_current_task_context().log(
-        message, level=level, payload=payload, channels=channels, immediate=immediate
+        message, level=level, payload=payload, channels=channels, actor=actor, immediate=immediate
     )
 
 
@@ -245,11 +263,12 @@ async def publish_task_event(
     message: "str | None" = None,
     payload: "dict[str, Any] | None" = None,
     channels: "Sequence[str] | None" = None,
+    actor: "QueueEventActor | None" = None,
     immediate: "bool" = False,
 ) -> "None":
     """Publish a custom event through the currently bound task context."""
     await require_current_task_context().event(
-        event_type, message=message, payload=payload, channels=channels, immediate=immediate
+        event_type, message=message, payload=payload, channels=channels, actor=actor, immediate=immediate
     )
 
 

--- a/src/litestar_queues/events/history.py
+++ b/src/litestar_queues/events/history.py
@@ -6,12 +6,22 @@ from typing import TYPE_CHECKING, Any, Protocol
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
     from datetime import datetime
 
     from litestar_queues.events.models import QueueEvent
 
-__all__ = ("RESERVED_EVENT_HISTORY_COLUMNS", "EventHistoryConfig", "EventHistoryExtraColumn", "QueueEventLog", "QueueEventLogRecord", "QueueEventStageSummary", "validate_event_history_extra_columns")
+__all__ = (
+    "RESERVED_EVENT_HISTORY_COLUMNS",
+    "EventHistoryConfig",
+    "EventHistoryExtraColumn",
+    "QueueEventLog",
+    "QueueEventLogRecord",
+    "QueueEventStageSummary",
+    "extract_event_extras",
+    "validate_event_extra_filter",
+    "validate_event_history_extra_columns",
+)
 
 
 def _is_unquoted_identifier_part(identifier: "str") -> "bool":
@@ -91,8 +101,6 @@ def validate_event_history_extra_columns(
         if not _is_unquoted_identifier_part(column.name):
             msg = f"Invalid SQL identifier in event_history_extra_columns: {column.name!r}"
             raise QueueConfigurationError(msg)
-        # Unquoted SQL identifiers fold case, so every name comparison below does
-        # too: ``TASK_ID`` and ``task_id`` are one column to the database.
         folded = column.name.lower()
         if folded in _EVENT_HISTORY_COLUMN_NAMES:
             msg = f"event_history_extra_columns may not redeclare package-owned column {column.name!r}"
@@ -114,6 +122,47 @@ def validate_event_history_extra_columns(
     return tuple(validated)
 
 
+def validate_event_extra_filter(
+    filter_map: "Mapping[str, str] | None", declared_columns: "Sequence[EventHistoryExtraColumn]"
+) -> "dict[str, str]":
+    """Validate and resolve extra column filter key-value pairs against declared columns.
+
+    Returns:
+        Mapping of resolved physical column names to expected filter values.
+
+    Raises:
+        QueueConfigurationError: If any filter key is not declared in declared_columns.
+    """
+    if not filter_map:
+        return {}
+    declared_map = {col.name.lower(): col.name for col in declared_columns}
+    resolved: "dict[str, str]" = {}
+    for key, value in filter_map.items():
+        folded = key.lower()
+        if folded not in declared_map:
+            msg = f"Undeclared event_history extra column in filter: {key!r}"
+            raise QueueConfigurationError(msg)
+        resolved[declared_map[folded]] = str(value)
+    return resolved
+
+
+def extract_event_extras(
+    payload: "Mapping[str, Any] | None", declared_columns: "Sequence[EventHistoryExtraColumn]"
+) -> "dict[str, str]":
+    """Extract declared extra columns from an event payload dict.
+
+    Returns:
+        Mapping of physical column names to extracted string values.
+    """
+    if not payload or not declared_columns:
+        return {}
+    extracted: "dict[str, str]" = {}
+    for col in declared_columns:
+        if col.source in payload and payload[col.source] is not None:
+            extracted[col.name] = str(payload[col.source])
+    return extracted
+
+
 @dataclass(slots=True)
 class EventHistoryConfig:
     """Configuration for backend-managed queue event history."""
@@ -130,6 +179,9 @@ class EventHistoryConfig:
     memory_capacity: "int" = 1000
     """Maximum retained records for the memory backend."""
 
+    extra_columns: "tuple[EventHistoryExtraColumn, ...]" = field(default_factory=tuple)
+    """Adopter-declared scoping columns on the event-history table."""
+
     def __post_init__(self) -> "None":
         """Validate event-history configuration."""
         if self.batch_size <= 0:
@@ -141,6 +193,7 @@ class EventHistoryConfig:
         if self.memory_capacity <= 0:
             msg = "EventHistoryConfig.memory_capacity must be greater than 0."
             raise QueueConfigurationError(msg)
+        self.extra_columns = validate_event_history_extra_columns(self.extra_columns)
 
 
 @dataclass(frozen=True, slots=True)
@@ -200,6 +253,7 @@ class QueueEventLog(Protocol):
         task_name: "str | None" = None,
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
+        extra: "Mapping[str, str] | None" = None,
         limit: "int | None" = None,
     ) -> "list[QueueEventLogRecord]":
         """Return durable event history records.

--- a/src/litestar_queues/events/history.py
+++ b/src/litestar_queues/events/history.py
@@ -1,16 +1,117 @@
 """Backend-owned queue event history contracts."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import datetime
 
     from litestar_queues.events.models import QueueEvent
 
-__all__ = ("EventHistoryConfig", "QueueEventLog", "QueueEventLogRecord", "QueueEventStageSummary")
+__all__ = ("RESERVED_EVENT_HISTORY_COLUMNS", "EventHistoryConfig", "EventHistoryExtraColumn", "QueueEventLog", "QueueEventLogRecord", "QueueEventStageSummary", "validate_event_history_extra_columns")
+
+
+def _is_unquoted_identifier_part(identifier: "str") -> "bool":
+    """Return whether an identifier part is safe unquoted text."""
+    return (
+        identifier.isascii()
+        and bool(identifier)
+        and (identifier[0].isalpha() or identifier[0] == "_")
+        and all(character.isalnum() or character == "_" for character in identifier)
+    )
+
+
+_EVENT_HISTORY_COLUMN_NAMES = frozenset({
+    "event_id",
+    "event_type",
+    "task_id",
+    "task_name",
+    "queue",
+    "worker_id",
+    "execution_backend",
+    "execution_profile",
+    "actor_type",
+    "actor_id",
+    "stage",
+    "level",
+    "message",
+    "detail",
+    "progress_current",
+    "progress_total",
+    "progress_percent",
+    "duration_ms",
+    "sequence",
+    "occurred_at",
+    "created_at",
+})
+
+
+RESERVED_EVENT_HISTORY_COLUMNS = frozenset({"entity", "scope", "scope_key"})
+"""Names held for built-in event-history scoping dimensions.
+
+These are not columns on the table yet. They are reserved so an adopter-declared
+extra column cannot claim a name the package intends to own.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class EventHistoryExtraColumn:
+    """Adopter-declared scoping column on the SQLSpec event-history table."""
+
+    name: "str"
+    """Physical column name; must be a valid unquoted SQL identifier."""
+
+    source: "str"
+    """Key looked up in the event payload (``QueueEvent.payload``)."""
+
+    indexed: "bool" = False
+    """Whether a ``(name, occurred_at)`` index is created."""
+
+
+def validate_event_history_extra_columns(
+    columns: "Sequence[EventHistoryExtraColumn]",
+) -> "tuple[EventHistoryExtraColumn, ...]":
+    """Validate adopter-declared extra event-history columns.
+
+    Returns:
+        The validated declarations as a tuple.
+
+    Raises:
+        QueueConfigurationError: If a name is not a valid unquoted SQL
+            identifier, collides with a package-owned column, uses a reserved
+            scoping-dimension name, repeats another declaration, or the payload
+            source key is empty.
+    """
+    seen: "set[str]" = set()
+    validated: "list[EventHistoryExtraColumn]" = []
+    for column in columns:
+        if not _is_unquoted_identifier_part(column.name):
+            msg = f"Invalid SQL identifier in event_history_extra_columns: {column.name!r}"
+            raise QueueConfigurationError(msg)
+        # Unquoted SQL identifiers fold case, so every name comparison below does
+        # too: ``TASK_ID`` and ``task_id`` are one column to the database.
+        folded = column.name.lower()
+        if folded in _EVENT_HISTORY_COLUMN_NAMES:
+            msg = f"event_history_extra_columns may not redeclare package-owned column {column.name!r}"
+            raise QueueConfigurationError(msg)
+        if folded in RESERVED_EVENT_HISTORY_COLUMNS:
+            msg = (
+                f"event_history_extra_columns may not use {column.name!r}: "
+                f"{sorted(RESERVED_EVENT_HISTORY_COLUMNS)!r} are reserved for built-in scoping dimensions"
+            )
+            raise QueueConfigurationError(msg)
+        if folded in seen:
+            msg = f"Duplicate column in event_history_extra_columns: {column.name!r}"
+            raise QueueConfigurationError(msg)
+        if not column.source:
+            msg = f"event_history_extra_columns entry {column.name!r} requires a non-empty payload source key"
+            raise QueueConfigurationError(msg)
+        seen.add(folded)
+        validated.append(column)
+    return tuple(validated)
 
 
 @dataclass(slots=True)
@@ -67,6 +168,7 @@ class QueueEventLogRecord:
     sequence: "int | None"
     occurred_at: "datetime"
     created_at: "datetime"
+    extra: "dict[str, str]" = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -23,7 +23,7 @@ from litestar_queues._identity import IDENTITY_VERSION, arguments_identity, task
 from litestar_queues.backends.base import interruption_count
 from litestar_queues.config import execution_backend_name, queue_backend_name
 from litestar_queues.events.context import TaskExecutionContext, bind_task_context
-from litestar_queues.events.models import QueueEvent
+from litestar_queues.events.models import QueueEvent, QueueEventActor
 from litestar_queues.events.producer import QueueEventProducer
 from litestar_queues.events.sinks import _call_optional_lifecycle, _select_lifecycle_error
 from litestar_queues.exceptions import JobCancelledError, NonRetryableError, QueueConfigurationError
@@ -746,6 +746,7 @@ class QueueService:
         runtime = self.observability_runtime
         telemetry = _start_execution_observability(runtime, record, worker_id=worker_id)
         task_context = _task_execution_context(record, worker_id=worker_id, event_publisher=self.get_event_publisher())
+        task_context.actor = _resolve_task_actor(task_obj)
         execution_scope = _bind_execution_context(task_context, record.metadata)
         final_status = "failed"
         try:
@@ -1458,6 +1459,28 @@ def _task_execution_context(
         attempt=record.retry_count + 1,
         event_publisher=event_publisher,
     )
+
+
+def _resolve_task_actor(task_obj: "Task[Any, Any]") -> "QueueEventActor | None":
+    """Resolve a task's declared actor for this attempt.
+
+    Returns:
+        The resolved actor, or ``None`` when the task declares none.
+
+    Raises:
+        QueueConfigurationError: If a declared resolver returns a non-actor.
+    """
+    declared = task_obj.actor
+    if declared is None or isinstance(declared, QueueEventActor):
+        return declared
+    resolved = declared()
+    if not isinstance(resolved, QueueEventActor):
+        msg = (
+            f"@task(actor=...) resolver for {task_obj.name!r} returned "
+            f"{type(resolved).__name__}; QueueEventActor is required."
+        )
+        raise QueueConfigurationError(msg)
+    return resolved
 
 
 def _capture_enqueue_context(runtime: "QueueObservabilityRuntimeProtocol", metadata: "dict[str, Any]") -> "None":

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -1473,7 +1473,7 @@ def _resolve_task_actor(task_obj: "Task[Any, Any]") -> "QueueEventActor | None":
     declared = task_obj.actor
     if declared is None or isinstance(declared, QueueEventActor):
         return declared
-    resolved = declared()
+    resolved: Any = declared()
     if not isinstance(resolved, QueueEventActor):
         msg = (
             f"@task(actor=...) resolver for {task_obj.name!r} returned "

--- a/src/litestar_queues/task.py
+++ b/src/litestar_queues/task.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from types import ModuleType
     from uuid import UUID
 
-    from litestar_queues.events import TaskExecutionContext
+    from litestar_queues.events import QueueEventActor, TaskExecutionContext
     from litestar_queues.models import QueuedTaskRecord, TaskStatus
     from litestar_queues.service import QueueService
 
@@ -414,6 +414,7 @@ class Task(Generic[P, T]):
 
     __slots__ = (
         "__dict__",
+        "_actor",
         "_description",
         "_execution_backend",
         "_execution_profile",
@@ -461,6 +462,7 @@ class Task(Generic[P, T]):
         requeue_on_shutdown: "bool | None" = None,
         on_stale_failure: "StaleFailureHandler | None" = None,
         sync_to_thread: "bool | None" = None,
+        actor: "QueueEventActor | Callable[[], QueueEventActor] | None" = None,
     ) -> "None":
         _validate_uniqueness(name=name, key=key, unique_by=unique_by, unique_until=unique_until)
         self._sync_to_thread = sync_to_thread
@@ -484,6 +486,7 @@ class Task(Generic[P, T]):
         self._requeue_on_stale = requeue_on_stale
         self._requeue_on_shutdown = requeue_on_shutdown
         self._on_stale_failure = on_stale_failure
+        self._actor = actor
 
     @property
     def name(self) -> "str":
@@ -598,6 +601,11 @@ class Task(Generic[P, T]):
         inline on the event loop.
         """
         return self._sync_to_thread
+
+    @property
+    def actor(self) -> "QueueEventActor | Callable[[], QueueEventActor] | None":
+        """Task-specific declared actor or actor resolver."""
+        return self._actor
 
     async def __call__(self, *args: "P.args", **kwargs: "P.kwargs") -> "T":
         """Execute the wrapped callable directly.
@@ -869,6 +877,7 @@ def task(
     requeue_on_shutdown: "bool | None" = None,
     on_stale_failure: "StaleFailureHandler | None" = None,
     sync_to_thread: "bool | None" = None,
+    actor: "QueueEventActor | Callable[[], QueueEventActor] | None" = None,
     cron: "str | None" = None,
     interval: "float | timedelta | None" = None,
     timezone: "str" = "UTC",
@@ -900,6 +909,7 @@ def task(
     requeue_on_shutdown: "bool | None" = None,
     on_stale_failure: "StaleFailureHandler | None" = None,
     sync_to_thread: "bool | None" = None,
+    actor: "QueueEventActor | Callable[[], QueueEventActor] | None" = None,
     cron: "str | None" = None,
     interval: "float | timedelta | None" = None,
     timezone: "str" = "UTC",
@@ -958,6 +968,7 @@ def task(
             requeue_on_shutdown=requeue_on_shutdown,
             on_stale_failure=on_stale_failure,
             sync_to_thread=sync_to_thread,
+            actor=actor,
         )
         _task_registry[task_name] = task_obj
         if schedule is not None:

--- a/src/tests/integration/_event_extra_contract.py
+++ b/src/tests/integration/_event_extra_contract.py
@@ -1,0 +1,77 @@
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEvent, QueueEventActor
+from litestar_queues.exceptions import QueueConfigurationError
+
+if TYPE_CHECKING:
+    from litestar_queues.backends import BaseQueueBackend
+
+
+def _event(
+    *, task_id: "str", actor: "QueueEventActor | None" = None, payload: "dict[str, Any] | None" = None
+) -> "QueueEvent":
+    return QueueEvent(
+        type="task.log",
+        scope="task",
+        task_id=task_id,
+        task_name="test.task",
+        queue="default",
+        worker_id="w-1",
+        execution_backend="local",
+        execution_profile=None,
+        attempt=1,
+        sequence=1,
+        actor=actor,
+        payload=dict(payload or {}),
+    )
+
+
+async def _bootstrap_if_sqlspec(queue_backend: "BaseQueueBackend", config: "EventHistoryConfig") -> "None":
+    if hasattr(queue_backend, "_session") and hasattr(queue_backend, "_get_event_log_store"):
+        store = queue_backend._get_event_log_store(extra_columns=config.extra_columns)
+        async with queue_backend._session() as driver:
+            for stmt in store.create_statements():
+                await driver.execute_script(stmt)
+            await driver.commit()
+
+
+async def assert_event_extra_contract(queue_backend: "BaseQueueBackend") -> "None":
+    """Every backend filters declared extras identically and rejects undeclared names."""
+    config = EventHistoryConfig(
+        batch_size=1, flush_interval=0.1, extra_columns=(EventHistoryExtraColumn(name="tenant", source="tenant_id"),)
+    )
+    await _bootstrap_if_sqlspec(queue_backend, config)
+    log = queue_backend.get_event_log(config)
+    assert log is not None
+    await log.publish_event(_event(task_id="a", payload={"tenant_id": "acme"}))
+    await log.publish_event(_event(task_id="b", payload={"tenant_id": "other"}))
+    await log.flush_events()
+
+    matched = await log.list_events(extra={"tenant": "acme"})
+    assert [r.task_id for r in matched] == ["a"]
+    assert matched[0].extra == {"tenant": "acme"}
+
+    assert await log.list_events(extra={"tenant": "missing"}) == []
+
+    with pytest.raises(QueueConfigurationError):
+        await log.list_events(extra={"undeclared": "x"})
+
+
+async def assert_event_actor_contract(queue_backend: "BaseQueueBackend") -> "None":
+    """Attach, persist, filter: the actor round-trips on every backend."""
+    config = EventHistoryConfig(batch_size=1, flush_interval=0.1)
+    await _bootstrap_if_sqlspec(queue_backend, config)
+    log = queue_backend.get_event_log(config)
+    assert log is not None
+    await log.publish_event(_event(task_id="a", actor=QueueEventActor(type="user", id="u1")))
+    await log.publish_event(_event(task_id="b", actor=QueueEventActor(type="user", id="u2")))
+    await log.flush_events()
+
+    matched_id = await log.list_events(actor_id="u1")
+    assert [r.task_id for r in matched_id] == ["a"]
+    assert matched_id[0].actor_type == "user"
+
+    matched_type = await log.list_events(actor_type="user")
+    assert {r.task_id for r in matched_type} >= {"a", "b"}

--- a/src/tests/integration/backends/sqlspec/test_event_log_extra_columns.py
+++ b/src/tests/integration/backends/sqlspec/test_event_log_extra_columns.py
@@ -13,6 +13,7 @@ from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
 from litestar_queues.backends.sqlspec.event_log import create_event_log_store
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME, configure_queue_migration_extension
 from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEventsConfig, publish_task_log
+from litestar_queues.exceptions import QueueConfigurationError
 from litestar_queues.task import clear_task_registry
 from tests.integration._names import table_name_for_test
 from tests.integration.backends.sqlspec._schema import bootstrap_queue_schema
@@ -72,7 +73,7 @@ async def _run_scoped_task(config: "Any", *, tenants: "tuple[str, ...]") -> "lis
         await publish_task_log("scoped", payload={"tenant_id": tenant, "stage": "load", "note": "kept"})
         return tenant
 
-    history = EventHistoryConfig(batch_size=1, flush_interval=60)
+    history = EventHistoryConfig(batch_size=1, flush_interval=60, extra_columns=(_TENANT_COLUMN,))
     backend_config = SQLSpecBackendConfig(sqlspec_config=config, event_history_extra_columns=(_TENANT_COLUMN,))
     await bootstrap_queue_schema(backend_config, event_history_enabled=True)
     queue_config = QueueConfig(
@@ -92,7 +93,7 @@ async def _run_scoped_task(config: "Any", *, tenants: "tuple[str, ...]") -> "lis
         scoped = await event_log.list_events(extra={"tenant_id": tenants[0]})
         everything = await event_log.list_events()
 
-        with pytest.raises(ValueError, match="tenant_id"):
+        with pytest.raises(QueueConfigurationError):
             await event_log.list_events(extra={"unknown": "x"})
 
     assert len(everything) > len(scoped)

--- a/src/tests/integration/backends/sqlspec/test_event_log_extra_columns.py
+++ b/src/tests/integration/backends/sqlspec/test_event_log_extra_columns.py
@@ -9,10 +9,10 @@ import pytest
 pytest.importorskip("sqlspec")
 
 from litestar_queues import QueueConfig, QueueService, WorkerConfig, task
-from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
 from litestar_queues.backends.sqlspec.event_log import create_event_log_store
 from litestar_queues.backends.sqlspec.extension import QUEUE_EXTENSION_NAME, configure_queue_migration_extension
-from litestar_queues.events import EventHistoryConfig, QueueEventsConfig, publish_task_log
+from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEventsConfig, publish_task_log
 from litestar_queues.task import clear_task_registry
 from tests.integration._names import table_name_for_test
 from tests.integration.backends.sqlspec._schema import bootstrap_queue_schema

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -840,3 +840,15 @@ async def test_backend_contract_stale_requeue_priority_policy(queue_backend: "Ba
     from tests.integration._interrupt_contract import assert_stale_requeue_priority_policy
 
     await assert_stale_requeue_priority_policy(queue_backend)
+
+
+async def test_backend_contract_event_extra(queue_backend: "BaseQueueBackend") -> "None":
+    from tests.integration._event_extra_contract import assert_event_extra_contract
+
+    await assert_event_extra_contract(queue_backend)
+
+
+async def test_backend_contract_event_actor(queue_backend: "BaseQueueBackend") -> "None":
+    from tests.integration._event_extra_contract import assert_event_actor_contract
+
+    await assert_event_actor_contract(queue_backend)

--- a/src/tests/unit/backends/test_ephemeral_event_log_extras.py
+++ b/src/tests/unit/backends/test_ephemeral_event_log_extras.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from litestar_queues.backends.ephemeral import EphemeralQueueBackend
@@ -6,11 +8,14 @@ from litestar_queues.backends.ephemeral.server import EphemeralServerContext
 from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEvent
 from litestar_queues.exceptions import QueueConfigurationError
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture
-def server_context() -> "EphemeralServerContext":
+def server_context() -> "Iterator[EphemeralServerContext]":
     with EphemeralServerContext(nonce="test-nonce") as context:
         yield context
 

--- a/src/tests/unit/backends/test_ephemeral_event_log_extras.py
+++ b/src/tests/unit/backends/test_ephemeral_event_log_extras.py
@@ -1,0 +1,36 @@
+import pytest
+
+from litestar_queues.backends.ephemeral import EphemeralQueueBackend
+from litestar_queues.backends.ephemeral.event_log import EphemeralQueueEventLog
+from litestar_queues.backends.ephemeral.server import EphemeralServerContext
+from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEvent
+from litestar_queues.exceptions import QueueConfigurationError
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def server_context() -> "EphemeralServerContext":
+    with EphemeralServerContext(nonce="test-nonce") as context:
+        yield context
+
+
+async def test_ephemeral_filters_declared_extra(server_context: "EphemeralServerContext") -> "None":
+    config = EventHistoryConfig(extra_columns=(EventHistoryExtraColumn(name="tenant", source="tenant_id"),))
+    backend = EphemeralQueueBackend()
+    await backend.open()
+    try:
+        log = EphemeralQueueEventLog(config, backend=backend)
+        await log.publish_event(
+            QueueEvent(type="task.started", scope="task", task_id="a", payload={"tenant_id": "acme"})
+        )
+        await log.publish_event(
+            QueueEvent(type="task.started", scope="task", task_id="b", payload={"tenant_id": "other"})
+        )
+
+        events = await log.list_events(extra={"tenant": "acme"})
+        assert [r.task_id for r in events] == ["a"]
+        with pytest.raises(QueueConfigurationError):
+            await log.list_events(extra={"project": "x"})
+    finally:
+        await backend.close()

--- a/src/tests/unit/backends/test_memory_event_log_extras.py
+++ b/src/tests/unit/backends/test_memory_event_log_extras.py
@@ -1,0 +1,19 @@
+import pytest
+
+from litestar_queues.backends.memory.event_log import InMemoryQueueEventLog
+from litestar_queues.events import EventHistoryConfig, EventHistoryExtraColumn, QueueEvent
+from litestar_queues.exceptions import QueueConfigurationError
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_memory_filters_declared_extra() -> "None":
+    config = EventHistoryConfig(extra_columns=(EventHistoryExtraColumn(name="tenant", source="tenant_id"),))
+    log = InMemoryQueueEventLog(config)
+    await log.publish_event(QueueEvent(type="task.started", scope="task", task_id="a", payload={"tenant_id": "acme"}))
+    await log.publish_event(QueueEvent(type="task.started", scope="task", task_id="b", payload={"tenant_id": "other"}))
+
+    events = await log.list_events(extra={"tenant": "acme"})
+    assert [r.task_id for r in events] == ["a"]
+    with pytest.raises(QueueConfigurationError):
+        await log.list_events(extra={"project": "x"})

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -225,7 +225,7 @@ def test_select_events_filters_on_actor() -> "None":
 def test_select_events_rejects_undeclared_extra_filter() -> "None":
     store = _store(_TENANT)
 
-    with pytest.raises(ValueError, match="tenant_id"):
+    with pytest.raises(QueueConfigurationError):
         store.select_events(extra={"unknown": "x"})  # type: ignore[attr-defined]
 
 

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -197,10 +197,13 @@ def test_mssql_event_history_bypasses_sqlglot_for_native_datetime_type() -> "Non
     assert all("CREATE INDEX IF NOT EXISTS" not in statement for statement in statements[1:])
 
 
-def test_oracle_event_history_quotes_reserved_level_column() -> "None":
+def test_oracle_event_history_prefixes_reserved_level_column() -> "None":
     statements = _store_for_dialect("oracle").create_statements()  # type: ignore[attr-defined]
 
-    assert '"LEVEL" VARCHAR(255)' in statements[0]
+    store = _store_for_dialect("oracle")
+    assert '"event_level" VARCHAR(255)' in statements[0]
+    assert '"event_level"' in store.insert_events_template()  # type: ignore[attr-defined]
+    assert "event_level AS level" in store.select_events().build(dialect="oracle").sql  # type: ignore[attr-defined]
     assert '("task_id", "sequence", "occurred_at")' in statements[1]
 
 

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -9,9 +9,10 @@ from typing import TYPE_CHECKING
 
 from sqlspec.adapters.aiosqlite import AiosqliteConfig
 
-from litestar_queues.backends.sqlspec import EventHistoryExtraColumn, SQLSpecBackendConfig
+from litestar_queues.backends.sqlspec import SQLSpecBackendConfig
 from litestar_queues.backends.sqlspec.event_log import create_event_log_store
-from litestar_queues.backends.sqlspec.schema import EVENT_HISTORY_COLUMNS, validate_event_history_extra_columns
+from litestar_queues.backends.sqlspec.schema import EVENT_HISTORY_COLUMNS
+from litestar_queues.events import EventHistoryExtraColumn, validate_event_history_extra_columns
 from litestar_queues.exceptions import QueueConfigurationError
 
 if TYPE_CHECKING:

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -203,7 +203,9 @@ def test_oracle_event_history_prefixes_reserved_level_column() -> "None":
     store = _store_for_dialect("oracle")
     assert '"event_level" VARCHAR(255)' in statements[0]
     assert '"event_level"' in store.insert_events_template()  # type: ignore[attr-defined]
-    assert "event_level AS level" in store.select_events().build(dialect="oracle").sql  # type: ignore[attr-defined]
+    selected = store.select_events().build(dialect="oracle").sql  # type: ignore[attr-defined]
+    assert "event_level" in selected
+    assert "event_level AS level" not in selected
     assert '("task_id", "sequence", "occurred_at")' in statements[1]
 
 

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -27,6 +27,12 @@ def _store(*extra: "EventHistoryExtraColumn") -> "object":
     )
 
 
+def _store_for_dialect(dialect: "str") -> "object":
+    config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    config.statement_config.dialect = dialect
+    return create_event_log_store(config, queue_table_name="queue_task")
+
+
 def test_extra_column_declaration_validates() -> "None":
     columns = (EventHistoryExtraColumn(name="tenant_id", source="tenant_id", indexed=True),)
 
@@ -163,6 +169,29 @@ def test_store_without_extras_emits_unchanged_statements() -> "None":
     assert not any("tenant_id" in statement for statement in statements)
     assert "tenant_id" not in template
     assert template.count(":") == len(EVENT_HISTORY_COLUMNS)
+
+
+def test_mysql_event_history_uses_inline_indexes_and_backtick_quoting() -> "None":
+    statements = _store_for_dialect("mysql").create_statements()  # type: ignore[attr-defined]
+
+    assert len(statements) == 1
+    assert statements[0].startswith("CREATE TABLE IF NOT EXISTS `queue_task_event_history`")
+    assert "INDEX `ix_queue_task_event_history_task_id`" in statements[0]
+    assert "CREATE INDEX IF NOT EXISTS" not in statements[0]
+
+
+def test_mssql_event_history_bypasses_sqlglot_for_native_datetime_type() -> "None":
+    statements = _store_for_dialect("tsql").create_statements()  # type: ignore[attr-defined]
+
+    assert statements[0].lstrip().startswith("IF OBJECT_ID")
+    assert "DATETIME2(6)" in statements[0]
+    assert all("CREATE INDEX IF NOT EXISTS" not in statement for statement in statements[1:])
+
+
+def test_oracle_event_history_quotes_reserved_level_column() -> "None":
+    statements = _store_for_dialect("oracle").create_statements()  # type: ignore[attr-defined]
+
+    assert '"LEVEL" VARCHAR(255)' in statements[0]
 
 
 def test_extra_columns_appear_in_ddl_and_insert_template() -> "None":

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -180,6 +180,15 @@ def test_mysql_event_history_uses_inline_indexes_and_backtick_quoting() -> "None
     assert "CREATE INDEX IF NOT EXISTS" not in statements[0]
 
 
+def test_mysql_event_history_bounds_generated_index_names() -> "None":
+    config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    config.statement_config.dialect = "mysql"
+    store = create_event_log_store(config, queue_table_name="queue_task_mysql_aiomysql_637b5b4678")
+
+    assert len(store._index_name("occurred_at")) <= 63
+    assert store._quoted_index_name("occurred_at") in store.create_statements()[0]
+
+
 def test_mssql_event_history_bypasses_sqlglot_for_native_datetime_type() -> "None":
     statements = _store_for_dialect("tsql").create_statements()  # type: ignore[attr-defined]
 
@@ -192,6 +201,13 @@ def test_oracle_event_history_quotes_reserved_level_column() -> "None":
     statements = _store_for_dialect("oracle").create_statements()  # type: ignore[attr-defined]
 
     assert '"LEVEL" VARCHAR(255)' in statements[0]
+    assert '("task_id", "sequence", "occurred_at")' in statements[1]
+
+
+def test_spanner_event_history_uses_backtick_quoted_identifiers() -> "None":
+    statements = _store_for_dialect("spanner").create_statements()  # type: ignore[attr-defined]
+
+    assert statements[0].startswith("CREATE TABLE IF NOT EXISTS `queue_task_event_history`")
 
 
 def test_extra_columns_appear_in_ddl_and_insert_template() -> "None":

--- a/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
+++ b/src/tests/unit/backends/test_sqlspec_event_history_extra_columns.py
@@ -201,12 +201,12 @@ def test_oracle_event_history_prefixes_reserved_level_column() -> "None":
     statements = _store_for_dialect("oracle").create_statements()  # type: ignore[attr-defined]
 
     store = _store_for_dialect("oracle")
-    assert '"event_level" VARCHAR(255)' in statements[0]
-    assert '"event_level"' in store.insert_events_template()  # type: ignore[attr-defined]
+    assert "EVENT_LEVEL VARCHAR(255)" in statements[0]
+    assert "EVENT_LEVEL" in store.insert_events_template()  # type: ignore[attr-defined]
     selected = store.select_events().build(dialect="oracle").sql  # type: ignore[attr-defined]
     assert "event_level" in selected
     assert "event_level AS level" not in selected
-    assert '("task_id", "sequence", "occurred_at")' in statements[1]
+    assert "(TASK_ID, SEQUENCE, OCCURRED_AT)" in statements[1]
 
 
 def test_spanner_event_history_uses_backtick_quoted_identifiers() -> "None":

--- a/src/tests/unit/test_event_history_extras.py
+++ b/src/tests/unit/test_event_history_extras.py
@@ -2,10 +2,9 @@ from litestar_queues.events import EventHistoryExtraColumn, validate_event_histo
 
 
 def test_extra_column_is_public_from_events() -> "None":
-    (column,) = validate_event_history_extra_columns(
-        [EventHistoryExtraColumn(name="tenant", source="tenant_id")]
-    )
+    (column,) = validate_event_history_extra_columns([EventHistoryExtraColumn(name="tenant", source="tenant_id")])
     assert (column.name, column.source, column.indexed) == ("tenant", "tenant_id", False)
+
 
 def test_sqlspec_no_longer_re_exports_the_declaration() -> "None":
     import litestar_queues.backends.sqlspec as sqlspec_backend

--- a/src/tests/unit/test_event_history_extras.py
+++ b/src/tests/unit/test_event_history_extras.py
@@ -1,0 +1,13 @@
+from litestar_queues.events import EventHistoryExtraColumn, validate_event_history_extra_columns
+
+
+def test_extra_column_is_public_from_events() -> "None":
+    (column,) = validate_event_history_extra_columns(
+        [EventHistoryExtraColumn(name="tenant", source="tenant_id")]
+    )
+    assert (column.name, column.source, column.indexed) == ("tenant", "tenant_id", False)
+
+def test_sqlspec_no_longer_re_exports_the_declaration() -> "None":
+    import litestar_queues.backends.sqlspec as sqlspec_backend
+
+    assert not hasattr(sqlspec_backend, "EventHistoryExtraColumn")

--- a/src/tests/unit/test_event_log_protocol.py
+++ b/src/tests/unit/test_event_log_protocol.py
@@ -1,0 +1,9 @@
+import inspect
+
+from litestar_queues.events.history import QueueEventLog
+
+
+def test_protocol_declares_extra() -> "None":
+    signature = inspect.signature(QueueEventLog.list_events)
+    assert "extra" in signature.parameters
+    assert signature.parameters["extra"].default is None

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -1228,8 +1228,9 @@ class _RecordingEventLog:
         actor_id: "str | None" = None,
         actor_type: "str | None" = None,
         limit: "int | None" = None,
+        extra: "Mapping[str, str] | None" = None,
     ) -> "list[QueueEventLogRecord]":
-        del task_id, task_name, actor_id, actor_type, limit
+        del task_id, task_name, actor_id, actor_type, limit, extra
         return []
 
     async def summarize_stages(self, *, task_name: "str | None" = None) -> "list[QueueEventStageSummary]":

--- a/src/tests/unit/test_task_actor.py
+++ b/src/tests/unit/test_task_actor.py
@@ -1,0 +1,107 @@
+from typing import Any
+
+import pytest
+
+from litestar_queues import QueueConfig, QueueService, WorkerConfig, task
+from litestar_queues.backends.memory import InMemoryQueueBackend
+from litestar_queues.events import (
+    EventBufferConfig,
+    InMemoryQueueEventSink,
+    QueueEventActor,
+    QueueEventPublisher,
+    require_current_task_context,
+)
+from litestar_queues.exceptions import QueueConfigurationError
+
+pytestmark = pytest.mark.anyio
+
+
+def test_decorator_stores_literal_actor() -> "None":
+    actor = QueueEventActor(type="system", id="cron")
+
+    @task(actor=actor)
+    async def work() -> None: ...
+
+    assert work.actor is actor
+
+
+def test_decorator_stores_callable_without_calling_it() -> "None":
+    calls: list[int] = []
+
+    def resolver() -> QueueEventActor:
+        calls.append(1)
+        return QueueEventActor(type="user", id="u1")
+
+    @task(actor=resolver)
+    async def work() -> None: ...
+
+    assert calls == []
+    assert work.actor is resolver
+
+
+async def _execute_task_in_service(task_obj: "Any") -> "list[Any]":
+    sink = InMemoryQueueEventSink()
+    publisher = QueueEventPublisher(sink, buffer_config=EventBufferConfig())
+    backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="server")), queue_backend=backend, event_publisher=publisher
+    )
+    record = await backend.enqueue(task_obj.name)
+    await service.execute_record(record, worker_id="test-worker")
+    return list(sink.events)
+
+
+async def test_actor_resolved_once_before_body_runs() -> "None":
+    seen: list[str | None] = []
+
+    @task(actor=lambda: QueueEventActor(type="user", id="u1"))
+    async def work_with_actor() -> None:
+        ctx = require_current_task_context()
+        seen.append(ctx.actor.id if ctx.actor is not None else None)
+
+    await _execute_task_in_service(work_with_actor)
+    assert seen == ["u1"]
+
+
+async def test_raising_resolver_fails_the_attempt() -> "None":
+    def failing_resolver() -> QueueEventActor:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    @task(actor=failing_resolver)
+    async def work_failing_resolver() -> None: ...
+
+    sink = InMemoryQueueEventSink()
+    publisher = QueueEventPublisher(sink, buffer_config=EventBufferConfig())
+    backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="server")), queue_backend=backend, event_publisher=publisher
+    )
+    record = await backend.enqueue(work_failing_resolver.name)
+    with pytest.raises(RuntimeError, match="boom"):
+        await service.execute_record(record, worker_id="test-worker")
+
+
+async def test_resolver_returning_non_actor_raises_configuration_error() -> "None":
+    @task(actor=lambda: "nope")  # type: ignore[arg-type,return-value]
+    async def work_invalid_actor() -> None: ...
+
+    sink = InMemoryQueueEventSink()
+    publisher = QueueEventPublisher(sink, buffer_config=EventBufferConfig())
+    backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="server")), queue_backend=backend, event_publisher=publisher
+    )
+    record = await backend.enqueue(work_invalid_actor.name)
+    with pytest.raises(QueueConfigurationError, match=work_invalid_actor.name):
+        await service.execute_record(record, worker_id="test-worker")
+
+
+async def test_every_lifecycle_event_carries_the_declared_actor() -> "None":
+    @task(actor=QueueEventActor(type="user", id="u1"))
+    async def work_lifecycle() -> None: ...
+
+    events = await _execute_task_in_service(work_lifecycle)
+    lifecycle = [e for e in events if e.type in {"task.started", "task.completed"}]
+    assert lifecycle, "no lifecycle events captured"
+    assert all(e.actor is not None and e.actor.id == "u1" for e in lifecycle)

--- a/src/tests/unit/test_task_context_actor.py
+++ b/src/tests/unit/test_task_context_actor.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 
 from litestar_queues.events import (
@@ -88,7 +90,7 @@ async def test_convenience_methods_forward_actor(method_name: "str") -> "None":
 
 async def test_module_helpers_accept_actor() -> "None":
     context = _make_context()
-    sink = context.event_publisher._sink  # type: ignore[attr-defined]
+    sink = cast("InMemoryQueueEventSink", context.event_publisher._sink)
     with bind_task_context(context):
         await publish_task_progress(current=1, total=2, actor=QueueEventActor(type="user", id="u1"), immediate=True)
         await publish_task_log("hello", actor=QueueEventActor(type="user", id="u2"), immediate=True)

--- a/src/tests/unit/test_task_context_actor.py
+++ b/src/tests/unit/test_task_context_actor.py
@@ -1,0 +1,97 @@
+import pytest
+
+from litestar_queues.events import (
+    EventBufferConfig,
+    InMemoryQueueEventSink,
+    QueueEventActor,
+    QueueEventPublisher,
+    TaskExecutionContext,
+    bind_task_context,
+    publish_task_event,
+    publish_task_log,
+    publish_task_progress,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _make_context() -> "TaskExecutionContext":
+    sink = InMemoryQueueEventSink()
+    publisher = QueueEventPublisher(sink, buffer_config=EventBufferConfig())
+    return TaskExecutionContext(
+        task_id="t-1",
+        task_name="test_task",
+        queue="default",
+        worker_id="w-1",
+        execution_backend="memory",
+        execution_profile=None,
+        attempt=1,
+        event_publisher=publisher,
+    )
+
+
+def test_context_actor_defaults_to_none() -> "None":
+    context = _make_context()
+    assert context.actor is None
+
+
+def test_context_actor_is_assignable() -> "None":
+    context = _make_context()
+    context.actor = QueueEventActor(type="user", id="u1")
+    assert context.actor.id == "u1"
+
+
+async def test_publish_stamps_per_call_actor() -> "None":
+    context = _make_context()
+    event = await context.publish("custom", actor=QueueEventActor(type="user", id="u1"))
+    assert event.actor is not None and event.actor.id == "u1"
+
+
+async def test_publish_falls_back_to_context_actor() -> "None":
+    context = _make_context()
+    context.actor = QueueEventActor(type="service", id="s1")
+    event = await context.publish("custom")
+    assert event.actor is not None and event.actor.id == "s1"
+
+
+async def test_per_call_actor_overrides_context() -> "None":
+    context = _make_context()
+    context.actor = QueueEventActor(type="service", id="s1")
+    event = await context.publish("custom", actor=QueueEventActor(type="user", id="u1"))
+    assert event.actor is not None and event.actor.id == "u1"
+
+
+async def test_no_actor_anywhere_leaves_it_unset() -> "None":
+    assert (await _make_context().publish("custom")).actor is None
+
+
+@pytest.mark.parametrize("method_name", ["progress", "log", "event"])
+async def test_convenience_methods_forward_actor(method_name: "str") -> "None":
+    context = _make_context()
+    context.actor = QueueEventActor(type="service", id="s1")
+    method = getattr(context, method_name)
+    if method_name == "progress":
+        await method(current=1, total=2, actor=QueueEventActor(type="user", id="u1"))
+    elif method_name == "log":
+        await method("log msg", actor=QueueEventActor(type="user", id="u1"))
+    elif method_name == "event":
+        await method("my.event", actor=QueueEventActor(type="user", id="u1"))
+
+    # When actor is omitted, inherits context actor
+    if method_name == "progress":
+        await method(current=2, total=2)
+    elif method_name == "log":
+        await method("second msg")
+    elif method_name == "event":
+        await method("second.event")
+
+
+async def test_module_helpers_accept_actor() -> "None":
+    context = _make_context()
+    sink = context.event_publisher._sink  # type: ignore[attr-defined]
+    with bind_task_context(context):
+        await publish_task_progress(current=1, total=2, actor=QueueEventActor(type="user", id="u1"), immediate=True)
+        await publish_task_log("hello", actor=QueueEventActor(type="user", id="u2"), immediate=True)
+        await publish_task_event("custom.done", actor=QueueEventActor(type="user", id="u3"), immediate=True)
+
+    assert [e.actor.id for e in sink.events if e.actor is not None] == ["u1", "u2", "u3"]


### PR DESCRIPTION
Closes #125

### Summary

Implements public actor attachment and cross-backend `extra=` query filtering across all queue event history backends.

### Key Changes
- **Backend-neutral extra columns**: Moved `EventHistoryExtraColumn` to `litestar_queues.events` and standardized extraction/validation helpers across all backends.
- **Protocol `extra=` filtering**: Added `extra: Mapping[str, str] | None` filtering to event log query operations across memory, ephemeral, SQLSpec, Advanced Alchemy, Redis, and Valkey.
- **Actor attachment**: Added `QueueEventActor` support on `TaskExecutionContext`, decorator `@task(actor=...)`, and per-call publishing methods (`publish`, `log`, `progress`, `event`).
- **Contract tests & documentation**: Added cross-backend contract suites verifying extra filtering and actor round-tripping, along with updated Sphinx documentation.