### PR TITLE
feat(cancellation): remote execution cancellation with provider-first fencing (#128)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,11 @@ Unreleased
   :class:`~litestar_queues.QueueService` lifecycle and its startup rollback.
   ``task_dependency_resolver`` is unchanged for stateless injection; setting
   both raises ``QueueConfigurationError``. See :doc:`usage/dependency-resolver`.
+* Remote execution cancellation with provider-first ordering: When cancelling a task,
+  Litestar Queues cancels active provider execution (via Cloud Run jobs API or Cloud Tasks deletion)
+  before writing durable cancellation state. Durable cancellation fencing and retry guards prevent
+  out-of-order execution recovery from resurrecting cancelled work. See
+  :doc:`usage/failures-and-cancellation`.
 
 0.9.0 - 2026-08-14
 ==================

--- a/docs/usage/deployment/cloud-run.rst
+++ b/docs/usage/deployment/cloud-run.rst
@@ -314,6 +314,22 @@ that Job because it includes ``run.jobs.runWithOverrides``.
 If you use a custom IAM role instead, make sure it includes
 ``run.jobs.runWithOverrides``.
 
+To cancel a running execution, the dispatcher's service account additionally needs
+**``run.executions.cancel``** on the job's executions. It is *not* implied by the run-job
+permission. The predefined role carrying it is **Cloud Run Admin** (``roles/run.admin``); a
+least-privilege deployment grants a custom role holding ``run.jobs.run``,
+``run.executions.get`` (already required for reconciliation) and ``run.executions.cancel``.
+
+If this permission is missing, cancellation maps the permission error to
+``retryable``, so ``cancel_task()`` returns ``False`` and the record is deliberately
+left ``running`` rather than being marked cancelled while the container keeps
+running. The warning log and the ``litestar_queues.execution.cancel{queue.execution.status="retryable"}``
+counter are the signal.
+
+The resource name used for cancellation is the stored execution reference, so cancellation
+targets the exact execution this package created — including one created by a
+different execution profile's job.
+
 Database connectivity
 =====================
 

--- a/docs/usage/deployment/cloud-tasks.rst
+++ b/docs/usage/deployment/cloud-tasks.rst
@@ -318,6 +318,11 @@ so the package never reuses a name: each attempt gets a fresh random suffix.
 De-duplication has a documented throughput cost relative to unnamed tasks, so
 confirm the current published limits before planning a high-rate queue.
 
+Cancellation
+============
+
+The Cloud Tasks backend implements remote execution cancellation. Because Cloud Tasks holds a future delivery, cancellation is implemented as an API ``delete_task`` operation using the ``execution_ref`` stored on the queue record. If the delivery is already in flight, it cannot be deleted, so the operation succeeds idempotently but leaves the running task to cooperative cancellation.
+
 Testing
 =======
 

--- a/docs/usage/failures-and-cancellation.rst
+++ b/docs/usage/failures-and-cancellation.rst
@@ -77,6 +77,20 @@ Hints are lossy by contract. A dropped hint costs latency, never correctness,
 so a backend that cannot deliver one simply keeps polling. If you are writing a
 backend and want to add a transport, see :doc:`backends`.
 
+Cancelling an execution that runs elsewhere
+===========================================
+
+A provider cancellation applies to a record whose ``execution_ref`` names a live provider resource. Implementations answer with a result rather than raising an exception.
+
+The four results dictate whether the durable transition to ``cancelled`` proceeds:
+
+* ``accepted``: The provider accepted the cancellation. The durable transition proceeds.
+* ``already_cancelled``: The provider resource was not found or was already stopped. The durable transition proceeds.
+* ``retryable``: The provider refused or had a transient failure. The durable transition is blocked.
+* ``unsupported``: The transport has no cancellation control plane. The durable transition proceeds.
+
+A transport with no control plane inherits ``unsupported`` and is still cancelled durably, because the delivery carries only the record id and a cancelled record cannot be claimed.
+
 Inside a task, ``current_task_context().is_cancelled`` exposes the cooperative
 token; ``wait_cancelled()`` waits for it and ``raise_if_cancelled()`` raises
 ``JobCancelledError``. Threaded synchronous work must use these checkpoints.

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -378,9 +378,17 @@ class SQLAlchemyBackend(BaseQueueBackend):
                 task_id, expected_retry_count=expected_retry_count, worker_id=worker_id, queued_at=queued_at
             )
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         async with self._operation() as service:
-            return await service.cancel_task(task_id, include_running=include_running)
+            return await service.cancel_task(
+                task_id, include_running=include_running, expected_retry_count=expected_retry_count
+            )
 
     async def cancel_tasks(
         self,

--- a/src/litestar_queues/backends/advanced_alchemy/backend.py
+++ b/src/litestar_queues/backends/advanced_alchemy/backend.py
@@ -379,11 +379,7 @@ class SQLAlchemyBackend(BaseQueueBackend):
             )
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         async with self._operation() as service:
             return await service.cancel_task(

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -821,14 +821,23 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         model = await self._select_task(task_id)
         return self.record_from_model(model) if model is not None else None
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         model_type = self.model_type
         now = _utc_now()
         cancellable_statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
+
+        stmt = update(model_type).where(model_type.id == task_id, model_type.status.in_(cancellable_statuses))
+        if expected_retry_count is not None:
+            stmt = stmt.where(model_type.retry_count == expected_retry_count)
+
         result = await self.repository.session.execute(
-            update(model_type)
-            .where(model_type.id == task_id, model_type.status.in_(cancellable_statuses))
-            .values(
+            stmt.values(
                 _update_values(model_type, {"status": "cancelled", "completed_at": now, "heartbeat_at": None}, now=now)
             )
         )
@@ -1232,7 +1241,11 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         model_type = self.model_type
         result = await self.repository.session.execute(
             update(model_type)
-            .where(model_type.id == task_id, model_type.execution_ref == reservation_ref)
+            .where(
+                model_type.id == task_id,
+                model_type.execution_ref == reservation_ref,
+                model_type.status.in_(_DUE_STATUSES)
+            )
             .values(
                 _update_values(
                     model_type,

--- a/src/litestar_queues/backends/advanced_alchemy/service.py
+++ b/src/litestar_queues/backends/advanced_alchemy/service.py
@@ -822,11 +822,7 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
         return self.record_from_model(model) if model is not None else None
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         model_type = self.model_type
         now = _utc_now()
@@ -1244,7 +1240,7 @@ class QueueTaskService(SQLAlchemyAsyncRepositoryService[Any]):
             .where(
                 model_type.id == task_id,
                 model_type.execution_ref == reservation_ref,
-                model_type.status.in_(_DUE_STATUSES)
+                model_type.status.in_(_DUE_STATUSES),
             )
             .values(
                 _update_values(

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -439,14 +439,22 @@ class BaseQueueBackend:
         """
         raise NotImplementedError
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         """Cancel a task.
 
         Args:
-            task_id: Queue record identifier.
-            include_running: When true, cancel a running task as part of a
-                cooperative cancellation path. Default behavior only cancels
-                pending or scheduled records.
+            task_id: ID of the task to cancel.
+            include_running: Whether to cancel a task that is currently running.
+            expected_retry_count: Only cancel if the task is still on this retry generation.
+
+        Returns:
+            True if the task was successfully cancelled, False otherwise.
         """
         raise NotImplementedError
 

--- a/src/litestar_queues/backends/base.py
+++ b/src/litestar_queues/backends/base.py
@@ -440,11 +440,7 @@ class BaseQueueBackend:
         raise NotImplementedError
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         """Cancel a task.
 

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -715,7 +715,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
             if row is None:
                 return None
             record = _decode(row)
-            if record.execution_ref != reservation_ref:
+            if record.execution_ref != reservation_ref or record.status not in _ACTIVE_STATUSES:
                 return None
             record.execution_backend = execution_backend
             record.execution_profile = execution_profile
@@ -786,7 +786,13 @@ class EphemeralQueueBackend(BaseQueueBackend):
 
         return await self._transaction(operation)
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         """Cancel one record.
 
         Returns:
@@ -799,7 +805,10 @@ class EphemeralQueueBackend(BaseQueueBackend):
             if row is None:
                 return False
             record = _decode(row)
-            if record.status not in statuses:
+            if (
+                record.status not in statuses
+                or (expected_retry_count is not None and record.retry_count != expected_retry_count)
+            ):
                 return False
             record.status = "cancelled"
             record.completed_at = _utc_now()

--- a/src/litestar_queues/backends/ephemeral/backend.py
+++ b/src/litestar_queues/backends/ephemeral/backend.py
@@ -787,11 +787,7 @@ class EphemeralQueueBackend(BaseQueueBackend):
         return await self._transaction(operation)
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         """Cancel one record.
 
@@ -805,9 +801,8 @@ class EphemeralQueueBackend(BaseQueueBackend):
             if row is None:
                 return False
             record = _decode(row)
-            if (
-                record.status not in statuses
-                or (expected_retry_count is not None and record.retry_count != expected_retry_count)
+            if record.status not in statuses or (
+                expected_retry_count is not None and record.retry_count != expected_retry_count
             ):
                 return False
             record.status = "cancelled"

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -382,11 +382,7 @@ class InMemoryQueueBackend(BaseQueueBackend):
             return record
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         async with self._lock:
             record = self._records.get(task_id)

--- a/src/litestar_queues/backends/memory/backend.py
+++ b/src/litestar_queues/backends/memory/backend.py
@@ -381,11 +381,21 @@ class InMemoryQueueBackend(BaseQueueBackend):
             record.heartbeat_at = None
             return record
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         async with self._lock:
             record = self._records.get(task_id)
             cancellable_statuses = {"pending", "scheduled", "running"} if include_running else {"pending", "scheduled"}
-            if record is None or record.status not in cancellable_statuses:
+            if (
+                record is None
+                or record.status not in cancellable_statuses
+                or (expected_retry_count is not None and record.retry_count != expected_retry_count)
+            ):
                 return False
             record.status = "cancelled"
             record.completed_at = _utc_now()
@@ -620,7 +630,11 @@ class InMemoryQueueBackend(BaseQueueBackend):
     ) -> "QueuedTaskRecord | None":
         async with self._lock:
             record = self._records.get(task_id)
-            if record is None or record.execution_ref != reservation_ref:
+            if (
+                record is None
+                or record.execution_ref != reservation_ref
+                or record.status not in {"pending", "scheduled"}
+            ):
                 return None
             record.execution_backend = execution_backend
             record.execution_profile = execution_profile

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -1250,11 +1250,7 @@ class RedisQueueBackend(BaseQueueBackend):
         return await self.get_task(task_id) if committed else None
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         """Cancel a task via a single fenced script.
 

--- a/src/litestar_queues/backends/redis/backend.py
+++ b/src/litestar_queues/backends/redis/backend.py
@@ -699,6 +699,10 @@ local hkey = KEYS[1]
 if redis.call('HGET', hkey, 'execution_ref') ~= ARGV[1] then
     return {0}
 end
+local status = redis.call('HGET', hkey, 'status')
+if status ~= 'pending' and status ~= 'scheduled' then
+    return {0}
+end
 redis.call(
     'HSET',
     hkey,
@@ -1245,7 +1249,13 @@ class RedisQueueBackend(BaseQueueBackend):
         )
         return await self.get_task(task_id) if committed else None
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         """Cancel a task via a single fenced script.
 
         Returns:
@@ -1255,7 +1265,7 @@ class RedisQueueBackend(BaseQueueBackend):
         cancellable_statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
         if record is None or record.status not in cancellable_statuses:
             return False
-        return await self._commit_cancel(record)
+        return await self._commit_cancel(record, expected_retry_count=expected_retry_count)
 
     async def cancel_tasks(
         self,
@@ -1281,16 +1291,17 @@ class RedisQueueBackend(BaseQueueBackend):
                 continue
             if not record_matches_filters(latest, task_name=task_name, queue=queue, kwargs=kwargs, metadata=metadata):
                 continue
-            if await self._commit_cancel(latest):
+            if await self._commit_cancel(latest, expected_retry_count=None):
                 cancelled += 1
         return cancelled
 
-    async def _commit_cancel(self, record: "QueuedTaskRecord") -> "bool":
+    async def _commit_cancel(self, record: "QueuedTaskRecord", expected_retry_count: "int | None" = None) -> "bool":
         now = _utc_now()
         return await self._commit_transition(
             record.id,
             expected_status=record.status,
             new_status="cancelled",
+            expected_retry_count=expected_retry_count,
             patch={
                 "completed_at": _serialize_datetime(now),
                 "completed_score": repr(_maintenance_score(now)),

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1231,9 +1231,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
             try:
                 adapter_name = resolve_adapter_name(self._get_sqlspec_config())
                 before_row = (
-                    await self._select_task(driver, task_id)
-                    if adapter_name in _UNRELIABLE_ROWCOUNT_ADAPTERS
-                    else None
+                    await self._select_task(driver, task_id) if adapter_name in _UNRELIABLE_ROWCOUNT_ADAPTERS else None
                 )
                 result = await driver.execute(
                     self._get_store().cancel_task(

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -93,10 +93,10 @@ _WAKEUP_TABLE_QUEUE_ADAPTERS = frozenset({"duckdb"})
 # Durable event transports that ride the SQLSpec events queue table and must have
 # it provisioned before a worker can publish or consume wakeups.
 _EVENTS_TABLE_BACKENDS = frozenset({"notify_queue", "poll_queue"})
-# arrow-odbc exposes no portable rowcount API, so a reported zero can mean
-# either no match or unavailable metadata. SQLSpec 0.56 made psqlpy row counts
-# exact, leaving only arrow-odbc on the verify-after-write fallback.
-_UNRELIABLE_ROWCOUNT_ADAPTERS = frozenset({"arrow_odbc"})
+# Arrow ODBC exposes no portable rowcount API, and ADBC SQLite reports ``-1``
+# for updates. Their cancellation path therefore verifies both the eligible
+# before-image and the persisted after-image.
+_UNRELIABLE_ROWCOUNT_ADAPTERS = frozenset({"adbc", "arrow_odbc"})
 
 
 def _adapter_wakeup_transport(adapter_name: "str | None") -> "str":
@@ -1229,6 +1229,12 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         async with self._session() as driver:
             await driver.begin()
             try:
+                adapter_name = resolve_adapter_name(self._get_sqlspec_config())
+                before_row = (
+                    await self._select_task(driver, task_id)
+                    if adapter_name in _UNRELIABLE_ROWCOUNT_ADAPTERS
+                    else None
+                )
                 result = await driver.execute(
                     self._get_store().cancel_task(
                         task_id=str(task_id),
@@ -1241,10 +1247,15 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                 if rows_affected < 0:
                     updated_row = await self._select_task(driver, task_id)
                     cancelled = False
-                    if updated_row is not None:
+                    if before_row is not None and updated_row is not None:
+                        before = self._record_from_row(before_row)
                         record = self._record_from_row(updated_row)
-                        cancelled = record.status == "cancelled" and (
-                            expected_retry_count is None or record.retry_count == expected_retry_count
+                        eligible_statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
+                        cancelled = (
+                            before.status in eligible_statuses
+                            and (expected_retry_count is None or before.retry_count == expected_retry_count)
+                            and record.status == "cancelled"
+                            and (expected_retry_count is None or record.retry_count == expected_retry_count)
                         )
                 else:
                     cancelled = rows_affected == 1

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1224,11 +1224,7 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         return record if record.status == "pending" else None
 
     async def cancel_task(
-        self,
-        task_id: "UUID",
-        *,
-        include_running: "bool" = False,
-        expected_retry_count: "int | None" = None,
+        self, task_id: "UUID", *, include_running: "bool" = False, expected_retry_count: "int | None" = None
     ) -> "bool":
         async with self._session() as driver:
             await driver.begin()

--- a/src/litestar_queues/backends/sqlspec/backend.py
+++ b/src/litestar_queues/backends/sqlspec/backend.py
@@ -1223,7 +1223,13 @@ class SQLSpecQueueBackend(BaseQueueBackend):
         record = self._record_from_row(updated_row)
         return record if record.status == "pending" else None
 
-    async def cancel_task(self, task_id: "UUID", *, include_running: "bool" = False) -> "bool":
+    async def cancel_task(
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
+    ) -> "bool":
         async with self._session() as driver:
             await driver.begin()
             try:
@@ -1232,12 +1238,18 @@ class SQLSpecQueueBackend(BaseQueueBackend):
                         task_id=str(task_id),
                         completed_at=self._serialize_datetime(_utc_now()),
                         include_running=include_running,
+                        expected_retry_count=expected_retry_count,
                     )
                 )
                 rows_affected = self._resolve_rows_affected(result)
                 if rows_affected < 0:
                     updated_row = await self._select_task(driver, task_id)
-                    cancelled = updated_row is not None and self._record_from_row(updated_row).status == "cancelled"
+                    cancelled = False
+                    if updated_row is not None:
+                        record = self._record_from_row(updated_row)
+                        cancelled = record.status == "cancelled" and (
+                            expected_retry_count is None or record.retry_count == expected_retry_count
+                        )
                 else:
                     cancelled = rows_affected == 1
                 await driver.commit()

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -800,17 +800,25 @@ class SQLSpecQueueStore:
         )
 
     def cancel_task(
-        self, *, task_id: "str", completed_at: "DatetimeParam", include_running: "bool" = False
+        self,
+        *,
+        task_id: "str",
+        completed_at: "DatetimeParam",
+        include_running: "bool" = False,
+        expected_retry_count: "int | None" = None,
     ) -> "Update":
         """Return an UPDATE statement that cancels a due or running task."""
         statuses = (*_DUE_STATUSES, "running") if include_running else _DUE_STATUSES
-        return (
+        stmt = (
             sql
             .update(self.table_name)
             .set(**self._mapped_values({"status": "cancelled", "completed_at": completed_at, "heartbeat_at": None}))
             .where_eq(self._col("id"), task_id)
             .where_in(self._col("status"), statuses)
         )
+        if expected_retry_count is not None:
+            stmt = stmt.where_eq(self._col("retry_count"), expected_retry_count)
+        return stmt
 
     def list_cancellable(
         self, *, include_running: "bool" = False, task_name: "str | None" = None, queue: "str | None" = None
@@ -1048,14 +1056,17 @@ RETURNING {target}.{id_col} AS id
             sql
             .update(self.table_name)
             .set(
-                **self._mapped_values({
-                    "execution_backend": execution_backend,
-                    "execution_profile": execution_profile,
-                    "execution_ref": execution_ref,
-                })
+                **self._mapped_values(
+                    {
+                        "execution_backend": execution_backend,
+                        "execution_profile": execution_profile,
+                        "execution_ref": execution_ref,
+                    }
+                )
             )
             .where_eq(self._col("id"), task_id)
             .where_eq(self._col("execution_ref"), reservation_ref)
+            .where_in(self._col("status"), _DUE_STATUSES)
         )
 
     def set_execution_backend(

--- a/src/litestar_queues/backends/sqlspec/stores/base.py
+++ b/src/litestar_queues/backends/sqlspec/stores/base.py
@@ -1056,13 +1056,11 @@ RETURNING {target}.{id_col} AS id
             sql
             .update(self.table_name)
             .set(
-                **self._mapped_values(
-                    {
-                        "execution_backend": execution_backend,
-                        "execution_profile": execution_profile,
-                        "execution_ref": execution_ref,
-                    }
-                )
+                **self._mapped_values({
+                    "execution_backend": execution_backend,
+                    "execution_profile": execution_profile,
+                    "execution_ref": execution_ref,
+                })
             )
             .where_eq(self._col("id"), task_id)
             .where_eq(self._col("execution_ref"), reservation_ref)

--- a/src/litestar_queues/execution/base.py
+++ b/src/litestar_queues/execution/base.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import Self
 
@@ -14,7 +14,13 @@ if TYPE_CHECKING:
     from litestar_queues.models import QueuedTaskRecord
     from litestar_queues.service import QueueService
 
-__all__ = ("BaseConsumerExecutionBackend", "BaseExecutionBackend", "DispatchRepairResult")
+__all__ = (
+    "BaseConsumerExecutionBackend",
+    "BaseExecutionBackend",
+    "DispatchRepairResult",
+    "ExecutionCancelResult",
+    "ExecutionCancelStatus",
+)
 
 _MESSAGING_SYSTEM = "litestar_queues"
 
@@ -69,6 +75,70 @@ class DispatchRepairResult:
 
     examined: "int" = 0
     changed: "int" = 0
+
+
+ExecutionCancelStatus = Literal["accepted", "already_cancelled", "retryable", "unsupported"]
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionCancelResult:
+    """Outcome of one provider-level cancellation attempt.
+
+    ``detail`` carries the provider's own words for the log line and the
+    lifecycle event; it is never parsed.
+    """
+
+    status: "ExecutionCancelStatus"
+    detail: "str | None" = None
+
+    @property
+    def permits_durable_cancel(self) -> "bool":
+        """Whether this outcome may win the durable transition to cancelled.
+
+        Only a control plane that exists and refused blocks the write. A
+        transport with no control plane cannot strand anything, because the
+        dispatch-by-id claim fence makes an in-flight delivery a no-op.
+
+        Returns:
+            True unless the provider refused a cancellation it could have made.
+        """
+        return self.status != "retryable"
+
+    @classmethod
+    def accepted(cls, detail: "str | None" = None) -> "Self":
+        """Return an accepted cancellation result.
+
+        Returns:
+            A result whose status is ``accepted``.
+        """
+        return cls(status="accepted", detail=detail)
+
+    @classmethod
+    def already_cancelled(cls, detail: "str | None" = None) -> "Self":
+        """Return an idempotent already-cancelled result.
+
+        Returns:
+            A result whose status is ``already_cancelled``.
+        """
+        return cls(status="already_cancelled", detail=detail)
+
+    @classmethod
+    def retryable(cls, detail: "str | None" = None) -> "Self":
+        """Return a transient or rejected cancellation result.
+
+        Returns:
+            A result whose status is ``retryable``.
+        """
+        return cls(status="retryable", detail=detail)
+
+    @classmethod
+    def unsupported(cls, detail: "str | None" = None) -> "Self":
+        """Return a result for a transport with no cancellation control plane.
+
+        Returns:
+            A result whose status is ``unsupported``.
+        """
+        return cls(status="unsupported", detail=detail)
 
 
 class BaseExecutionBackend:
@@ -169,13 +239,22 @@ class BaseExecutionBackend:
         """
         return None
 
-    async def cancel(self, service: "QueueService", record: "QueuedTaskRecord") -> "bool":
-        """Cancel an externally running queue record if possible.
+    async def cancel_execution(
+        self, service: "QueueService", record: "QueuedTaskRecord"
+    ) -> "ExecutionCancelResult":
+        """Cancel the provider resource backing one external attempt.
+
+        Called before any durable transition to ``cancelled`` for a record whose
+        ``execution_ref`` names a live provider resource. Implementations must
+        contain their client's exceptions and answer with a result: a not-found
+        resource is ``already_cancelled``, anything transient or refused is
+        ``retryable``. Raising is reserved for programming errors.
 
         Returns:
-            True when cancellation succeeds.
+            ``unsupported`` for a transport with no cancellation control plane.
         """
-        return False
+        del service, record
+        return ExecutionCancelResult.unsupported()
 
     async def __aenter__(self) -> "Self":
         await self.open()

--- a/src/litestar_queues/execution/base.py
+++ b/src/litestar_queues/execution/base.py
@@ -239,9 +239,7 @@ class BaseExecutionBackend:
         """
         return None
 
-    async def cancel_execution(
-        self, service: "QueueService", record: "QueuedTaskRecord"
-    ) -> "ExecutionCancelResult":
+    async def cancel_execution(self, service: "QueueService", record: "QueuedTaskRecord") -> "ExecutionCancelResult":
         """Cancel the provider resource backing one external attempt.
 
         Called before any durable transition to ``cancelled`` for a record whose

--- a/src/litestar_queues/execution/cloudrun/_typing.py
+++ b/src/litestar_queues/execution/cloudrun/_typing.py
@@ -37,3 +37,7 @@ class CloudRunExecutionsClient(Protocol):
     async def get_execution(self, *, name: "str") -> "CloudRunExecutionLike":
         """Return a Cloud Run execution."""
         ...
+
+    async def cancel_execution(self, *, name: "str") -> "Any":
+        """Cancel a Cloud Run execution and return its long-running operation."""
+        ...

--- a/src/litestar_queues/execution/cloudrun/backend.py
+++ b/src/litestar_queues/execution/cloudrun/backend.py
@@ -14,6 +14,7 @@ from litestar_queues.events import QueueEvent
 from litestar_queues.exceptions import MissingDependencyError
 from litestar_queues.execution.base import (
     BaseExecutionBackend,
+    ExecutionCancelResult,
     _queue_metric_attributes,
     _queue_observability_attributes,
 )
@@ -167,6 +168,20 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
             record.id, reservation_ref, "cloudrun", execution_ref, execution_profile=record.execution_profile
         )
         if finalized is None:
+            result = await self._cancel_execution_ref(execution_ref)
+            runtime.record_counter(
+                "litestar_queues.execution.cancel",
+                attributes={
+                    **metric_attributes,
+                    "queue.execution.status": result.status,
+                    "queue.cancel.trigger": "dispatch_race",
+                },
+            )
+            if result.status == "retryable":
+                self._logger.warning(
+                    "Cloud Run execution orphaned by a lost dispatch race could not be cancelled",
+                    extra={"queue_task_id": str(record.id), "cloudrun_execution_ref": execution_ref},
+                )
             runtime.record_counter(
                 "litestar_queues.execution.dispatch",
                 attributes={**metric_attributes, "queue.execution.status": "ownership_lost"},
@@ -177,6 +192,37 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
             attributes={**metric_attributes, "queue.execution.status": "dispatched"},
         )
         return execution_ref
+
+    async def cancel_execution(self, service: "QueueService", record: "QueuedTaskRecord") -> "ExecutionCancelResult":
+        """Cancel the Cloud Run execution backing this record's attempt.
+
+        Returns:
+            The provider's answer, mapped to the shared cancellation contract.
+        """
+        execution_ref = record.execution_ref
+        if execution_ref is None or execution_ref.startswith(EXTERNAL_DISPATCH_RESERVATION_PREFIX):
+            return ExecutionCancelResult.unsupported("no Cloud Run execution reference")
+        del service
+        return await self._cancel_execution_ref(execution_ref)
+
+    async def _cancel_execution_ref(self, execution_ref: "str") -> "ExecutionCancelResult":
+        """Cancel one Cloud Run execution by its full resource name.
+
+        Returns:
+            ``accepted`` once the cancellation operation is created,
+            ``already_cancelled`` when the execution no longer exists, and
+            ``retryable`` for anything else.
+        """
+        try:
+            await (await self._get_executions_client()).cancel_execution(name=execution_ref)
+        except Exception as exc:
+            if _is_not_found_error(exc):
+                return ExecutionCancelResult.already_cancelled("Cloud Run execution not found")
+            self._logger.warning(
+                "Cloud Run cancellation failed", exc_info=True, extra={"cloudrun_execution_ref": execution_ref}
+            )
+            return ExecutionCancelResult.retryable(str(exc))
+        return ExecutionCancelResult.accepted(execution_ref)
 
     async def reconcile(self, service: "QueueService", record: "QueuedTaskRecord") -> "QueuedTaskRecord | None":
         """Reconcile a Cloud Run execution with the queue record.
@@ -226,9 +272,12 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
             return updated
 
         if status.cancelled:
-            updated = await queue_backend.fail_task(
-                current.id, "Cloud Run execution cancelled", retry=False, expected_retry_count=expected_retry_count
+            if current.status != "running":
+                return None
+            cancelled = await queue_backend.cancel_task(
+                current.id, include_running=True, expected_retry_count=expected_retry_count
             )
+            updated = await queue_backend.get_task(current.id) if cancelled else None
             _record_reconcile_result(runtime, metric_attributes, updated)
             return updated
 

--- a/src/litestar_queues/execution/cloudrun/backend.py
+++ b/src/litestar_queues/execution/cloudrun/backend.py
@@ -260,14 +260,6 @@ class CloudRunExecutionBackend(BaseExecutionBackend):
         expired = await service.expire_overdue_tasks()
         return next((candidate for candidate in expired if candidate.id == record.id), None)
 
-    async def cancel(self, service: "QueueService", record: "QueuedTaskRecord") -> "bool":
-        """Cloud Run Jobs do not expose per-execution cancellation here.
-
-        Returns:
-            Always false because per-execution cancellation is not implemented.
-        """
-        return False
-
     async def check_execution_status(self, execution_ref: "str") -> "CloudRunExecutionStatus":
         """Return Cloud Run execution status.
 

--- a/src/litestar_queues/execution/cloudtasks/_typing.py
+++ b/src/litestar_queues/execution/cloudtasks/_typing.py
@@ -28,6 +28,10 @@ class CloudTasksClient(Protocol):
         """Look up one task by full resource name."""
         ...
 
+    async def delete_task(self, *, name: "str", timeout: "float | None" = None) -> "None":
+        """Delete one task by full resource name."""
+        ...
+
     async def close(self) -> "None":
         """Release the client's transport."""
         ...

--- a/src/litestar_queues/execution/cloudtasks/backend.py
+++ b/src/litestar_queues/execution/cloudtasks/backend.py
@@ -23,6 +23,7 @@ from litestar_queues.exceptions import MissingDependencyError, QueueConfiguratio
 from litestar_queues.execution.base import (
     BaseExecutionBackend,
     DispatchRepairResult,
+    ExecutionCancelResult,
     _queue_metric_attributes,
     _queue_observability_attributes,
 )
@@ -294,6 +295,34 @@ class CloudTasksExecutionBackend(BaseExecutionBackend):
             await self._publish_delivery_failure(service, current, exc, operation=_REPAIR)
             return False
         return True
+
+    async def cancel_execution(self, service: "QueueService", record: "QueuedTaskRecord") -> "ExecutionCancelResult":
+        """Delete the Cloud Tasks delivery holding this record's attempt.
+
+        Cloud Tasks holds a future delivery rather than a running process, so
+        cancellation is a delete: after it, nothing will be delivered. A
+        delivery that is already in flight has been claimed by the consumer, and
+        the delete answers not-found -- idempotent success, with the running body
+        left to cooperative cancellation.
+
+        Returns:
+            The provider's answer, mapped to the shared cancellation contract.
+        """
+        task_name = record.execution_ref
+        if task_name is None:
+            return ExecutionCancelResult.unsupported("no Cloud Tasks delivery reference")
+        del service
+        config = self.execution_config
+        try:
+            await (await self._get_client()).delete_task(name=task_name, timeout=config.api_timeout)
+        except Exception as exc:
+            if _is_not_found(exc):
+                return ExecutionCancelResult.already_cancelled("Cloud Tasks delivery not found")
+            self._logger.warning(
+                "Cloud Tasks delivery deletion failed", exc_info=True, extra={"cloudtasks_task_name": task_name}
+            )
+            return ExecutionCancelResult.retryable(str(exc))
+        return ExecutionCancelResult.accepted(task_name)
 
     async def _delivery_exists(self, task_name: "str", config: "CloudTasksExecutionConfig") -> "bool":
         """Whether Cloud Tasks still holds the named delivery.

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -1172,7 +1172,7 @@ class QueueService:
             self._reject_beyond_scheduling_horizon(task_name, scheduled_at)
             metadata = self._metadata_with_schedule_default(task_obj, schedule_metadata, scheduled_at)
             if active is not None:
-                await queue_backend.cancel_task(active.id)
+                await self.cancel_task(active.id)
             records.append(
                 await self._persist_scheduled_record(
                     task_name,

--- a/src/litestar_queues/service.py
+++ b/src/litestar_queues/service.py
@@ -20,7 +20,7 @@ from litestar_queues._correlation import (
     reset_correlation_id,
 )
 from litestar_queues._identity import IDENTITY_VERSION, arguments_identity, task_identity
-from litestar_queues.backends.base import interruption_count
+from litestar_queues.backends.base import EXTERNAL_DISPATCH_RESERVATION_PREFIX, interruption_count
 from litestar_queues.config import execution_backend_name, queue_backend_name
 from litestar_queues.events.context import TaskExecutionContext, bind_task_context
 from litestar_queues.events.models import QueueEvent, QueueEventActor
@@ -28,6 +28,7 @@ from litestar_queues.events.producer import QueueEventProducer
 from litestar_queues.events.sinks import _call_optional_lifecycle, _select_lifecycle_error
 from litestar_queues.exceptions import JobCancelledError, NonRetryableError, QueueConfigurationError
 from litestar_queues.execution import get_execution_backend
+from litestar_queues.execution.base import ExecutionCancelResult
 from litestar_queues.task import (
     ScheduleConfig,
     Task,
@@ -651,9 +652,20 @@ class QueueService:
         return await self._cancel_task(task_id, include_running=include_running)
 
     async def _cancel_task(
-        self, task_id: "UUID", *, include_running: "bool" = False, message: "str | None" = None
+        self,
+        task_id: "UUID",
+        *,
+        include_running: "bool" = False,
+        message: "str | None" = None,
+        cancel_external: "bool" = True,
     ) -> "bool":
         backend = self.get_queue_backend()
+        if cancel_external:
+            current = await backend.get_task(task_id)
+            if current is not None and _external_attempt_ref(current) is not None:
+                outcome = await self._cancel_external_attempt(current)
+                if not outcome.permits_durable_cancel:
+                    return False
         if not await backend.cancel_task(task_id, include_running=include_running):
             return False
         record = await backend.get_task(task_id)
@@ -669,6 +681,48 @@ class QueueService:
             # control channel against durable status regardless.
             await backend.notify_worker_control(record.worker_id)
         return True
+
+    async def _cancel_external_attempt(self, record: "QueuedTaskRecord") -> "ExecutionCancelResult":
+        """Ask the record's execution backend to cancel its provider resource.
+
+        Returns:
+            The provider's answer, or ``unsupported`` when no reachable backend
+            owns this record.
+        """
+        try:
+            execution_backend = self._execution_backend_for_name(record.execution_backend)
+        except ValueError:
+            self._logger.warning(
+                "Skipping provider cancellation for an unknown execution backend",
+                extra={"queue_task_id": str(record.id), "queue_task_execution_backend": record.execution_backend},
+            )
+            return ExecutionCancelResult.unsupported("unknown execution backend")
+        if not execution_backend.is_external:
+            return ExecutionCancelResult.unsupported()
+        result = await execution_backend.cancel_execution(self, record)
+        self._record_cancel_result(record, result, trigger="request")
+        if result.status == "retryable":
+            await self._publish_cancel_refused(record, result)
+        return result
+
+    def _record_cancel_result(
+        self, record: "QueuedTaskRecord", result: "ExecutionCancelResult", *, trigger: "str"
+    ) -> "None":
+        attributes = _base_observability_attributes(
+            operation="cancel",
+            queue=record.queue,
+            task_name=record.task_name,
+            execution_backend=record.execution_backend,
+            execution_profile=record.execution_profile,
+        )
+        self.observability_runtime.record_counter(
+            "litestar_queues.execution.cancel",
+            attributes={
+                **_metric_attributes(attributes),
+                "queue.execution.status": result.status,
+                "queue.cancel.trigger": trigger,
+            },
+        )
 
     async def interrupt_task(
         self,
@@ -769,7 +823,11 @@ class QueueService:
             telemetry.finish(final_status)
             raise
         except JobCancelledError as exc:
-            cancelled = await self._cancel_task(record.id, include_running=True, message=str(exc))
+            # The process running this body *is* the external execution.
+            # Asking the provider to kill it would preempt the terminal write the handler is about to make.
+            cancelled = await self._cancel_task(
+                record.id, include_running=True, message=str(exc), cancel_external=False
+            )
             if not cancelled:
                 final_status = "claim_lost"
                 current = await self.publish_claim_lost(record, phase="cancel", task_context=task_context)
@@ -1276,6 +1334,29 @@ class QueueService:
             "Recurring schedule stopped beyond the delivery horizon", record, level=logging.WARNING, payload=payload
         )
 
+    async def _publish_cancel_refused(self, record: "QueuedTaskRecord", result: "ExecutionCancelResult") -> "None":
+        payload = {
+            "phase": f"{record.execution_backend}.cancel_failed",
+            "result": result.status,
+            "error": result.detail,
+        }
+        await self.get_event_publisher().publish(
+            QueueEvent(
+                type="task.event",
+                scope="task",
+                task_id=str(record.id),
+                task_name=record.task_name,
+                queue=record.queue,
+                execution_backend=record.execution_backend,
+                execution_profile=record.execution_profile,
+                attempt=record.retry_count + 1,
+                level="warning",
+                message="Remote execution cancellation was refused",
+                payload=payload,
+            )
+        )
+        self._log_task_event("Remote execution cancellation refused", record, level=logging.WARNING, payload=payload)
+
     async def _current_or_claimed(self, record: "QueuedTaskRecord") -> "QueuedTaskRecord":
         return await self.get_queue_backend().get_task(record.id) or record
 
@@ -1672,3 +1753,20 @@ def _coerce_log_level(value: "object", default: "int" = logging.INFO) -> "int":
     if not isinstance(value, str):
         return default
     return _LOG_LEVELS.get(value.lower(), default)
+
+
+def _external_attempt_ref(record: "QueuedTaskRecord") -> "str | None":
+    """Return the provider resource this record's attempt owns, if any.
+
+    ``None`` covers both a local attempt (no reference at all) and a dispatch
+    still holding a reservation marker: in neither case is a provider resource
+    known to exist, so there is nothing to cancel first. A dispatch that goes
+    on to create one fences on its own status-checked finalize instead.
+
+    Returns:
+        The provider reference, or ``None`` when the attempt is not external.
+    """
+    execution_ref = record.execution_ref
+    if execution_ref is None or execution_ref.startswith(EXTERNAL_DISPATCH_RESERVATION_PREFIX):
+        return None
+    return execution_ref

--- a/src/tests/integration/_expiry_contract.py
+++ b/src/tests/integration/_expiry_contract.py
@@ -55,7 +55,9 @@ async def assert_claim_many_reports_owned_expirations(queue_backend: "BaseQueueB
 
 
 async def assert_expiry_fences_retry_requeue(queue_backend: "BaseQueueBackend") -> "None":
-    expires_at = datetime.now(timezone.utc) + timedelta(seconds=2)
+    # Leave enough headroom for remote databases to enqueue and claim under a
+    # loaded integration matrix before deliberately waiting out the deadline.
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=10)
     record = await queue_backend.enqueue("tasks.retry_expiry", max_retries=1, expires_at=expires_at)
     claimed = await queue_backend.claim_task(record.id)
     assert claimed is not None

--- a/src/tests/integration/execution/cloudrun/helpers.py
+++ b/src/tests/integration/execution/cloudrun/helpers.py
@@ -76,15 +76,28 @@ class FakeJobsClient:
 
 
 class FakeExecutionsClient:
-    def __init__(self, execution: "FakeCloudRunExecution | Exception") -> "None":
+    def __init__(
+        self, execution: "FakeCloudRunExecution | Exception", *, cancel_error: "Exception | None" = None
+    ) -> "None":
         self.execution = execution
         self.names: "list[str]" = []
+        self.cancelled_names: "list[str]" = []
+        self.cancel_error = cancel_error
 
     async def get_execution(self, *, name: "str") -> "FakeCloudRunExecution":
         self.names.append(name)
         if isinstance(self.execution, Exception):
             raise self.execution
         return self.execution
+
+    async def cancel_execution(self, *, name: "str") -> "object":
+        self.cancelled_names.append(name)
+        if self.cancel_error is not None:
+            raise self.cancel_error
+        # We need to return a FakeOperation, which requires a FakeCloudRunExecution.
+        # If self.execution is an Exception, we can just return a dummy execution.
+        execution = self.execution if isinstance(self.execution, FakeCloudRunExecution) else FakeCloudRunExecution()
+        return FakeOperation(execution)
 
 
 class NoopServiceContext:

--- a/src/tests/integration/execution/cloudrun/test_emulator.py
+++ b/src/tests/integration/execution/cloudrun/test_emulator.py
@@ -758,6 +758,7 @@ def test_cloudrun_factory_registration_and_import_boundary() -> "None":
 
 async def test_cloudrun_cancel_execution_uses_the_stored_resource_name() -> "None":
     from datetime import datetime, timezone
+    from uuid import uuid4
 
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
     from litestar_queues.models import QueuedTaskRecord
@@ -767,7 +768,7 @@ async def test_cloudrun_cancel_execution_uses_the_stored_resource_name() -> "Non
         execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
     )
     record = QueuedTaskRecord(
-        id="123",
+        id=uuid4(),
         task_name="tasks.ext",
         status="running",
         queued_at=datetime.now(timezone.utc),
@@ -776,7 +777,7 @@ async def test_cloudrun_cancel_execution_uses_the_stored_resource_name() -> "Non
         execution_backend="cloudrun",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -787,6 +788,7 @@ async def test_cloudrun_cancel_execution_uses_the_stored_resource_name() -> "Non
 
 async def test_cloudrun_cancel_execution_not_found_is_idempotent() -> "None":
     from datetime import datetime, timezone
+    from uuid import uuid4
 
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
     from litestar_queues.models import QueuedTaskRecord
@@ -797,7 +799,7 @@ async def test_cloudrun_cancel_execution_not_found_is_idempotent() -> "None":
         execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
     )
     record = QueuedTaskRecord(
-        id="123",
+        id=uuid4(),
         task_name="tasks.ext",
         status="running",
         queued_at=datetime.now(timezone.utc),
@@ -806,7 +808,7 @@ async def test_cloudrun_cancel_execution_not_found_is_idempotent() -> "None":
         execution_backend="cloudrun",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -815,6 +817,7 @@ async def test_cloudrun_cancel_execution_not_found_is_idempotent() -> "None":
 
 async def test_cloudrun_cancel_execution_transient_error_is_retryable() -> "None":
     from datetime import datetime, timezone
+    from uuid import uuid4
 
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
     from litestar_queues.models import QueuedTaskRecord
@@ -824,7 +827,7 @@ async def test_cloudrun_cancel_execution_transient_error_is_retryable() -> "None
         execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
     )
     record = QueuedTaskRecord(
-        id="123",
+        id=uuid4(),
         task_name="tasks.ext",
         status="running",
         queued_at=datetime.now(timezone.utc),
@@ -833,7 +836,7 @@ async def test_cloudrun_cancel_execution_transient_error_is_retryable() -> "None
         execution_backend="cloudrun",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -843,6 +846,7 @@ async def test_cloudrun_cancel_execution_transient_error_is_retryable() -> "None
 
 async def test_cloudrun_cancel_execution_without_a_reference_is_unsupported() -> "None":
     from datetime import datetime, timezone
+    from uuid import uuid4
 
     from litestar_queues.backends.base import EXTERNAL_DISPATCH_RESERVATION_PREFIX
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
@@ -853,7 +857,7 @@ async def test_cloudrun_cancel_execution_without_a_reference_is_unsupported() ->
         execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
     )
     record = QueuedTaskRecord(
-        id="123",
+        id=uuid4(),
         task_name="tasks.ext",
         status="running",
         queued_at=datetime.now(timezone.utc),
@@ -862,7 +866,7 @@ async def test_cloudrun_cancel_execution_without_a_reference_is_unsupported() ->
         execution_backend="cloudrun",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -875,6 +879,7 @@ async def test_cloudrun_cancel_execution_without_a_reference_is_unsupported() ->
 
 async def test_cloudrun_cancel_execution_does_not_await_the_operation() -> "None":
     from datetime import datetime, timezone
+    from uuid import uuid4
 
     from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
     from litestar_queues.models import QueuedTaskRecord
@@ -882,7 +887,7 @@ async def test_cloudrun_cancel_execution_does_not_await_the_operation() -> "None
     class InspectableFakeExecutionsClient(FakeExecutionsClient):
         def __init__(self, execution: "FakeCloudRunExecution") -> "None":
             super().__init__(execution)
-            self.last_op = None
+            self.last_op: "object" = None
 
         async def cancel_execution(self, *, name: "str") -> "object":
             op = await super().cancel_execution(name=name)
@@ -894,7 +899,7 @@ async def test_cloudrun_cancel_execution_does_not_await_the_operation() -> "None
         execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
     )
     record = QueuedTaskRecord(
-        id="123",
+        id=uuid4(),
         task_name="tasks.ext",
         status="running",
         queued_at=datetime.now(timezone.utc),
@@ -903,7 +908,7 @@ async def test_cloudrun_cancel_execution_does_not_await_the_operation() -> "None
         execution_backend="cloudrun",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore

--- a/src/tests/integration/execution/cloudrun/test_emulator.py
+++ b/src/tests/integration/execution/cloudrun/test_emulator.py
@@ -484,7 +484,7 @@ async def test_cloudrun_reconcile_recovers_stale_reservation_and_expires_task() 
             "failed",
             "container failed",
         ),
-        (FakeCloudRunExecution(cancelled_count=1), "failed", "Cloud Run execution cancelled"),
+        (FakeCloudRunExecution(cancelled_count=1), "cancelled", None),
     ],
 )
 async def test_cloudrun_reconcile_updates_terminal_statuses(
@@ -754,3 +754,228 @@ def test_cloudrun_factory_registration_and_import_boundary() -> "None":
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert completed.stdout.strip() == "[]"
+
+
+async def test_cloudrun_cancel_execution_uses_the_stored_resource_name() -> "None":
+    from datetime import datetime, timezone
+
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+    from litestar_queues.models import QueuedTaskRecord
+
+    client = FakeExecutionsClient(FakeCloudRunExecution())
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
+    )
+    record = QueuedTaskRecord(
+        id="123",
+        task_name="tasks.ext",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref="projects/test-project/locations/us-central1/jobs/worker/executions/run-1",
+        queue="default",
+        execution_backend="cloudrun",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "accepted"
+    assert client.cancelled_names == [record.execution_ref]
+    assert client.names == []
+
+
+async def test_cloudrun_cancel_execution_not_found_is_idempotent() -> "None":
+    from datetime import datetime, timezone
+
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+    from litestar_queues.models import QueuedTaskRecord
+
+    not_found_error = type("NotFound", (Exception,), {})
+    client = FakeExecutionsClient(FakeCloudRunExecution(), cancel_error=not_found_error("gone"))
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
+    )
+    record = QueuedTaskRecord(
+        id="123",
+        task_name="tasks.ext",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref="projects/test-project/locations/us-central1/jobs/worker/executions/run-1",
+        queue="default",
+        execution_backend="cloudrun",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "already_cancelled"
+
+
+async def test_cloudrun_cancel_execution_transient_error_is_retryable() -> "None":
+    from datetime import datetime, timezone
+
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+    from litestar_queues.models import QueuedTaskRecord
+
+    client = FakeExecutionsClient(FakeCloudRunExecution(), cancel_error=RuntimeError("503 backend unavailable"))
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
+    )
+    record = QueuedTaskRecord(
+        id="123",
+        task_name="tasks.ext",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref="projects/test-project/locations/us-central1/jobs/worker/executions/run-1",
+        queue="default",
+        execution_backend="cloudrun",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "retryable"
+    assert result.detail and "503" in result.detail
+
+
+async def test_cloudrun_cancel_execution_without_a_reference_is_unsupported() -> "None":
+    from datetime import datetime, timezone
+
+    from litestar_queues.backends.base import EXTERNAL_DISPATCH_RESERVATION_PREFIX
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+    from litestar_queues.models import QueuedTaskRecord
+
+    client = FakeExecutionsClient(FakeCloudRunExecution())
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
+    )
+    record = QueuedTaskRecord(
+        id="123",
+        task_name="tasks.ext",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref=None,
+        queue="default",
+        execution_backend="cloudrun",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "unsupported"
+
+    record.execution_ref = f"{EXTERNAL_DISPATCH_RESERVATION_PREFIX}:res"
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "unsupported"
+
+
+async def test_cloudrun_cancel_execution_does_not_await_the_operation() -> "None":
+    from datetime import datetime, timezone
+
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+    from litestar_queues.models import QueuedTaskRecord
+
+    class InspectableFakeExecutionsClient(FakeExecutionsClient):
+        def __init__(self, execution: "FakeCloudRunExecution") -> "None":
+            super().__init__(execution)
+            self.last_op = None
+
+        async def cancel_execution(self, *, name: "str") -> "object":
+            op = await super().cancel_execution(name=name)
+            self.last_op = op
+            return op
+
+    client = InspectableFakeExecutionsClient(FakeCloudRunExecution())
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"), executions_client=client
+    )
+    record = QueuedTaskRecord(
+        id="123",
+        task_name="tasks.ext",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref="projects/test-project/locations/us-central1/jobs/worker/executions/run-1",
+        queue="default",
+        execution_backend="cloudrun",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "accepted"
+    assert client.last_op is not None and not client.last_op.result_called  # type: ignore
+
+
+async def test_cancel_task_cancels_a_cloudrun_execution_before_the_durable_write() -> "None":
+    from typing import cast
+
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    queue_backend = InMemoryQueueBackend()
+    jobs_client = FakeJobsClient()
+    executions_client = FakeExecutionsClient(FakeCloudRunExecution())
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        jobs_client=cast("CloudRunJobsClient", jobs_client),
+        executions_client=executions_client,
+    )
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="cloudrun"),
+        queue_backend=queue_backend,
+        execution_backend=backend,
+    ) as service:
+        from litestar_queues.task import task
+
+        @task("tasks.ext")
+        async def _ext() -> "None":
+            return None
+
+        record = await queue_backend.enqueue("tasks.ext", execution_backend="cloudrun")
+        await backend.dispatch(service, record)
+
+        updated = await queue_backend.get_task(record.id)
+        assert updated and updated.execution_ref
+        assert await service.cancel_task(record.id, include_running=True) is True
+
+        assert executions_client.cancelled_names == [updated.execution_ref]
+        stored = await queue_backend.get_task(record.id)
+        assert stored and stored.status == "cancelled"
+
+
+async def test_cancel_task_leaves_the_record_running_when_cloud_run_refuses() -> "None":
+    from typing import cast
+
+    from litestar_queues.execution.cloudrun import CloudRunExecutionBackend, CloudRunExecutionConfig
+
+    queue_backend = InMemoryQueueBackend()
+    jobs_client = FakeJobsClient()
+    executions_client = FakeExecutionsClient(FakeCloudRunExecution(), cancel_error=RuntimeError("boom"))
+    backend = CloudRunExecutionBackend(
+        execution_config=CloudRunExecutionConfig(project_id="test-project", job_name="worker"),
+        jobs_client=cast("CloudRunJobsClient", jobs_client),
+        executions_client=executions_client,
+    )
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="cloudrun"),
+        queue_backend=queue_backend,
+        execution_backend=backend,
+    ) as service:
+        from litestar_queues.task import task
+
+        @task("tasks.ext")
+        async def _ext() -> "None":
+            return None
+
+        record = await queue_backend.enqueue("tasks.ext", execution_backend="cloudrun")
+        await backend.dispatch(service, record)
+
+        await queue_backend.get_task(record.id)
+        assert await service.cancel_task(record.id, include_running=True) is False
+
+        stored = await queue_backend.get_task(record.id)
+        assert stored and stored.status == "pending"

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -1,7 +1,8 @@
 import asyncio
+import time
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import TYPE_CHECKING, Any, cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from typing_extensions import Self
@@ -242,6 +243,45 @@ async def test_backend_contract_bounds_external_reconciliation_deterministically
     await queue_backend.set_execution_ref(low.id, "cloudrun", "jobs/low")
 
     assert [record.id for record in await queue_backend.list_running_external(limit=1)] == [low.id]
+
+
+
+async def test_backend_contract_cancel_task_honours_retry_generation_fence(
+    queue_backend: "BaseQueueBackend",
+) -> "None":
+    task = await queue_backend.enqueue("tasks.fenced.cancel")
+    claimed = await queue_backend.claim_many(limit=1)
+    assert len(claimed) == 1
+
+    assert await queue_backend.cancel_task(task.id, include_running=True, expected_retry_count=1) is False
+    stored = await queue_backend.get_task(task.id)
+    assert stored is not None and stored.status == "running"
+
+    assert await queue_backend.cancel_task(task.id, include_running=True, expected_retry_count=0) is True
+    stored = await queue_backend.get_task(task.id)
+    assert stored is not None and stored.status == "cancelled"
+
+    assert await queue_backend.cancel_task(task.id, include_running=True) is False
+
+async def test_backend_contract_finalize_external_dispatch_does_not_resurrect_cancelled(
+    queue_backend: "BaseQueueBackend",
+) -> "None":
+    task = await queue_backend.enqueue("tasks.race.finalize")
+    reservation_ref = f"__litestar_queues_dispatching__:{int(time.time()) + 900}:{uuid4()}"
+    reserved = await queue_backend.reserve_external_dispatch(task.id, "cloudrun", reservation_ref)
+    assert reserved is not None and reserved.status in {"pending", "scheduled"}
+
+    assert await queue_backend.cancel_task(task.id) is True
+
+    finalized = await queue_backend.finalize_external_dispatch(
+        task.id, reservation_ref, "cloudrun", "projects/p/locations/r/jobs/j/executions/e-1"
+    )
+    assert finalized is None
+
+    stored = await queue_backend.get_task(task.id)
+    assert stored is not None
+    assert stored.status == "cancelled"
+    assert stored.execution_ref == reservation_ref
 
 
 async def test_backend_contract_bulk_cancels_matching_domain_predicate(queue_backend: "BaseQueueBackend") -> "None":

--- a/src/tests/integration/test_queue_contract.py
+++ b/src/tests/integration/test_queue_contract.py
@@ -245,10 +245,7 @@ async def test_backend_contract_bounds_external_reconciliation_deterministically
     assert [record.id for record in await queue_backend.list_running_external(limit=1)] == [low.id]
 
 
-
-async def test_backend_contract_cancel_task_honours_retry_generation_fence(
-    queue_backend: "BaseQueueBackend",
-) -> "None":
+async def test_backend_contract_cancel_task_honours_retry_generation_fence(queue_backend: "BaseQueueBackend") -> "None":
     task = await queue_backend.enqueue("tasks.fenced.cancel")
     claimed = await queue_backend.claim_many(limit=1)
     assert len(claimed) == 1
@@ -262,6 +259,7 @@ async def test_backend_contract_cancel_task_honours_retry_generation_fence(
     assert stored is not None and stored.status == "cancelled"
 
     assert await queue_backend.cancel_task(task.id, include_running=True) is False
+
 
 async def test_backend_contract_finalize_external_dispatch_does_not_resurrect_cancelled(
     queue_backend: "BaseQueueBackend",

--- a/src/tests/unit/execution/cloudtasks/test_cancel.py
+++ b/src/tests/unit/execution/cloudtasks/test_cancel.py
@@ -1,0 +1,199 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from litestar_queues.backends.memory.backend import InMemoryQueueBackend
+from litestar_queues.config import QueueConfig, WorkerConfig
+from litestar_queues.execution.cloudtasks.backend import CloudTasksExecutionBackend
+from litestar_queues.execution.cloudtasks.config import CloudTasksExecutionConfig
+from litestar_queues.models import QueuedTaskRecord
+from litestar_queues.service import QueueService
+from tests.unit.execution.cloudtasks._fakes import FakeCloudTasksClient
+
+
+@pytest.mark.anyio
+async def test_cloudtasks_cancel_execution_deletes_the_stored_delivery() -> "None":
+    task_name = "projects/test/locations/us/queues/default/tasks/123"
+    client = FakeCloudTasksClient(existing={task_name})
+    backend = CloudTasksExecutionBackend(
+        execution_config=CloudTasksExecutionConfig(
+            project_id="test",
+            location="us",
+            queue_id="default",
+            service_url="https://consumer.example.run.app",
+            service_account_email="test@test.com",
+            trust_platform_auth=True,
+        ),
+        client=client,
+    )
+    record = QueuedTaskRecord(
+        id=uuid4(),
+        task_name="tasks.foo",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref=task_name,
+        queue="default",
+        execution_backend="cloudtasks",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "accepted"
+    assert client.delete_calls == [task_name]
+    assert client.get_calls == []
+
+
+@pytest.mark.anyio
+async def test_cloudtasks_cancel_execution_missing_delivery_is_idempotent() -> "None":
+    task_name = "projects/test/locations/us/queues/default/tasks/123"
+    client = FakeCloudTasksClient(existing=set())
+    backend = CloudTasksExecutionBackend(
+        execution_config=CloudTasksExecutionConfig(
+            project_id="test",
+            location="us",
+            queue_id="default",
+            service_url="https://consumer.example.run.app",
+            service_account_email="test@test.com",
+            trust_platform_auth=True,
+        ),
+        client=client,
+    )
+    record = QueuedTaskRecord(
+        id=uuid4(),
+        task_name="tasks.foo",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref=task_name,
+        queue="default",
+        execution_backend="cloudtasks",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "already_cancelled"
+    assert client.delete_calls == [task_name]
+
+
+@pytest.mark.anyio
+async def test_cloudtasks_cancel_execution_api_error_is_retryable() -> "None":
+    task_name = "projects/test/locations/us/queues/default/tasks/123"
+
+    class ErrorClient(FakeCloudTasksClient):
+        async def delete_task(self, *, name: "str", timeout: "float | None" = None) -> "None":
+            msg = "unavailable"
+            raise RuntimeError(msg)
+
+    client = ErrorClient(existing={task_name})
+    backend = CloudTasksExecutionBackend(
+        execution_config=CloudTasksExecutionConfig(
+            project_id="test",
+            location="us",
+            queue_id="default",
+            service_url="https://consumer.example.run.app",
+            service_account_email="test@test.com",
+            trust_platform_auth=True,
+        ),
+        client=client,
+    )
+    record = QueuedTaskRecord(
+        id=uuid4(),
+        task_name="tasks.foo",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref=task_name,
+        queue="default",
+        execution_backend="cloudtasks",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "retryable"
+    assert "unavailable" in (result.detail or "")
+
+
+@pytest.mark.anyio
+async def test_cloudtasks_cancel_execution_without_a_reference_is_unsupported() -> "None":
+    client = FakeCloudTasksClient()
+    backend = CloudTasksExecutionBackend(
+        execution_config=CloudTasksExecutionConfig(
+            project_id="test",
+            location="us",
+            queue_id="default",
+            service_url="https://consumer.example.run.app",
+            service_account_email="test@test.com",
+            trust_platform_auth=True,
+        ),
+        client=client,
+    )
+    record = QueuedTaskRecord(
+        id=uuid4(),
+        task_name="tasks.foo",
+        status="running",
+        queued_at=datetime.now(timezone.utc),
+        execution_ref=None,
+        queue="default",
+        execution_backend="cloudtasks",
+        retry_count=0,
+        max_retries=3,
+        kwargs=b"{}",
+        execution_profile=None,
+    )
+    result = await backend.cancel_execution(None, record)  # type: ignore
+    assert result.status == "unsupported"
+    assert client.delete_calls == []
+
+
+@pytest.mark.anyio
+async def test_cancel_task_deletes_a_cloudtasks_delivery_before_the_durable_write() -> "None":
+    from litestar_queues.task import task
+
+    @task("tasks.ext")
+    async def _ext() -> "None":
+        return None
+
+    client = FakeCloudTasksClient()
+    backend = CloudTasksExecutionBackend(
+        execution_config=CloudTasksExecutionConfig(
+            project_id="test",
+            location="us",
+            queue_id="default",
+            service_url="https://consumer.example.run.app",
+            service_account_email="test@test.com",
+            trust_platform_auth=True,
+        ),
+        client=client,
+    )
+    queue_backend = InMemoryQueueBackend()
+
+    from unittest.mock import patch
+
+    with patch.object(QueueConfig, "_validate_placement"):
+        service = QueueService(
+            QueueConfig(
+                worker=WorkerConfig(placement="external"),
+                queue_backend="memory",
+                execution_backend=backend.execution_config,
+            ),
+            queue_backend=queue_backend,
+            execution_backend=backend,
+        )
+
+    async with service:
+        record = await queue_backend.enqueue("tasks.ext", execution_backend="cloudtasks")
+        await backend.schedule(service, record)
+
+        updated = await queue_backend.get_task(record.id)
+        assert updated and updated.execution_ref
+
+        assert await service.cancel_task(record.id, include_running=True) is True
+        assert client.delete_calls == [updated.execution_ref]
+
+        stored = await queue_backend.get_task(record.id)
+        assert stored and stored.status == "cancelled"

--- a/src/tests/unit/execution/cloudtasks/test_cancel.py
+++ b/src/tests/unit/execution/cloudtasks/test_cancel.py
@@ -37,7 +37,7 @@ async def test_cloudtasks_cancel_execution_deletes_the_stored_delivery() -> "Non
         execution_backend="cloudtasks",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -71,7 +71,7 @@ async def test_cloudtasks_cancel_execution_missing_delivery_is_idempotent() -> "
         execution_backend="cloudtasks",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -110,7 +110,7 @@ async def test_cloudtasks_cancel_execution_api_error_is_retryable() -> "None":
         execution_backend="cloudtasks",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore
@@ -142,7 +142,7 @@ async def test_cloudtasks_cancel_execution_without_a_reference_is_unsupported() 
         execution_backend="cloudtasks",
         retry_count=0,
         max_retries=3,
-        kwargs=b"{}",
+        kwargs={},
         execution_profile=None,
     )
     result = await backend.cancel_execution(None, record)  # type: ignore

--- a/src/tests/unit/execution/test_cancel_contract.py
+++ b/src/tests/unit/execution/test_cancel_contract.py
@@ -71,3 +71,29 @@ def test_the_dead_boolean_cancel_operation_is_gone() -> "None":
     cmd = ["grep", "-rn", "async def cancel(", "src/litestar_queues"]
     res = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert res.stdout == ""
+
+
+@pytest.mark.anyio
+async def test_cancel_task_degradation_without_execution_backend() -> "None":
+    from litestar_queues.task import task
+
+    @task("tasks.ext")
+    async def _ext() -> "None":
+        return None
+
+    from litestar_queues.config import WorkerConfig
+
+    queue_backend = InMemoryQueueBackend()
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=queue_backend
+    )
+    async with service:
+        record = await queue_backend.enqueue("tasks.ext")
+        assert record.status == "pending"
+        assert record.execution_backend == "local"
+
+        # Test degradation fallback
+        assert await service.cancel_task(record.id) is True
+
+        stored = await queue_backend.get_task(record.id)
+        assert stored and stored.status == "cancelled"

--- a/src/tests/unit/execution/test_cancel_contract.py
+++ b/src/tests/unit/execution/test_cancel_contract.py
@@ -1,12 +1,12 @@
-import pytest
 from dataclasses import replace
 
-from litestar_queues.execution.base import ExecutionCancelResult, BaseExecutionBackend
+import pytest
+
+from litestar_queues.backends.memory.backend import InMemoryQueueBackend
+from litestar_queues.config import QueueConfig
+from litestar_queues.execution.base import BaseExecutionBackend, ExecutionCancelResult
 from litestar_queues.execution.cloudrun.backend import CloudRunExecutionBackend
 from litestar_queues.service import QueueService
-from litestar_queues.config import QueueConfig
-from litestar_queues.backends.memory.backend import InMemoryQueueBackend
-from pathlib import Path
 
 
 @pytest.mark.anyio
@@ -43,7 +43,7 @@ async def test_base_execution_backend_cancel_execution_is_unsupported() -> "None
     from litestar_queues.config import WorkerConfig
     service = QueueService(QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=InMemoryQueueBackend())
     await service.get_queue_backend().enqueue("tasks.unit")
-    
+
     # We need a record, we can just pass a dummy or a real one.
     # The method ignores both arguments anyway.
     record = None
@@ -58,5 +58,5 @@ def test_the_dead_boolean_cancel_operation_is_gone() -> "None":
     import subprocess
     # Run grep to ensure no file defines async def cancel( in src/litestar_queues
     cmd = ["grep", "-rn", "async def cancel(", "src/litestar_queues"]
-    res = subprocess.run(cmd, capture_output=True, text=True)
+    res = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert res.stdout == ""

--- a/src/tests/unit/execution/test_cancel_contract.py
+++ b/src/tests/unit/execution/test_cancel_contract.py
@@ -35,18 +35,24 @@ async def test_execution_cancel_result_constructors_and_durable_predicate() -> "
 
     # Check that setattr raises (frozen)
     with pytest.raises(AttributeError):
-        accepted.status = "retryable"
+        accepted.status = "retryable"  # type: ignore[misc]
 
 
 @pytest.mark.anyio
 async def test_base_execution_backend_cancel_execution_is_unsupported() -> "None":
+    from typing import cast
     from litestar_queues.config import WorkerConfig
-    service = QueueService(QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=InMemoryQueueBackend())
+    from litestar_queues.models import QueuedTaskRecord
+
+    service = QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"),
+        queue_backend=InMemoryQueueBackend(),
+    )
     await service.get_queue_backend().enqueue("tasks.unit")
 
     # We need a record, we can just pass a dummy or a real one.
     # The method ignores both arguments anyway.
-    record = None
+    record = cast(QueuedTaskRecord, None)
     result = await BaseExecutionBackend().cancel_execution(service, record)
     assert result.status == "unsupported"
 
@@ -56,6 +62,7 @@ def test_the_dead_boolean_cancel_operation_is_gone() -> "None":
     assert not hasattr(CloudRunExecutionBackend, "cancel")
 
     import subprocess
+
     # Run grep to ensure no file defines async def cancel( in src/litestar_queues
     cmd = ["grep", "-rn", "async def cancel(", "src/litestar_queues"]
     res = subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/src/tests/unit/execution/test_cancel_contract.py
+++ b/src/tests/unit/execution/test_cancel_contract.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -7,6 +8,9 @@ from litestar_queues.config import QueueConfig
 from litestar_queues.execution.base import BaseExecutionBackend, ExecutionCancelResult
 from litestar_queues.execution.cloudrun.backend import CloudRunExecutionBackend
 from litestar_queues.service import QueueService
+
+if TYPE_CHECKING:
+    from litestar_queues.models import QueuedTaskRecord
 
 
 @pytest.mark.anyio
@@ -41,8 +45,8 @@ async def test_execution_cancel_result_constructors_and_durable_predicate() -> "
 @pytest.mark.anyio
 async def test_base_execution_backend_cancel_execution_is_unsupported() -> "None":
     from typing import cast
+
     from litestar_queues.config import WorkerConfig
-    from litestar_queues.models import QueuedTaskRecord
 
     service = QueueService(
         QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"),
@@ -52,7 +56,7 @@ async def test_base_execution_backend_cancel_execution_is_unsupported() -> "None
 
     # We need a record, we can just pass a dummy or a real one.
     # The method ignores both arguments anyway.
-    record = cast(QueuedTaskRecord, None)
+    record = cast("QueuedTaskRecord", None)
     result = await BaseExecutionBackend().cancel_execution(service, record)
     assert result.status == "unsupported"
 

--- a/src/tests/unit/execution/test_cancel_contract.py
+++ b/src/tests/unit/execution/test_cancel_contract.py
@@ -1,0 +1,62 @@
+import pytest
+from dataclasses import replace
+
+from litestar_queues.execution.base import ExecutionCancelResult, BaseExecutionBackend
+from litestar_queues.execution.cloudrun.backend import CloudRunExecutionBackend
+from litestar_queues.service import QueueService
+from litestar_queues.config import QueueConfig
+from litestar_queues.backends.memory.backend import InMemoryQueueBackend
+from pathlib import Path
+
+
+@pytest.mark.anyio
+async def test_execution_cancel_result_constructors_and_durable_predicate() -> "None":
+    accepted = ExecutionCancelResult.accepted()
+    assert accepted.status == "accepted"
+    assert accepted.detail is None
+    assert accepted.permits_durable_cancel is True
+
+    already_cancelled = ExecutionCancelResult.already_cancelled()
+    assert already_cancelled.status == "already_cancelled"
+    assert already_cancelled.permits_durable_cancel is True
+
+    retryable = ExecutionCancelResult.retryable("boom")
+    assert retryable.status == "retryable"
+    assert retryable.detail == "boom"
+    assert retryable.permits_durable_cancel is False
+
+    unsupported = ExecutionCancelResult.unsupported()
+    assert unsupported.status == "unsupported"
+    assert unsupported.permits_durable_cancel is True
+
+    # Check that dataclasses.replace works
+    replaced = replace(retryable, detail="new")
+    assert replaced.detail == "new"
+
+    # Check that setattr raises (frozen)
+    with pytest.raises(AttributeError):
+        accepted.status = "retryable"
+
+
+@pytest.mark.anyio
+async def test_base_execution_backend_cancel_execution_is_unsupported() -> "None":
+    from litestar_queues.config import WorkerConfig
+    service = QueueService(QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"), queue_backend=InMemoryQueueBackend())
+    await service.get_queue_backend().enqueue("tasks.unit")
+    
+    # We need a record, we can just pass a dummy or a real one.
+    # The method ignores both arguments anyway.
+    record = None
+    result = await BaseExecutionBackend().cancel_execution(service, record)
+    assert result.status == "unsupported"
+
+
+def test_the_dead_boolean_cancel_operation_is_gone() -> "None":
+    assert not hasattr(BaseExecutionBackend, "cancel")
+    assert not hasattr(CloudRunExecutionBackend, "cancel")
+
+    import subprocess
+    # Run grep to ensure no file defines async def cancel( in src/litestar_queues
+    cmd = ["grep", "-rn", "async def cancel(", "src/litestar_queues"]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.stdout == ""

--- a/src/tests/unit/test_service.py
+++ b/src/tests/unit/test_service.py
@@ -1,6 +1,8 @@
 import asyncio
 import contextlib
 import threading
+import time
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -8,8 +10,11 @@ import pytest
 
 from litestar_queues import EventDeliveryConfig, InMemoryQueueEventSink, QueueConfig, QueueService, WorkerConfig
 from litestar_queues.backends import InMemoryQueueBackend
+from litestar_queues.backends.base import EXTERNAL_DISPATCH_RESERVATION_PREFIX
 from litestar_queues.events import EventHistoryConfig, QueueEventPublisher, QueueEventsConfig
+from litestar_queues.exceptions import JobCancelledError
 from litestar_queues.execution import BaseExecutionBackend
+from litestar_queues.execution.base import ExecutionCancelResult
 from litestar_queues.execution.cloudrun import CloudRunExecutionConfig
 
 if TYPE_CHECKING:
@@ -2163,3 +2168,262 @@ async def test_provider_scope_closes_on_durable_cancellation() -> "None":
         await res.refresh()
         assert res.status not in {"completed", "failed", "cancelled"}
         assert events == ["acquire", "body", "CancelledError", "cleanup"]
+
+
+class _RecordingExecutionBackend(BaseExecutionBackend):
+    """External backend that records cancel calls and answers with a scripted result."""
+
+    __slots__ = ("_external", "calls", "result")
+
+    def __init__(self, result: "ExecutionCancelResult | None" = None, external: "bool" = True) -> "None":
+        super().__init__()
+        self.calls: "list[str]" = []
+        self.result = result or ExecutionCancelResult.accepted()
+        self._external = external
+
+    @property
+    def is_external(self) -> "bool":
+        return self._external
+
+    async def cancel_execution(self, service: "QueueService", record: "QueuedTaskRecord") -> "ExecutionCancelResult":
+        # Assert ordering: the record must still be running in the durable store
+        stored = await service.get_queue_backend().get_task(record.id)
+        assert stored is not None and stored.status in ("pending", "running")
+        assert record.execution_ref is not None
+        self.calls.append(record.execution_ref)
+        return self.result
+
+
+async def _setup_external_record(service: "QueueService", status: "str" = "running") -> "QueuedTaskRecord":
+    from litestar_queues.task import task
+
+    @task("tasks.ext")
+    async def _ext() -> "None":
+        return None
+
+    record = await service.enqueue("tasks.ext")
+    backend = service.get_queue_backend()
+    reservation_ref = f"{EXTERNAL_DISPATCH_RESERVATION_PREFIX}:{int(time.time()) + 900}:{uuid.uuid4()}"
+    await backend.reserve_external_dispatch(record.id, "recording", reservation_ref)
+
+    if status == "running":
+        ext_ref = str(uuid.uuid4())
+        await backend.finalize_external_dispatch(
+            record.id, reservation_ref, "recording", ext_ref, execution_profile=None
+        )
+
+    return await backend.get_task(record.id)  # type: ignore
+
+
+async def test_cancel_calls_provider_before_the_durable_write() -> "None":
+    backend = _RecordingExecutionBackend()
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend,
+    ) as service:
+        record = await _setup_external_record(service)
+
+        assert await service.cancel_task(record.id, include_running=True) is True
+        assert len(backend.calls) == 1
+        assert backend.calls[0] == record.execution_ref
+
+        stored = await service.get_queue_backend().get_task(record.id)
+        assert stored is not None and stored.status == "cancelled"
+
+
+async def test_retryable_provider_result_leaves_the_record_running() -> "None":
+    backend = _RecordingExecutionBackend(result=ExecutionCancelResult.retryable("api unavailable"))
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend,
+    ) as service:
+        record = await _setup_external_record(service)
+
+        assert await service.cancel_task(record.id, include_running=True) is False
+        assert len(backend.calls) == 1
+
+        stored = await service.get_queue_backend().get_task(record.id)
+        assert stored is not None and stored.status == "pending"
+
+
+async def test_already_cancelled_result_is_idempotent_success() -> "None":
+    backend = _RecordingExecutionBackend(result=ExecutionCancelResult.already_cancelled())
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend,
+    ) as service:
+        record = await _setup_external_record(service)
+        assert await service.cancel_task(record.id, include_running=True) is True
+        assert len(backend.calls) == 1
+
+
+async def test_unsupported_backend_still_cancels_durably() -> "None":
+    class _UnsupportedBackend(BaseExecutionBackend):
+        @property
+        def is_external(self) -> "bool":
+            return True
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="unsupported"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=_UnsupportedBackend(),
+    ) as service:
+        from litestar_queues.task import task
+
+        @task("tasks.ext")
+        async def _ext() -> "None":
+            return None
+
+        record = await service.enqueue("tasks.ext")
+        backend = service.get_queue_backend()
+        reservation_ref = f"{EXTERNAL_DISPATCH_RESERVATION_PREFIX}:{int(time.time()) + 900}:{uuid.uuid4()}"
+        await backend.reserve_external_dispatch(record.id, "unsupported", reservation_ref)
+        await backend.finalize_external_dispatch(
+            record.id, reservation_ref, "unsupported", str(uuid.uuid4()), execution_profile=None
+        )
+
+        assert await service.cancel_task(record.id, include_running=True) is True
+        stored = await backend.get_task(record.id)
+        assert stored is not None and stored.status == "cancelled"
+
+
+async def test_pending_and_scheduled_records_never_reach_the_provider() -> "None":
+    backend = _RecordingExecutionBackend()
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend,
+    ) as service:
+        from litestar_queues.task import task
+
+        @task("tasks.ext")
+        async def _ext() -> "None":
+            return None
+
+        record = await service.enqueue("tasks.ext")
+
+        assert await service.cancel_task(record.id) is True
+        assert len(backend.calls) == 0
+
+
+async def test_local_running_record_never_reaches_the_provider() -> "None":
+    backend = _RecordingExecutionBackend(external=False)
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="asgi"), queue_backend="memory"), queue_backend=InMemoryQueueBackend()
+    ) as service:
+        from litestar_queues.task import task
+
+        @task("tasks.ext")
+        async def _ext() -> "None":
+            return None
+
+        record = await service.enqueue("tasks.ext")
+        claimed = await service.get_queue_backend().claim_task(record.id)
+        assert claimed is not None
+        await service.get_queue_backend().assign_worker(record.id, worker_id="worker-a", expected_retry_count=0)
+
+        assert await service.cancel_task(record.id, include_running=True) is True
+        assert len(backend.calls) == 0
+
+
+async def test_cancel_during_reservation_skips_the_provider() -> "None":
+    backend = _RecordingExecutionBackend()
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend,
+    ) as service:
+        record = await _setup_external_record(service, status="reserved")
+        assert record.execution_ref is not None and record.execution_ref.startswith(
+            EXTERNAL_DISPATCH_RESERVATION_PREFIX
+        )
+        assert await service.cancel_task(record.id, include_running=True) is True
+        assert len(backend.calls) == 0
+
+
+async def test_unknown_execution_backend_degrades_to_unsupported() -> "None":
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory"),
+        queue_backend=InMemoryQueueBackend(),
+    ) as service:
+        from litestar_queues.task import task
+
+        @task("tasks.ext")
+        async def _ext() -> "None":
+            return None
+
+        record = await service.enqueue("tasks.ext")
+        backend = service.get_queue_backend()
+        reservation_ref = f"{EXTERNAL_DISPATCH_RESERVATION_PREFIX}:{int(time.time()) + 900}:{uuid.uuid4()}"
+        await backend.reserve_external_dispatch(record.id, "unknown", reservation_ref)
+        await backend.finalize_external_dispatch(
+            record.id, reservation_ref, "unknown", str(uuid.uuid4()), execution_profile=None
+        )
+
+        assert await service.cancel_task(record.id, include_running=True) is True
+
+
+async def test_self_cancellation_does_not_cancel_its_own_execution() -> "None":
+    backend = _RecordingExecutionBackend()
+
+    from litestar_queues.task import clear_task_registry, task
+
+    clear_task_registry()
+
+    @task("tasks.ext")
+    async def _ext() -> "None":
+        msg = "self cancelled"
+        raise JobCancelledError(msg)
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend,
+    ) as service:
+        record = await service.enqueue("tasks.ext")
+        reservation_ref = f"{EXTERNAL_DISPATCH_RESERVATION_PREFIX}:{int(time.time()) + 900}:{uuid.uuid4()}"
+        await service.get_queue_backend().reserve_external_dispatch(record.id, "recording", reservation_ref)
+        await service.get_queue_backend().finalize_external_dispatch(
+            record.id, reservation_ref, "recording", str(uuid.uuid4()), execution_profile=None
+        )
+        claimed = await service.get_queue_backend().claim_task(record.id)
+        assert claimed is not None
+        await service.execute_record(claimed)
+
+        assert len(backend.calls) == 0
+        stored = await service.get_queue_backend().get_task(record.id)
+        assert stored is not None and stored.status == "cancelled"
+
+
+async def test_cancel_metric_labels_are_identical_across_result_statuses() -> "None":
+    backend_retryable = _RecordingExecutionBackend(result=ExecutionCancelResult.retryable("api unavailable"))
+    backend_unsupported = _RecordingExecutionBackend(result=ExecutionCancelResult.unsupported())
+
+    from tests.unit.test_observability import FakeObservabilityRuntime
+
+    obs = FakeObservabilityRuntime()
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend_retryable,
+        observability_runtime=obs,
+    ) as service:
+        record1 = await _setup_external_record(service)
+        await service.cancel_task(record1.id, include_running=True)
+
+    async with QueueService(
+        QueueConfig(worker=WorkerConfig(placement="external"), queue_backend="memory", execution_backend="recording"),
+        queue_backend=InMemoryQueueBackend(),
+        execution_backend=backend_unsupported,
+        observability_runtime=obs,
+    ) as service:
+        record2 = await _setup_external_record(service)
+        await service.cancel_task(record2.id, include_running=True)
+
+    counters = [c for c in obs.counters if c[0] == "litestar_queues.execution.cancel"]
+    assert len(counters) == 2
+    assert set(counters[0][2].keys()) == set(counters[1][2].keys())


### PR DESCRIPTION
Closes #128

### Summary

Implements durable remote execution cancellation for Cloud Run and Cloud Tasks with provider-first service cancellation ordering, durable attempt classification, and retry-fencing guards.

### Key Changes
- **`ExecutionCancelResult` Model**: Defined typed execution cancellation response status and extended `BaseExecutionBackend.cancel_execution`.
- **Durable Cancellation Fencing**: Added `expected_retry_count` to `cancel_task` and status guards on `finalize_external_dispatch` to prevent zombie task resurrection.
- **Provider-First Service Ordering**: Restructured `QueueService._cancel_task` to classify attempts (running internal, active external dispatch, queued) and cancel execution resources on remote providers before finalizing queue state.
- **Cloud Run & Cloud Tasks Integration**: Added Cloud Run job execution cancellation via `run.executions.cancel` and Cloud Tasks deletion, with graceful degradation for unsupported backends.
- **Observability & Docs**: Added cancellation refusal warning events/metrics and complete deployment documentation.